### PR TITLE
Features/digital output

### DIFF
--- a/Inc/ST-LIB_LOW/Actuator/DigitalOutput/DigitalOutput.hpp
+++ b/Inc/ST-LIB_LOW/Actuator/DigitalOutput/DigitalOutput.hpp
@@ -11,6 +11,7 @@
 
 class DigitalOutput {
 public:
+	DigitalOutput() = default;
 	DigitalOutput(Pin& pin);
 
 	void turn_on();

--- a/Inc/ST-LIB_LOW/Actuator/DigitalOutput/DigitalOutput.hpp
+++ b/Inc/ST-LIB_LOW/Actuator/DigitalOutput/DigitalOutput.hpp
@@ -1,0 +1,24 @@
+/*
+ * DigitalOutput.hpp
+ *
+ *  Created on: 1 dic. 2022
+ *      Author: aleja
+ */
+
+#pragma once
+
+#include "DigitalOutputservice/DigitalOutputservice.hpp"
+
+class DigitalOutput {
+public:
+	DigitalOutput(Pin& pin);
+
+	void turn_on();
+	void turn_off();
+	void set_pin_state(PinState state);
+private:
+	uint8_t id;
+	Pin pin;
+};
+
+

--- a/Inc/ST-LIB_LOW/ST-LIB_LOW.hpp
+++ b/Inc/ST-LIB_LOW/ST-LIB_LOW.hpp
@@ -3,3 +3,4 @@
 #include "Clocks/Counter.hpp"
 #include "Clocks/Stopwatch.hpp"
 #include "Actuator/PWM/PWM.hpp"
+#include "Actuator/DigitalOutput/DigitalOutput.hpp"

--- a/Src/ST-LIB_LOW/Actuator/DigitalOutput/DigitalOutput.cpp
+++ b/Src/ST-LIB_LOW/Actuator/DigitalOutput/DigitalOutput.cpp
@@ -1,0 +1,31 @@
+/*
+ * DigitalOutput.cpp
+ *
+ *  Created on: 1 dic. 2022
+ *      Author: aleja
+ */
+
+#pragma once
+
+#include "Actuator/DigitalOutput/DigitalOutput.hpp"
+
+DigitalOutput::DigitalOutput(Pin& pin) : pin(pin) {
+	optional<uint8_t> try_id = DigitalOutputservice::inscribe(pin);
+		if (not try_id) {
+			//TODO: error handler
+		}
+
+		id = try_id.value();
+}
+
+void DigitalOutput::turn_on() {
+	DigitalOutputservice::turn_on(id);
+}
+
+void DigitalOutput::turn_off() {
+	DigitalOutputservice::turn_off(id);
+}
+
+void DigitalOutput::set_pin_state(PinState state) {
+	DigitalOutputservice::set_pin_state(id, state);
+}


### PR DESCRIPTION
# Digital Output
This PR implements the Digital Output class on top of the Digital Output service, that allows to create Digital Output instances. It will be used for the half bridges and the linear induction motor (LIM).

Works exactly the same as the PWM class, see [this PR](https://github.com/HyperloopUPV-H8/ST-LIB/pull/66) for more info.