### PR TITLE
[NO MERGE] Include guards

### DIFF
--- a/Inc/ST-LIB.hpp
+++ b/Inc/ST-LIB.hpp
@@ -5,6 +5,11 @@
 #include "DigitalInput/DigitalInput.hpp"
 #include "Flash/Flash.hpp"
 #include "Flash/FlashTests/Flash_Test.hpp"
+#ifdef HAL_ADC_MODULE_ENABLED
 #include "ADC/ADC.hpp"
+#endif
+
+#ifdef HAL_TIM_MODULE_ENABLED
 #include "PWM/PWM.hpp"
 #include "Encoder/Encoder.hpp"
+#endif


### PR DESCRIPTION
I added simple include guards for the tim and adc module. It works as expected. I decided to put the guards in the st-lib.hpp as it seemed cleaner. Remember the ST-LIB will be split into four hpps on another pr, but the implementation will be almost equal. Any feedback?