### PR TITLE
Features/adc service

### DIFF
--- a/Inc/HALAL/Services/ADC/ADC.hpp
+++ b/Inc/HALAL/Services/ADC/ADC.hpp
@@ -21,13 +21,15 @@
 #define MAX_12BIT 4095.0
 #define MAX_16BIT 65535.0
 
-struct dma_buffer { // TODO Will be moved into appropiate file when include structure is fixed.
+// TODO: Will be moved into appropiate file when include structure is fixed.
+struct dma_buffer {
 public:
 	uint16_t* data;
 	uint8_t length;
+	bool is_on = false;
 
 	dma_buffer() = default;
-	dma_buffer(uint16_t* data, uint8_t length) : data(data), length(length) {};
+	dma_buffer(uint16_t* data, uint8_t length) : data(data), length(length), is_on(false) {};
 };
 
 struct low_power_timer {
@@ -39,28 +41,19 @@ public:
 	low_power_timer(LPTIM_HandleTypeDef* handle, uint16_t period) : handle(handle), period(period) {};
 };
 
-struct adc_data {
-public:
-	dma_buffer buffer;
-	low_power_timer timer;
-	bool is_on = false;
-
-	adc_data() = default;
-	adc_data(dma_buffer buffer, low_power_timer timer) : buffer(buffer), timer(timer), is_on(false) {};
-};
-
 class ADC {
 public:
 	class Instance {
 	public:
 		ADC_HandleTypeDef* adc;
 		uint8_t rank;
+		low_power_timer* timer;
+		dma_buffer* buffer;
 
 		Instance() = default;
-		Instance(ADC_HandleTypeDef* adc, uint8_t rank);
+		Instance(ADC_HandleTypeDef* adc, uint8_t rank, low_power_timer* timer, dma_buffer* buffer);
 	};
 
-	static map<ADC_HandleTypeDef*, adc_data> peripheral_data;
 	static map<Pin, Instance> available_instances;
 	static map<uint8_t, Instance> active_instances;
 	static forward_list<uint8_t> id_manager;
@@ -68,6 +61,5 @@ public:
 	static optional<uint8_t> inscribe(Pin pin);
 	static void start();
 	static void turn_on(uint8_t id);
-	static void turn_off(uint8_t id);
 	static optional<float> get_value(uint8_t id);
 };

--- a/Inc/HALAL/Services/ADC/ADC.hpp
+++ b/Inc/HALAL/Services/ADC/ADC.hpp
@@ -7,25 +7,45 @@
 
 #pragma once
 #include "ST-LIB.hpp"
+#include "C++Utilities/CppUtils.hpp"
 
 #define ADC_BUF1_LEN 4
 #define ADC_BUF2_LEN 2
 #define ADC_BUF3_LEN 2
 
-struct ADCchannel {
-	ADC_HandleTypeDef* adc;
-	uint8_t rank;
+#define LPTIM1_PERIOD 3000
+#define LPTIM2_PERIOD 3000
+#define LPTIM3_PERIOD 3000
+
+struct buffer { // Will be moved into appropiate file when include structure is fixed.
+	uint16_t* data;
+	uint8_t length;
 };
 
+struct low_power_timer {
+	LPTIM_HandleTypeDef* timer;
+	uint16_t period;
+};
 class ADC {
 public:
-	static map<uint8_t, Pin> service_IDs;
+	class Instance {
+	public:
+		ADC_HandleTypeDef* adc;
+		uint8_t rank;
 
-	static map<Pin, ADCchannel> pin_adc_map;
-	static forward_list<uint8_t> ID_manager;
+		Instance() = default;
+		Instance(ADC_HandleTypeDef* adc, uint8_t rank);
+	};
 
-	static optional<uint8_t> register_adc(Pin pin);
-	static void turn_on_adc(uint8_t id);
-	static void turn_off_adc(uint8_t id);
-	static optional<uint16_t> get_pin_value(uint8_t id);
+	static map<ADC_HandleTypeDef*, low_power_timer> low_power_timers;
+	static map<ADC_HandleTypeDef*, buffer> buffers;
+
+	static map<Pin, Instance> available_instances;
+	static map<uint8_t, Instance> active_instances;
+	static forward_list<uint8_t> id_manager;
+
+	static optional<uint8_t> inscribe(Pin pin);
+	static void turn_on(uint8_t id);
+	static void turn_off(uint8_t id);
+	static optional<float> get_value(uint8_t id);
 };

--- a/Inc/HALAL/Services/ADC/ADC.hpp
+++ b/Inc/HALAL/Services/ADC/ADC.hpp
@@ -22,14 +22,33 @@
 #define MAX_16BIT 65535.0
 
 struct dma_buffer { // TODO Will be moved into appropiate file when include structure is fixed.
+public:
 	uint16_t* data;
 	uint8_t length;
+
+	dma_buffer() = default;
+	dma_buffer(uint16_t* data, uint8_t length) : data(data), length(length) {};
 };
 
 struct low_power_timer {
-	LPTIM_HandleTypeDef* timer;
+public:
+	LPTIM_HandleTypeDef* handle;
 	uint16_t period;
+
+	low_power_timer() = default;
+	low_power_timer(LPTIM_HandleTypeDef* handle, uint16_t period) : handle(handle), period(period) {};
 };
+
+struct adc_data {
+public:
+	dma_buffer buffer;
+	low_power_timer timer;
+	bool is_on = false;
+
+	adc_data() = default;
+	adc_data(dma_buffer buffer, low_power_timer timer) : buffer(buffer), timer(timer), is_on(false) {};
+};
+
 class ADC {
 public:
 	class Instance {
@@ -41,14 +60,13 @@ public:
 		Instance(ADC_HandleTypeDef* adc, uint8_t rank);
 	};
 
-	static map<ADC_HandleTypeDef*, low_power_timer> low_power_timers;
-	static map<ADC_HandleTypeDef*, dma_buffer> buffers;
-
+	static map<ADC_HandleTypeDef*, adc_data> peripheral_data;
 	static map<Pin, Instance> available_instances;
 	static map<uint8_t, Instance> active_instances;
 	static forward_list<uint8_t> id_manager;
 
 	static optional<uint8_t> inscribe(Pin pin);
+	static void start();
 	static void turn_on(uint8_t id);
 	static void turn_off(uint8_t id);
 	static optional<float> get_value(uint8_t id);

--- a/Inc/HALAL/Services/ADC/ADC.hpp
+++ b/Inc/HALAL/Services/ADC/ADC.hpp
@@ -21,7 +21,7 @@
 #define MAX_12BIT 4095.0
 #define MAX_16BIT 65535.0
 
-struct buffer { // TODO Will be moved into appropiate file when include structure is fixed.
+struct dma_buffer { // TODO Will be moved into appropiate file when include structure is fixed.
 	uint16_t* data;
 	uint8_t length;
 };
@@ -42,7 +42,7 @@ public:
 	};
 
 	static map<ADC_HandleTypeDef*, low_power_timer> low_power_timers;
-	static map<ADC_HandleTypeDef*, buffer> buffers;
+	static map<ADC_HandleTypeDef*, dma_buffer> buffers;
 
 	static map<Pin, Instance> available_instances;
 	static map<uint8_t, Instance> active_instances;

--- a/Inc/HALAL/Services/ADC/ADC.hpp
+++ b/Inc/HALAL/Services/ADC/ADC.hpp
@@ -17,6 +17,10 @@
 #define LPTIM2_PERIOD 3000
 #define LPTIM3_PERIOD 3000
 
+#define MAX_VOLTAGE 3.3
+#define MAX_12BIT 4095.0
+#define MAX_16BIT 65535.0
+
 struct buffer { // Will be moved into appropiate file when include structure is fixed.
 	uint16_t* data;
 	uint8_t length;

--- a/Src/HALAL/Services/ADC/ADC.cpp
+++ b/Src/HALAL/Services/ADC/ADC.cpp
@@ -94,9 +94,9 @@ optional<float> ADC::get_value(uint8_t id) {
 
 	Instance& instance = active_instances[id];
 	if(instance.adc == &hadc3) {
-		return buffers[instance.adc].data[instance.rank-1] / 4096.0 * 3.3;
+		return buffers[instance.adc].data[instance.rank-1] / 4095.0 * 3.3;
 	}
 	else {
-		return buffers[instance.adc].data[instance.rank-1] / 65536.0 * 3.3;
+		return buffers[instance.adc].data[instance.rank-1] / 65535.0 * 3.3;
 	}
 }

--- a/Src/HALAL/Services/ADC/ADC.cpp
+++ b/Src/HALAL/Services/ADC/ADC.cpp
@@ -68,13 +68,13 @@ void ADC::turn_on(uint8_t id){
 
 	ADC_HandleTypeDef* adc = active_instances[id].adc;
 	if (HAL_ADC_Start_DMA(adc, (uint32_t*) buffers[adc].data, buffers[adc].length) != HAL_OK) {
-		__NOP();
-	}// TODO Error handling
+		return; // TODO Error handling
 
+	}
 	low_power_timer& lptim = low_power_timers[adc];
 	if (HAL_LPTIM_TimeOut_Start_IT(lptim.timer, lptim.period, lptim.period / 2) != HAL_OK) {
-		__NOP();
-	} // TODO Error handling
+		return; // TODO Error handling
+	}
 }
 
 void ADC::turn_off(uint8_t id) {

--- a/Src/HALAL/Services/ADC/ADC.cpp
+++ b/Src/HALAL/Services/ADC/ADC.cpp
@@ -11,103 +11,92 @@ extern ADC_HandleTypeDef hadc1;
 extern ADC_HandleTypeDef hadc2;
 extern ADC_HandleTypeDef hadc3;
 
+extern LPTIM_HandleTypeDef hlptim1;
+extern LPTIM_HandleTypeDef hlptim2;
+extern LPTIM_HandleTypeDef hlptim3;
+
 uint16_t adc_buf1[ADC_BUF1_LEN];
 uint16_t adc_buf2[ADC_BUF2_LEN];
 uint16_t adc_buf3[ADC_BUF3_LEN];
 
-uint16_t adc_read1[ADC_BUF1_LEN];
-uint16_t adc_read2[ADC_BUF2_LEN];
-uint16_t adc_read3[ADC_BUF3_LEN];
+forward_list<uint8_t> ADC::id_manager = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255};
+map<uint8_t, ADC::Instance> ADC::active_instances = {};
 
+map<ADC_HandleTypeDef*, low_power_timer> ADC::low_power_timers = {
+		{&hadc1, {.timer = &hlptim1, .period = LPTIM1_PERIOD}},
+		{&hadc2, {.timer = &hlptim2, .period = LPTIM2_PERIOD}},
+		{&hadc3, {.timer = &hlptim3, .period = LPTIM3_PERIOD}}
 
-forward_list<uint8_t> ADC::ID_manager = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255};
-map<uint8_t, Pin> ADC::service_IDs = {};
-map<Pin, ADCchannel> ADC::pin_adc_map = {
-		{PF11, {&hadc1, 1}},
-		{PA6, {&hadc1, 2}},
-		{PC4, {&hadc1, 3}},
-		{PB1, {&hadc1, 4}},
-		{PF13, {&hadc2, 1}},
-		{PC0, {&hadc2, 2}},
-		{PF9, {&hadc3, 1}},
-		{PF7, {&hadc3, 2}}
 };
 
+map<ADC_HandleTypeDef*, buffer> ADC::buffers = {
+		{&hadc1, {.data = adc_buf1, .length = ADC_BUF1_LEN}},
+		{&hadc2, {.data = adc_buf2, .length = ADC_BUF2_LEN}},
+		{&hadc3, {.data = adc_buf3, .length = ADC_BUF3_LEN}}
 
-void HAL_ADC_ConvCpltCallback(ADC_HandleTypeDef* hadc) {
-	if (hadc == &hadc1){
-		copy(adc_buf1 + ADC_BUF1_LEN/2, adc_buf1 + ADC_BUF1_LEN, adc_read1);
-	}
-	else if (hadc == &hadc2){
-		copy(adc_buf2 + ADC_BUF2_LEN/2, adc_buf2 + ADC_BUF2_LEN, adc_read2);
-	}
-	else if (hadc == &hadc3){
-		copy(adc_buf3 + ADC_BUF3_LEN/2, adc_buf3 + ADC_BUF3_LEN, adc_read3);
-	}
-}
+};
 
-void HAL_ADC_ConvHalfCpltCallback(ADC_HandleTypeDef *hadc) {
-	if (hadc == &hadc1){
-		copy(adc_buf1, adc_buf1 + ADC_BUF1_LEN/2, adc_read1);
-	}
-	else if (hadc == &hadc2){
-		copy(adc_buf2, adc_buf2 + ADC_BUF2_LEN/2, adc_read2);
-	}
-	else if (hadc == &hadc3){
-		copy(adc_buf3, adc_buf3 + ADC_BUF3_LEN/2, adc_read3);
-	}
-}
+ADC::Instance::Instance(ADC_HandleTypeDef* adc, uint8_t rank) :
+		adc(adc),
+		rank(rank)
+		{ }
 
-optional<uint8_t> ADC::register_adc(Pin pin) {
-	if (pin_adc_map.find(pin) == pin_adc_map.end()) { return {}; }
+map<Pin, ADC::Instance> ADC::available_instances = {
+		{PF11, Instance(&hadc1, 1)},
+		{PA6, Instance(&hadc1, 2)},
+		{PC4, Instance(&hadc1, 3)},
+		{PB1, Instance(&hadc1, 4)},
+		{PF13, Instance(&hadc2, 1)},
+		{PF14, Instance(&hadc2, 2)},
+		{PC2, Instance(&hadc3, 1)},
+		{PC3, Instance(&hadc3, 2)}
+};
 
-	Pin::register_pin(pin, ALTERNATIVE);
-	uint8_t id = ID_manager.front();
-	ADC::service_IDs[id] = pin;
-	ADC::ID_manager.pop_front();
+optional<uint8_t> ADC::inscribe(Pin pin) {
+	if (not available_instances.contains(pin)) {
+		return nullopt;
+	}
+
+	Pin::register_pin(pin, ANALOG);
+	uint8_t id = id_manager.front();
+	ADC::active_instances[id] = available_instances[pin];
+	ADC::id_manager.pop_front();
 	return id;
 }
 
-void ADC::turn_on_adc(uint8_t id){
-	if (!service_IDs.contains(id)) { return; }
-	Pin pin = service_IDs[id];
-	ADCchannel adc_channel = pin_adc_map[pin];
-
-	HAL_StatusTypeDef status;
-	if (adc_channel.adc == &hadc1){
-		status = HAL_ADC_Start_DMA(adc_channel.adc, (uint32_t*)adc_buf1, sizeof(adc_buf1) / sizeof(uint16_t));
-	}
-	else if (adc_channel.adc == &hadc2){
-		status = HAL_ADC_Start_DMA(adc_channel.adc, (uint32_t*)adc_buf2, sizeof(adc_buf2) / sizeof(uint16_t));
-	}
-	else if (adc_channel.adc == &hadc3){
-		status = HAL_ADC_Start_DMA(adc_channel.adc, (uint32_t*)adc_buf3, sizeof(adc_buf3) / sizeof(uint16_t));
+void ADC::turn_on(uint8_t id){
+	if (not active_instances.contains(id)) {
+		return;
 	}
 
-	if (status != HAL_OK) { }// TODO Error handling
+	ADC_HandleTypeDef* adc = active_instances[id].adc;
+	if (HAL_ADC_Start_DMA(adc, (uint32_t*) buffers[adc].data, buffers[adc].length) != HAL_OK) {
+		__NOP();
+	}// TODO Error handling
+
+	low_power_timer& lptim = low_power_timers[adc];
+	if (HAL_LPTIM_TimeOut_Start_IT(lptim.timer, lptim.period, lptim.period / 2) != HAL_OK) {
+		__NOP();
+	} // TODO Error handling
 }
 
-void ADC::turn_off_adc(uint8_t id) {
-	if (!service_IDs.contains(id)) { return; }
-	Pin pin = service_IDs[id];
-	ADCchannel adc_channel = pin_adc_map[pin];
-
-	HAL_StatusTypeDef status = HAL_ADC_Stop_DMA(adc_channel.adc);
-	if (status != HAL_OK) { } // TODO Error handling
+void ADC::turn_off(uint8_t id) {
+	if (not active_instances.contains(id)) {
+		return;
+	}
+	if (HAL_ADC_Stop_DMA(active_instances[id].adc) != HAL_OK) { } // TODO Error handling
 }
 
-optional<uint16_t> ADC::get_pin_value(uint8_t id) {
-	if (!service_IDs.contains(id)) { return {}; }
-	Pin pin = service_IDs[id];
+optional<float> ADC::get_value(uint8_t id) {
+	if (not active_instances.contains(id)) {
+		return nullopt;
+	}
 
-	ADCchannel adc_channel = pin_adc_map[pin];
-	if (adc_channel.adc == &hadc1){
-		return adc_read1[adc_channel.rank];
+	Instance& instance = active_instances[id];
+	if(instance.adc == &hadc3) {
+		return buffers[instance.adc].data[instance.rank-1] / 4096.0 * 3.3;
 	}
-	else if (adc_channel.adc == &hadc2){
-		return adc_read2[adc_channel.rank];
-	}
-	else if (adc_channel.adc == &hadc3){
-		return adc_read3[adc_channel.rank];
+	else {
+		return buffers[instance.adc].data[instance.rank-1] / 65536.0 * 3.3;
 	}
 }

--- a/Src/HALAL/Services/ADC/ADC.cpp
+++ b/Src/HALAL/Services/ADC/ADC.cpp
@@ -22,6 +22,9 @@ uint16_t adc_buf3[ADC_BUF3_LEN];
 forward_list<uint8_t> ADC::id_manager = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255};
 map<uint8_t, ADC::Instance> ADC::active_instances = {};
 
+ADC::Instance::Instance(ADC_HandleTypeDef* adc, uint8_t rank, low_power_timer* timer, dma_buffer* buffer) :
+		adc(adc), rank(rank), timer(timer), buffer(buffer) {}
+
 dma_buffer dma_buffer1 = dma_buffer(adc_buf1, ADC_BUF1_LEN);
 low_power_timer lptim1 = low_power_timer(&hlptim1, LPTIM1_PERIOD);
 dma_buffer dma_buffer2 = dma_buffer(adc_buf2, ADC_BUF2_LEN);
@@ -29,29 +32,15 @@ low_power_timer lptim2 = low_power_timer(&hlptim2, LPTIM2_PERIOD);
 dma_buffer dma_buffer3 = dma_buffer(adc_buf3, ADC_BUF3_LEN);
 low_power_timer lptim3 = low_power_timer(&hlptim3, LPTIM3_PERIOD);
 
-map<ADC_HandleTypeDef*, adc_data> ADC::peripheral_data = {
-		{&hadc1, adc_data(dma_buffer1, lptim1)},
-		{&hadc2, adc_data(dma_buffer2, lptim2)},
-		{&hadc3, adc_data(dma_buffer3, lptim3)}
-};
-
-//map<ADC_HandleTypeDef*, adc_data> ADC::peripheral_data = {
-//		{&hadc1, { .buffer = { .data = adc_buf1, .length = ADC_BUF1_LEN }, .timer = { .handle = &hlptim1, .period = LPTIM1_PERIOD} }},
-//		{&hadc2, { .buffer = { .data = adc_buf2, .length = ADC_BUF2_LEN }, .timer = {.handle = &hlptim2, .period = LPTIM2_PERIOD} }},
-//		{&hadc3, { .buffer = { .data = adc_buf3, .length = ADC_BUF3_LEN }, .timer = {.handle = &hlptim3, .period = LPTIM3_PERIOD} }}
-//};
-
-ADC::Instance::Instance(ADC_HandleTypeDef* adc, uint8_t rank) : adc(adc), rank(rank){}
-
 map<Pin, ADC::Instance> ADC::available_instances = {
-		{PF11, Instance(&hadc1, 1)},
-		{PA6, Instance(&hadc1, 2)},
-		{PC4, Instance(&hadc1, 3)},
-		{PB1, Instance(&hadc1, 4)},
-		{PF13, Instance(&hadc2, 1)},
-		{PF14, Instance(&hadc2, 2)},
-		{PC2, Instance(&hadc3, 1)},
-		{PC3, Instance(&hadc3, 2)}
+		{PF11, Instance(&hadc1, 1, &lptim1, &dma_buffer1)},
+		{PA6, Instance(&hadc1, 2, &lptim1, &dma_buffer1)},
+		{PC4, Instance(&hadc1, 3, &lptim1, &dma_buffer1)},
+		{PB1, Instance(&hadc1, 4, &lptim1, &dma_buffer1)},
+		{PF13, Instance(&hadc2, 1, &lptim2, &dma_buffer2)},
+		{PF14, Instance(&hadc2, 2, &lptim2, &dma_buffer2)},
+		{PC2, Instance(&hadc3, 1, &lptim3, &dma_buffer3)},
+		{PC3, Instance(&hadc3, 2, &lptim3, &dma_buffer3)}
 };
 
 optional<uint8_t> ADC::inscribe(Pin pin) {
@@ -75,34 +64,20 @@ void ADC::turn_on(uint8_t id){
 		return;
 	}
 
-	ADC_HandleTypeDef* adc = active_instances[id].adc;
-	if (peripheral_data[adc].is_on) {
+	dma_buffer* buffer = active_instances[id].buffer;
+	if (buffer->is_on) {
 		return;
 	}
 
-	dma_buffer& buf = peripheral_data[adc].buffer;
-	if (HAL_ADC_Start_DMA(adc, (uint32_t*) buf.data, buf.length) != HAL_OK) {
-		return; // TODO Error handling
+	if (HAL_ADC_Start_DMA(active_instances[id].adc, (uint32_t*) buffer->data, buffer->length) != HAL_OK) {
+		return; // TODO: Error handling
 	}
 
-	low_power_timer& timer = peripheral_data[adc].timer;
-	if (HAL_LPTIM_TimeOut_Start_IT(timer.handle, timer.period, timer.period / 2) != HAL_OK) {
-		return; // TODO Error handling
+	low_power_timer* timer = active_instances[id].timer;
+	if (HAL_LPTIM_TimeOut_Start_IT(timer->handle, timer->period, timer->period / 2) != HAL_OK) {
+		return; // TODO: Error handling
 	}
-	peripheral_data[adc].is_on = true;
-}
-
-void ADC::turn_off(uint8_t id) {
-	if (not active_instances.contains(id)) {
-		return;
-	}
-
-	ADC_HandleTypeDef* adc = active_instances[id].adc;
-	if (not peripheral_data[adc].is_on) {
-		return;
-	}
-	if (HAL_ADC_Stop_DMA(active_instances[id].adc) != HAL_OK) { } // TODO Error handling
-	peripheral_data[adc].is_on = false;
+	buffer->is_on = true;
 }
 
 optional<float> ADC::get_value(uint8_t id) {
@@ -111,7 +86,7 @@ optional<float> ADC::get_value(uint8_t id) {
 	}
 
 	Instance& instance = active_instances[id];
-	uint16_t& raw = peripheral_data[instance.adc].buffer.data[instance.rank-1];
+	uint16_t& raw = instance.buffer->data[instance.rank-1];
 	if(instance.adc == &hadc3) {
 		return raw / MAX_12BIT * MAX_VOLTAGE;
 	}

--- a/Src/HALAL/Services/ADC/ADC.cpp
+++ b/Src/HALAL/Services/ADC/ADC.cpp
@@ -29,17 +29,14 @@ map<ADC_HandleTypeDef*, low_power_timer> ADC::low_power_timers = {
 
 };
 
-map<ADC_HandleTypeDef*, buffer> ADC::buffers = {
+map<ADC_HandleTypeDef*, dma_buffer> ADC::buffers = {
 		{&hadc1, {.data = adc_buf1, .length = ADC_BUF1_LEN}},
 		{&hadc2, {.data = adc_buf2, .length = ADC_BUF2_LEN}},
 		{&hadc3, {.data = adc_buf3, .length = ADC_BUF3_LEN}}
 
 };
 
-ADC::Instance::Instance(ADC_HandleTypeDef* adc, uint8_t rank) :
-		adc(adc),
-		rank(rank)
-		{ }
+ADC::Instance::Instance(ADC_HandleTypeDef* adc, uint8_t rank) : adc(adc), rank(rank){}
 
 map<Pin, ADC::Instance> ADC::available_instances = {
 		{PF11, Instance(&hadc1, 1)},

--- a/Src/HALAL/Services/ADC/ADC.cpp
+++ b/Src/HALAL/Services/ADC/ADC.cpp
@@ -22,19 +22,24 @@ uint16_t adc_buf3[ADC_BUF3_LEN];
 forward_list<uint8_t> ADC::id_manager = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255};
 map<uint8_t, ADC::Instance> ADC::active_instances = {};
 
-map<ADC_HandleTypeDef*, low_power_timer> ADC::low_power_timers = {
-		{&hadc1, {.timer = &hlptim1, .period = LPTIM1_PERIOD}},
-		{&hadc2, {.timer = &hlptim2, .period = LPTIM2_PERIOD}},
-		{&hadc3, {.timer = &hlptim3, .period = LPTIM3_PERIOD}}
+dma_buffer dma_buffer1 = dma_buffer(adc_buf1, ADC_BUF1_LEN);
+low_power_timer lptim1 = low_power_timer(&hlptim1, LPTIM1_PERIOD);
+dma_buffer dma_buffer2 = dma_buffer(adc_buf2, ADC_BUF2_LEN);
+low_power_timer lptim2 = low_power_timer(&hlptim2, LPTIM2_PERIOD);
+dma_buffer dma_buffer3 = dma_buffer(adc_buf3, ADC_BUF3_LEN);
+low_power_timer lptim3 = low_power_timer(&hlptim3, LPTIM3_PERIOD);
 
+map<ADC_HandleTypeDef*, adc_data> ADC::peripheral_data = {
+		{&hadc1, adc_data(dma_buffer1, lptim1)},
+		{&hadc2, adc_data(dma_buffer2, lptim2)},
+		{&hadc3, adc_data(dma_buffer3, lptim3)}
 };
 
-map<ADC_HandleTypeDef*, dma_buffer> ADC::buffers = {
-		{&hadc1, {.data = adc_buf1, .length = ADC_BUF1_LEN}},
-		{&hadc2, {.data = adc_buf2, .length = ADC_BUF2_LEN}},
-		{&hadc3, {.data = adc_buf3, .length = ADC_BUF3_LEN}}
-
-};
+//map<ADC_HandleTypeDef*, adc_data> ADC::peripheral_data = {
+//		{&hadc1, { .buffer = { .data = adc_buf1, .length = ADC_BUF1_LEN }, .timer = { .handle = &hlptim1, .period = LPTIM1_PERIOD} }},
+//		{&hadc2, { .buffer = { .data = adc_buf2, .length = ADC_BUF2_LEN }, .timer = {.handle = &hlptim2, .period = LPTIM2_PERIOD} }},
+//		{&hadc3, { .buffer = { .data = adc_buf3, .length = ADC_BUF3_LEN }, .timer = {.handle = &hlptim3, .period = LPTIM3_PERIOD} }}
+//};
 
 ADC::Instance::Instance(ADC_HandleTypeDef* adc, uint8_t rank) : adc(adc), rank(rank){}
 
@@ -56,9 +61,13 @@ optional<uint8_t> ADC::inscribe(Pin pin) {
 
 	Pin::register_pin(pin, ANALOG);
 	uint8_t id = id_manager.front();
-	ADC::active_instances[id] = available_instances[pin];
-	ADC::id_manager.pop_front();
+	active_instances[id] = available_instances[pin];
+	id_manager.pop_front();
 	return id;
+}
+
+void ADC::start() {
+	// TODO: ADC init
 }
 
 void ADC::turn_on(uint8_t id){
@@ -67,21 +76,33 @@ void ADC::turn_on(uint8_t id){
 	}
 
 	ADC_HandleTypeDef* adc = active_instances[id].adc;
-	if (HAL_ADC_Start_DMA(adc, (uint32_t*) buffers[adc].data, buffers[adc].length) != HAL_OK) {
-		return; // TODO Error handling
+	if (peripheral_data[adc].is_on) {
+		return;
+	}
 
-	}
-	low_power_timer& lptim = low_power_timers[adc];
-	if (HAL_LPTIM_TimeOut_Start_IT(lptim.timer, lptim.period, lptim.period / 2) != HAL_OK) {
+	dma_buffer& buf = peripheral_data[adc].buffer;
+	if (HAL_ADC_Start_DMA(adc, (uint32_t*) buf.data, buf.length) != HAL_OK) {
 		return; // TODO Error handling
 	}
+
+	low_power_timer& timer = peripheral_data[adc].timer;
+	if (HAL_LPTIM_TimeOut_Start_IT(timer.handle, timer.period, timer.period / 2) != HAL_OK) {
+		return; // TODO Error handling
+	}
+	peripheral_data[adc].is_on = true;
 }
 
 void ADC::turn_off(uint8_t id) {
 	if (not active_instances.contains(id)) {
 		return;
 	}
+
+	ADC_HandleTypeDef* adc = active_instances[id].adc;
+	if (not peripheral_data[adc].is_on) {
+		return;
+	}
 	if (HAL_ADC_Stop_DMA(active_instances[id].adc) != HAL_OK) { } // TODO Error handling
+	peripheral_data[adc].is_on = false;
 }
 
 optional<float> ADC::get_value(uint8_t id) {
@@ -90,7 +111,7 @@ optional<float> ADC::get_value(uint8_t id) {
 	}
 
 	Instance& instance = active_instances[id];
-	uint16_t& raw = buffers[instance.adc].data[instance.rank-1];
+	uint16_t& raw = peripheral_data[instance.adc].buffer.data[instance.rank-1];
 	if(instance.adc == &hadc3) {
 		return raw / MAX_12BIT * MAX_VOLTAGE;
 	}

--- a/Src/HALAL/Services/ADC/ADC.cpp
+++ b/Src/HALAL/Services/ADC/ADC.cpp
@@ -93,10 +93,11 @@ optional<float> ADC::get_value(uint8_t id) {
 	}
 
 	Instance& instance = active_instances[id];
+	uint16_t& raw = buffers[instance.adc].data[instance.rank-1];
 	if(instance.adc == &hadc3) {
-		return buffers[instance.adc].data[instance.rank-1] / 4095.0 * 3.3;
+		return raw / MAX_12BIT * MAX_VOLTAGE;
 	}
 	else {
-		return buffers[instance.adc].data[instance.rank-1] / 65535.0 * 3.3;
+		return raw / MAX_16BIT * MAX_VOLTAGE;
 	}
 }


### PR DESCRIPTION

### Usage:
```
int main(void)
{

  HAL_Init();
  SystemClock_Config();
  PeriphCommonClock_Config();

  /* USER CODE BEGIN 1 */
  uint8_t adc = ADC::inscribe(PF11).value_or(69);
  Pin::start();
  /* USER CODE END 1 */

// ...

  /* USER CODE BEGIN 2 */

  ADC::turn_on(adc);
  while(1) {
	  HAL_Delay(100);
	  float value = ADC::get_value(adc).value();
	  __NOP();
  };
```

### Testing:
It has been tested that the 3 ADC can work in parallel without problems, and that register and turn on function errors are caught correctly (error handling will be implemented on a later commit).
