### PR TITLE
All UART init methods implemented 

### DIFF
--- a/Inc/HALAL/Models/Packets/RawPacket.hpp
+++ b/Inc/HALAL/Models/Packets/RawPacket.hpp
@@ -21,6 +21,18 @@ private:
     RawPacket(){};
 
 public:
+
+    /**
+     * @brief Construct a new Raw Packet object. The constructor will create an empty packet
+     *        of the specified size. This constructor is intended for receive packets.
+     * 
+     * @param size Size in bytes of the packet data.
+     */
+    RawPacket(uint32_t size) {
+		this->size = size;
+		this->data = (uint8_t*)malloc(this->size);
+    }
+
     /**
      * @brief Constructs a new RawPacket object. The constructor will handle automatically
      *           the data type and size.

--- a/Inc/HALAL/Services/Communication/UART/UART.hpp
+++ b/Inc/HALAL/Services/Communication/UART/UART.hpp
@@ -5,11 +5,14 @@
  *      Author: Pablo
  */
 
+
 #pragma once
 
 #include "ST-LIB.hpp"
 #include "C++Utilities/CppUtils.hpp"
 #include "Packets/RawPacket.hpp"
+
+#ifdef HAL_UART_MODULE_ENABLED
 
 extern UART_HandleTypeDef huart3;
 
@@ -31,7 +34,11 @@ private:
         Pin TX; /**< Clock pin. */
         Pin RX; /**< MOSI pin. */
         UART_HandleTypeDef* huart;  /**< HAL UART struct. */
+        USART_TypeDef* instance;
+        uint32_t baud_rate;
+        uint32_t word_length;
         bool receive_ready = false; /**< Receive value is ready to use pin. */
+
     };
 
     /**
@@ -68,6 +75,14 @@ public:
      * @return uint8_t Id of the service.
      */
     static uint8_t inscribe(UART::Peripheral& uart);
+
+    /**
+     * @brief 
+     * 
+     * @return true 
+     * @return false 
+     */
+    static void start();
 
     /**@brief	Transmits 1 RawPacket of any size by DMA and
      *          interrupts. Handles the packet size automatically. To
@@ -114,4 +129,16 @@ public:
      * @return bool Return true if the UART transmit operation is busy and false if not.
      */
     static bool is_busy(uint8_t id);
+
+    private:
+    /**
+     * @brief 
+     * 
+     * @param id 
+     * @return true 
+     * @return false 
+     */
+    static void init(UART::Instance* uart);
 };
+
+#endif

--- a/Inc/HALAL/Services/Communication/UART/UART.hpp
+++ b/Inc/HALAL/Services/Communication/UART/UART.hpp
@@ -5,7 +5,6 @@
  *      Author: Pablo
  */
 
-
 #pragma once
 
 #include "ST-LIB.hpp"
@@ -140,11 +139,9 @@ public:
 
     private:
     /**
-     * @brief 
+     * @brief This method initializes the UART peripheral that is passed to it as a parameter.
      * 
-     * @param id 
-     * @return true 
-     * @return false 
+     * @param uart Peripheral instance to be initialized.
      */
     static void init(UART::Instance* uart);
 };

--- a/Inc/HALAL/Services/Communication/UART/UART.hpp
+++ b/Inc/HALAL/Services/Communication/UART/UART.hpp
@@ -4,7 +4,6 @@
  *  Created on: 28 nov. 2022
  *      Author: Pablo
  */
-
 #pragma once
 
 #include "ST-LIB.hpp"
@@ -84,10 +83,9 @@ public:
     static uint8_t inscribe(UART::Peripheral& uart, uint32_t baud_rate, uint32_t word_length);
 
     /**
-     * @brief 
+     * @brief This method initializes all registered UARTs. The peripherals
+     * 		  must be enrolled before calling this method.
      * 
-     * @return true 
-     * @return false 
      */
     static void start();
 

--- a/Inc/HALAL/Services/Communication/UART/UART.hpp
+++ b/Inc/HALAL/Services/Communication/UART/UART.hpp
@@ -77,6 +77,14 @@ public:
     static uint8_t inscribe(UART::Peripheral& uart);
 
     /**
+     * @brief Registers a new UART.
+     *
+     * @param uart UART peripheral to register.
+     * @return uint8_t Id of the service.
+     */
+    static uint8_t inscribe(UART::Peripheral& uart, uint32_t baud_rate, uint32_t word_length);
+
+    /**
      * @brief 
      * 
      * @return true 

--- a/Inc/HALAL/Services/Communication/UART/UART.hpp
+++ b/Inc/HALAL/Services/Communication/UART/UART.hpp
@@ -36,6 +36,7 @@ private:
         uint32_t baud_rate;
         uint32_t word_length;
         bool receive_ready = false; /**< Receive value is ready to use pin. */
+        bool initialized = false;;
 
     };
 
@@ -48,7 +49,7 @@ private:
     };
 
 public:
-    static forward_list<uint8_t> id_manager;
+    static uint16_t id_counter;
     
     static unordered_map<uint8_t, UART::Instance* > registered_uart;
 
@@ -72,15 +73,7 @@ public:
      * @param uart UART peripheral to register.
      * @return uint8_t Id of the service.
      */
-    static uint8_t inscribe(UART::Peripheral& uart);
-
-    /**
-     * @brief Registers a new UART.
-     *
-     * @param uart UART peripheral to register.
-     * @return uint8_t Id of the service.
-     */
-    static uint8_t inscribe(UART::Peripheral& uart, uint32_t baud_rate, uint32_t word_length);
+    static optional<uint8_t> inscribe(UART::Peripheral& uart);
 
     /**
      * @brief This method initializes all registered UARTs. The peripherals

--- a/Inc/HALAL/Services/Communication/UART/UART.hpp
+++ b/Inc/HALAL/Services/Communication/UART/UART.hpp
@@ -36,7 +36,7 @@ private:
         uint32_t baud_rate;
         uint32_t word_length;
         bool receive_ready = false; /**< Receive value is ready to use pin. */
-        bool initialized = false;;
+        bool initialized = false;
 
     };
 

--- a/Src/HALAL/Services/Communication/UART/UART.cpp
+++ b/Src/HALAL/Services/Communication/UART/UART.cpp
@@ -39,6 +39,20 @@ uint8_t UART::inscribe(UART::Peripheral& uart){
     return id;
 }
 
+uint8_t UART::inscribe(UART::Peripheral& uart, uint32_t baud_rate, uint32_t word_length){
+
+	uint8_t res = UART::inscribe(uart);
+
+	if(res){
+	    UART::Instance* uart = UART::registered_uart[res];
+
+	    uart->baud_rate = baud_rate;
+	    uart->word_length = word_length;
+	}
+
+    return res;
+}
+
 void UART::start(){
 		for_each(UART::registered_uart.begin(), UART::registered_uart.end(),
 				[](pair<uint8_t, UART::Instance*> iter) { UART::init(iter.second); }

--- a/Src/HALAL/Services/Communication/UART/UART.cpp
+++ b/Src/HALAL/Services/Communication/UART/UART.cpp
@@ -9,7 +9,7 @@
 #ifdef HAL_UART_MODULE_ENABLED
 
 UART::Instance UART::instance3 = { .TX = PC10, .RX = PB2, .huart = &huart3,
-								   .instance = USART3,
+								   .instance = USART3, .baud_rate = 115200, .word_length = UART_WORDLENGTH_8B,
                                };
 UART::Peripheral UART::uart3 = UART::Peripheral::peripheral3;
 
@@ -33,13 +33,15 @@ optional<uint8_t> UART::inscribe(UART::Peripheral& uart){
 
     uint8_t id = UART::id_counter++;
 
+    UART::registered_uart[id] = uart_instance;
+
     return id;
 }
 
 void UART::start(){
-		for_each(UART::registered_uart.begin(), UART::registered_uart.end(),
-				[](pair<uint8_t, UART::Instance*> iter) { UART::init(iter.second); }
-		);
+		for(auto iter: UART::registered_uart){
+			UART::init(iter.second);
+		}
 }
 
 bool UART::transmit_next_packet(uint8_t id, RawPacket& packet){

--- a/Src/HALAL/Services/Communication/UART/UART.cpp
+++ b/Src/HALAL/Services/Communication/UART/UART.cpp
@@ -11,20 +11,19 @@
 UART::Instance UART::instance3 = { .TX = PC10, .RX = PB2, .huart = &huart3,
 								   .instance = USART3,
                                };
-
 UART::Peripheral UART::uart3 = UART::Peripheral::peripheral3;
 
-forward_list<uint8_t> UART::id_manager = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255 };
 
 unordered_map<uint8_t, UART::Instance* > UART::registered_uart;
-
 unordered_map<UART::Peripheral, UART::Instance*> UART::available_uarts = {
 	{UART::uart3, &UART::instance3}
 };
 
-uint8_t UART::inscribe(UART::Peripheral& uart){
+uint16_t UART::id_counter = 0;
+
+optional<uint8_t> UART::inscribe(UART::Peripheral& uart){
 	if ( !UART::available_uarts.contains(uart)){
-		return 0; //TODO: Error handler
+		return nullopt; //TODO: Error handler or throw exception
 	}
 
 	UART::Instance*	uart_instance = UART::available_uarts[uart];
@@ -32,27 +31,9 @@ uint8_t UART::inscribe(UART::Peripheral& uart){
     Pin::inscribe(uart_instance->TX, ALTERNATIVE);
     Pin::inscribe(uart_instance->RX, ALTERNATIVE);
 
-    uint8_t id = UART::id_manager.front();
-
-    UART::registered_uart[id] = uart_instance;
-
-    UART::id_manager.pop_front();
+    uint8_t id = UART::id_counter++;
 
     return id;
-}
-
-uint8_t UART::inscribe(UART::Peripheral& uart, uint32_t baud_rate, uint32_t word_length){
-
-	uint8_t res = UART::inscribe(uart);
-
-	if(res){
-	    UART::Instance* uart = UART::registered_uart[res];
-
-	    uart->baud_rate = baud_rate;
-	    uart->word_length = word_length;
-	}
-
-    return res;
 }
 
 void UART::start(){
@@ -134,6 +115,10 @@ void HAL_UART_ErrorCallback(UART_HandleTypeDef *uart){
 
 void UART::init(UART::Instance* uart){
 
+	if (uart->initialized) {
+		return;
+	}
+
 	uart->huart->Instance = uart->instance;
 	uart->huart->Init.BaudRate = uart->baud_rate;
 	uart->huart->Init.WordLength = uart->word_length;
@@ -161,6 +146,8 @@ void UART::init(UART::Instance* uart){
 	if (HAL_UARTEx_DisableFifoMode(uart->huart) != HAL_OK){
 		//TODO: Error Handler
 	}
+
+	uart->initialized = true;
 }
 
 #endif

--- a/Src/HALAL/Services/Communication/UART/UART.cpp
+++ b/Src/HALAL/Services/Communication/UART/UART.cpp
@@ -71,11 +71,13 @@ bool UART::receive_next_packet(uint8_t id, RawPacket& packet){
 
     *packet.get_data() = 0;
 
+
     if (HAL_UART_Receive_DMA(uart->huart, packet.get_data(), packet.get_size()) != HAL_OK) {
         return false; //TODO: Warning, Error during receive
     }
 
     uart->receive_ready = false;
+
     return true;
 }
 
@@ -85,7 +87,7 @@ void HAL_UART_RxCpltCallback(UART_HandleTypeDef * huart){
     if (result != UART::registered_uart.end()) {
         (*result).second->receive_ready = true;
     }else{
-        //TODO: Warning: Data receive form an unknown UART
+        __NOP();//TODO: Warning: Data received form an unknown UART
     }
 }
 

--- a/Src/HALAL/Services/Communication/UART/UART.cpp
+++ b/Src/HALAL/Services/Communication/UART/UART.cpp
@@ -6,8 +6,10 @@
  */
 #include "Communication/UART/UART.hpp"
 
+#ifdef HAL_UART_MODULE_ENABLED
+
 UART::Instance UART::instance3 = { .TX = PC10, .RX = PB2, .huart = &huart3,
-								   .instance = USART3, .baud_rate = 115200, .word_length = UART_WORDLENGTH_8B,
+								   .instance = USART3,
                                };
 
 UART::Peripheral UART::uart3 = UART::Peripheral::peripheral3;
@@ -161,3 +163,4 @@ void UART::init(UART::Instance* uart){
 	}
 }
 
+#endif


### PR DESCRIPTION
# Implementation

- [x] The init that normally autogenerates the STM32CubeIDE has been implemented in a simple and concise way. To keep the use of the service simple, only the `baud_rate` and `word_length` can be configured, which are the parameters that change the most.

#  Testing

- [x] The same tests that were passed when the service was implemented have been passed.