### PR TITLE
PWM Start update

### DIFF
--- a/Inc/HALAL/Models/PinModel/Pin.hpp
+++ b/Inc/HALAL/Models/PinModel/Pin.hpp
@@ -34,6 +34,7 @@ enum Operation_Mode{
 	OUTPUT,
 	ANALOG,
 	EXTERNAL_INTERRUPT,
+	PWM,
 	ALTERNATIVE,
 };
 

--- a/Inc/HALAL/Models/PinModel/Pin.hpp
+++ b/Inc/HALAL/Models/PinModel/Pin.hpp
@@ -34,7 +34,7 @@ enum Operation_Mode{
 	OUTPUT,
 	ANALOG,
 	EXTERNAL_INTERRUPT,
-	PWM,
+	PWM_MODE,
 	ALTERNATIVE,
 };
 

--- a/Inc/HALAL/Services/PWMservice/PWMservice.hpp
+++ b/Inc/HALAL/Services/PWMservice/PWMservice.hpp
@@ -25,9 +25,10 @@ public:
 		TIM_TypeDef* timer;
 		uint32_t prescaler;
 		uint32_t period;
+		uint32_t deadtime;
 		vector<uint32_t> channels;
 		TimerInitData() = default;
-		TimerInitData(TIM_TypeDef* timer, uint32_t prescaler, uint32_t period);
+		TimerInitData(TIM_TypeDef* timer, uint32_t prescaler = 275, uint32_t period = 1000, uint32_t deadtime = 0);
 	};
 
 	class TimerPeripheral {

--- a/Inc/HALAL/Services/PWMservice/PWMservice.hpp
+++ b/Inc/HALAL/Services/PWMservice/PWMservice.hpp
@@ -23,13 +23,11 @@ public:
 	};
 	struct TimerInitData {
 		TIM_TypeDef* timer;
-		GPIO_TypeDef* gpio_port;
-		uint32_t gpio_pins = 0;
 		uint32_t prescaler;
 		uint32_t period;
 		vector<uint32_t> channels;
 		TimerInitData() = default;
-		TimerInitData(TIM_TypeDef* timer, GPIO_TypeDef* gpio_port, uint32_t prescaler, uint32_t period);
+		TimerInitData(TIM_TypeDef* timer, uint32_t prescaler, uint32_t period);
 	};
 
 	class TimerPeripheral {

--- a/Src/HALAL/Models/PinModel/Pin.cpp
+++ b/Src/HALAL/Models/PinModel/Pin.cpp
@@ -181,7 +181,7 @@ void Pin::start(){
 			GPIO_InitStruct.Pull = GPIO_PULLDOWN;
 			HAL_GPIO_Init(pin.port, &GPIO_InitStruct);
 			break;
-		case Operation_Mode::PWM:
+		case Operation_Mode::PWM_MODE:
 			GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
 			GPIO_InitStruct.Pull = GPIO_NOPULL;
 			GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;

--- a/Src/HALAL/Models/PinModel/Pin.cpp
+++ b/Src/HALAL/Models/PinModel/Pin.cpp
@@ -177,10 +177,17 @@ void Pin::start(){
 			HAL_GPIO_Init(pin.port, &GPIO_InitStruct);
 			break;
 		case Operation_Mode::EXTERNAL_INTERRUPT:
-			  GPIO_InitStruct.Mode = GPIO_MODE_IT_RISING;
-			  GPIO_InitStruct.Pull = GPIO_PULLDOWN;
-			  HAL_GPIO_Init(pin.port, &GPIO_InitStruct);
-			  break;
+			GPIO_InitStruct.Mode = GPIO_MODE_IT_RISING;
+			GPIO_InitStruct.Pull = GPIO_PULLDOWN;
+			HAL_GPIO_Init(pin.port, &GPIO_InitStruct);
+			break;
+		case Operation_Mode::PWM:
+			GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+			GPIO_InitStruct.Pull = GPIO_NOPULL;
+			GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+			GPIO_InitStruct.Alternate = GPIO_AF1_TIM1;
+			HAL_GPIO_Init(pin.port, &GPIO_InitStruct);
+			break;
 
 		default:
 			break;

--- a/Src/HALAL/Models/Runes/Runes.cpp
+++ b/Src/HALAL/Models/Runes/Runes.cpp
@@ -29,8 +29,8 @@ extern TIM_HandleTypeDef htim1;
 extern TIM_HandleTypeDef htim15;
 extern TIM_HandleTypeDef htim23;
 
-PWMservice::TimerInitData init_data_timer1 = PWMservice::TimerInitData(TIM1, GPIOE, 2750, 1000);
-PWMservice::TimerInitData init_data_timer15 = PWMservice::TimerInitData(TIM15, GPIOE, 0, 65535);
+PWMservice::TimerInitData init_data_timer1 = PWMservice::TimerInitData(TIM1, 2750, 1000);
+PWMservice::TimerInitData init_data_timer15 = PWMservice::TimerInitData(TIM15, 0, 65535);
 
 
 PWMservice::TimerPeripheral PWMservice::timer_peripherals[H723_TIMERS] = {

--- a/Src/HALAL/Services/PWMservice/PWMservice.cpp
+++ b/Src/HALAL/Services/PWMservice/PWMservice.cpp
@@ -28,7 +28,7 @@ optional<uint8_t> PWMservice::inscribe(Pin& pin){
 		return nullopt; //TODO: error handlerr
 	}
 
-	Pin::inscribe(pin, PWM);
+	Pin::inscribe(pin, PWM_MODE);
 	uint8_t id = id_manager.front();
 	active_instances[id] = available_instances[pin];
 	id_manager.pop_front();

--- a/Src/HALAL/Services/PWMservice/PWMservice.cpp
+++ b/Src/HALAL/Services/PWMservice/PWMservice.cpp
@@ -11,8 +11,8 @@
 forward_list<uint8_t> PWMservice::id_manager = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255};
 map<uint8_t, PWMservice::Instance> PWMservice::active_instances = {};
 
-PWMservice::TimerInitData::TimerInitData(TIM_TypeDef* timer, uint32_t prescaler, uint32_t period) :
-		timer(timer), prescaler(prescaler), period(period), channels({}) {}
+PWMservice::TimerInitData::TimerInitData(TIM_TypeDef* timer, uint32_t prescaler, uint32_t period, uint32_t deadtime) :
+		timer(timer), prescaler(prescaler), period(period), deadtime(deadtime), channels({}) {}
 
 PWMservice::TimerPeripheral::TimerPeripheral(TIM_HandleTypeDef* handle, TimerInitData init_data) :
 		handle(handle), init_data(init_data) {}

--- a/Src/HALAL/Services/PWMservice/PWMservice.cpp
+++ b/Src/HALAL/Services/PWMservice/PWMservice.cpp
@@ -11,8 +11,8 @@
 forward_list<uint8_t> PWMservice::id_manager = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255};
 map<uint8_t, PWMservice::Instance> PWMservice::active_instances = {};
 
-PWMservice::TimerInitData::TimerInitData(TIM_TypeDef* timer, GPIO_TypeDef* gpio_port, uint32_t prescaler, uint32_t period) :
-		timer(timer), gpio_port(gpio_port), prescaler(prescaler), period(period), channels({}) {}
+PWMservice::TimerInitData::TimerInitData(TIM_TypeDef* timer, uint32_t prescaler, uint32_t period) :
+		timer(timer), prescaler(prescaler), period(period), channels({}) {}
 
 PWMservice::TimerPeripheral::TimerPeripheral(TIM_HandleTypeDef* handle, TimerInitData init_data) :
 		handle(handle), init_data(init_data) {}
@@ -28,14 +28,13 @@ optional<uint8_t> PWMservice::inscribe(Pin& pin){
 		return nullopt; //TODO: error handlerr
 	}
 
-	Pin::inscribe(pin, ALTERNATIVE);
+	Pin::inscribe(pin, PWM);
 	uint8_t id = id_manager.front();
 	active_instances[id] = available_instances[pin];
 	id_manager.pop_front();
 
 	TimerInitData& init_data = active_instances[id].peripheral->init_data;
 	init_data.channels.push_back(active_instances[id].channel);
-	init_data.gpio_pins |= pin.gpio_pin;
 	return id;
 }
 
@@ -186,16 +185,6 @@ void PWMservice::init(TimerPeripheral& peripheral) {
 	if (HAL_TIMEx_ConfigBreakDeadTime(&tim_handle, &sBreakDeadTimeConfig) != HAL_OK) {
 		//TODO: Error Handler
 	}
-
-	GPIO_InitTypeDef GPIO_InitStruct = {0};
-
-
-	GPIO_InitStruct.Pin = init_data.gpio_pins;
-	GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
-	GPIO_InitStruct.Pull = GPIO_NOPULL;
-	GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-	GPIO_InitStruct.Alternate = GPIO_AF1_TIM1;
-	HAL_GPIO_Init(init_data.gpio_port, &GPIO_InitStruct);
 }
 
 bool PWMservice::instance_exists(uint8_t id) {

--- a/Src/HALAL/Services/PWMservice/PWMservice.cpp
+++ b/Src/HALAL/Services/PWMservice/PWMservice.cpp
@@ -174,7 +174,7 @@ void PWMservice::init(TimerPeripheral& peripheral) {
 	sBreakDeadTimeConfig.OffStateRunMode = TIM_OSSR_DISABLE;
 	sBreakDeadTimeConfig.OffStateIDLEMode = TIM_OSSI_DISABLE;
 	sBreakDeadTimeConfig.LockLevel = TIM_LOCKLEVEL_OFF;
-	sBreakDeadTimeConfig.DeadTime = 0;
+	sBreakDeadTimeConfig.DeadTime = init_data.deadtime;
 	sBreakDeadTimeConfig.BreakState = TIM_BREAK_DISABLE;
 	sBreakDeadTimeConfig.BreakPolarity = TIM_BREAKPOLARITY_HIGH;
 	sBreakDeadTimeConfig.BreakFilter = 0;


### PR DESCRIPTION
# PWM Start update
Necessary update for PWM init in order to work with multiple gpio ports. It also simplifies the design and the initdata constructor.

### Testing:
![image](https://user-images.githubusercontent.com/59616818/205360805-fc079033-1403-4f87-a997-c0245ea59197.png)
It works.