### PR TITLE
Added extra features to Packets

### DIFF
--- a/Inc/HALAL/Models/Packets/Packet.hpp
+++ b/Inc/HALAL/Models/Packets/Packet.hpp
@@ -152,6 +152,7 @@ void Packet<Type, Types...>::fill_buffer() {
 template<class Type, class... Types>
 uint8_t* Packet<Type, Types...>::build() {
 	if (!has_been_built || has_container_values) {
+		buffer_size = sizeof(id);
 		calculate_sizes();
 		if(buffer != nullptr){
 			free(buffer);

--- a/Inc/HALAL/Models/Packets/PacketValue.hpp
+++ b/Inc/HALAL/Models/Packets/PacketValue.hpp
@@ -2,40 +2,136 @@
 
 #include "C++Utilities/CppUtils.hpp"
 
+template<typename T>
+struct has_const_iterator
+{
+private:
+    typedef char                      yes;
+    typedef struct { char array[2]; } no;
+
+    template<typename C> static yes test(typename C::const_iterator*);
+    template<typename C> static no  test(...);
+public:
+    static const bool value = sizeof(test<T>(0)) == sizeof(yes);
+    typedef T type;
+};
+
+template <typename T>
+struct has_begin_end
+{
+    template<typename C> static char(&f(typename std::enable_if<
+        std::is_same<decltype(static_cast<typename C::const_iterator(C::*)() const>(&C::begin)),
+        typename C::const_iterator(C::*)() const>::value, void>::type*))[1];
+
+    template<typename C> static char(&f(...))[2];
+
+    template<typename C> static char(&g(typename std::enable_if<
+        std::is_same<decltype(static_cast<typename C::const_iterator(C::*)() const>(&C::end)),
+        typename C::const_iterator(C::*)() const>::value, void>::type*))[1];
+
+    template<typename C> static char(&g(...))[2];
+
+    static bool const beg_value = sizeof(f<T>(0)) == 1;
+    static bool const end_value = sizeof(g<T>(0)) == 1;
+};
+
+template<typename T>
+struct is_container : integral_constant<bool, has_const_iterator<T>::value&& has_begin_end<T>::beg_value&& has_begin_end<T>::end_value>{};
+
+template<class Type>
+concept Integral = is_integral<Type>::value;
+
+template<class Type>
+concept NotIntegral = !is_integral<Type>::value;
+
+template<class Type>
+concept Container = is_container<Type>::value;
+
+template<class Type>
+concept NotContainer = !is_container<Type>::value;
+
+template<class BaseType>
+concept CustomButNotContainer = NotContainer<BaseType> && NotIntegral<BaseType>;
+
+template<class... Types> class PacketValue;
+
 template<class ConversionType>
-class PacketValue{
+class PacketValue<ConversionType>{
 public:
     using value_type = ConversionType;
     double* src;
     double factor;
 
-    PacketValue();
-    PacketValue(double* src, double factor);
+    PacketValue() = default;
+    PacketValue(double* src, double factor):src(src),factor(factor !=0 ? factor : 1){}
 
-    ConversionType convert();
+    ConversionType convert(){
+	    return static_cast<ConversionType>((*src) * factor);
+    }
 
-    void load(ConversionType new_data);
+    void load(ConversionType new_data){
+        *src = static_cast<double>(new_data / factor);
+    }
 
-    size_t size();
+    size_t size(){
+	    return sizeof(ConversionType);
+    }
 };
 
-template<class ConversionType>
-PacketValue<ConversionType>::PacketValue() = default;
+template<class BaseType> requires CustomButNotContainer<BaseType>
+class PacketValue<BaseType>{
+public:
+    using value_type = BaseType;
+    BaseType* src;
 
-template<class ConversionType>
-PacketValue<ConversionType>::PacketValue(double* src, double factor):src(src),factor(factor !=0 ? factor : 1){}
+    PacketValue() = default;
+    PacketValue(BaseType* src) : src(src){}
 
-template<class ConversionType>
-ConversionType PacketValue<ConversionType>::convert() {
-	return static_cast<ConversionType>((*src) * factor);
-}
+    BaseType convert() {
+        return *src;
+    }
 
-template<class ConversionType>
-void PacketValue<ConversionType>::load(ConversionType new_data) {
-    *src = static_cast<double>(new_data / factor);
-}
+    void load(BaseType new_data) {
+        *src = new_data;
+    }
 
-template<class ConversionType>
-size_t PacketValue<ConversionType>::size() {
-	return sizeof(ConversionType);
-}
+    size_t size() {
+        return sizeof(BaseType);
+    }
+};
+
+template<class BaseType> requires Container<BaseType>
+class PacketValue<BaseType> {
+public:
+    using value_type = BaseType;
+    BaseType* src;
+
+    PacketValue() = default;
+    PacketValue(BaseType* src) : src(src) {
+        if constexpr (is_same<string,BaseType>::value) {
+            is_string = true;
+        }
+    }
+
+    auto* convert() {
+        return src->data();
+    }
+
+    void load(BaseType* new_data) {
+        memcpy(src->data(), new_data, size());
+    }
+
+    size_t size() {
+        return src->size() * sizeof(typename remove_reference<decltype(*src)>::type::value_type) + is_string;
+    }
+private:
+    bool is_string = false;
+};
+
+#if __cpp_deduction_guides >= 201606
+template<Container BaseType>
+PacketValue(BaseType* src)->PacketValue<BaseType>;
+template<CustomButNotContainer BaseType>
+PacketValue(BaseType* src)->PacketValue<BaseType>;
+#endif
+

--- a/Inc/ST-LIB.hpp
+++ b/Inc/ST-LIB.hpp
@@ -9,7 +9,7 @@
 #include "Communication/Ethernet/UDP/DatagramSocket.hpp"
 #include "Communication/Ethernet/TCP/ServerSocket.hpp"
 #include "Communication/SPI/SPI.hpp"
-#include "Communication/UART/UART.hpp"
+//#include "Communication/UART/UART.hpp"
 #include "Time/Time.hpp"
 #include "Clocks/Counter.hpp"
 #include "Clocks/Stopwatch.hpp"

--- a/Inc/ST-LIB.hpp
+++ b/Inc/ST-LIB.hpp
@@ -9,7 +9,7 @@
 #include "Communication/Ethernet/UDP/DatagramSocket.hpp"
 #include "Communication/Ethernet/TCP/ServerSocket.hpp"
 #include "Communication/SPI/SPI.hpp"
-//#include "Communication/UART/UART.hpp"
+#include "Communication/UART/UART.hpp"
 #include "Time/Time.hpp"
 #include "Clocks/Counter.hpp"
 #include "Clocks/Stopwatch.hpp"

--- a/Src/HALAL/Services/Communication/Ethernet/UDP/DatagramSocket.cpp
+++ b/Src/HALAL/Services/Communication/Ethernet/UDP/DatagramSocket.cpp
@@ -7,9 +7,6 @@
 #ifdef HAL_ETH_MODULE_ENABLED
 #include "Communication/Ethernet/UDP/DatagramSocket.hpp"
 
-map<decltype(Packet<>::id), function<void(uint8_t*)>> Packet<>::save_by_id = {};
-map<decltype(Packet<>::id), void(*)()> Packet<>::on_received = {};
-
 DatagramSocket::DatagramSocket() = default;
 
 DatagramSocket::DatagramSocket(IPV4 local_ip, uint32_t local_port, IPV4 remote_ip, uint32_t remote_port): local_ip(local_ip), local_port(local_port), remote_ip(remote_ip), remote_port(remote_port){


### PR DESCRIPTION
This PR adds certain functionalities to Packet and PacketValue classes:
·Now Custom types can be sent and received with packets
·Now Dynamic Container Types can be sent and received with packets

>**Note**
>The sender can update the size of dynamic containers when building again a Packet but when receiving them the size received must be the same one as the last size sent, a way to bypass this is having all dynamic containers have a label before them indicating the size of the container, this is yet not implemented and will be further done if needed

Sintax for Packet Creation now looks like this:
![image](https://user-images.githubusercontent.com/24866863/206935502-100d6564-f758-4eac-add1-bd007040fce2.png)

Tests performed:
-Building Packet containing both Integral with factor PacketValues and dynamic container PacketValues, receiving the same Packet with new data and loading it:
**Code**:
```cpp
    double a = 3.3;
    double b = 55;
    double c = 5.5;

    string str = "hola1";
    string str2 = "adios";
    PacketValue value(&str);

    Packet paquete = {
        15,
        PacketValue<uint8_t>(&a,10),
        PacketValue<uint16_t>(&b,10),
        PacketValue<uint16_t>(&c,10),
        value
    };

    paquete.build();

    cout << "Variables before:" << endl;
    cout << "a: " << a << endl;
    cout << "b: " << b << endl;
    cout << "c: " << c << endl;
    cout << "str: " << str << endl;


    cout << "Packet Buffer:" << endl;

    cout << "ASCII    BYTE" << endl;
    for (int i = 0; i < paquete.bffr_size; i++) {
        cout << (char)paquete.bffr[i] << "       ";
        cout <<(int)paquete.bffr[i] << endl;
    }

    cout << "El tamaño del paquete es " << paquete.bffr_size << endl;

    uint8_t* new_ptr = (uint8_t*)malloc(7);
    new_ptr[0] = 15;
    new_ptr[1] = 0;
    new_ptr[2] = 22;
    new_ptr[3] = 44;
    new_ptr[4] = 0;
    new_ptr[5] = 44;
    new_ptr[6] = 0;

    memcpy(&new_ptr[7], str2.data(), str2.size()+1);
    save_by_id[paquete.id](new_ptr);


    cout << "Variables after:" << endl;
    cout << "a: " << a << endl;
    cout << "b: " << b << endl;
    cout << "c: " << c << endl;
    cout << "str: " << str << endl;
```
**Output**:
![image](https://user-images.githubusercontent.com/24866863/207099945-a5506c20-5308-4cbc-b1a5-18ea22d81467.png)

-Testing the features with Orders:
**Code:**
```cpp
void on_received_order() {
    cout << "ORDER RECEIVED" << endl;
}

double a = 3.3;
double b = 55;
double c = 5.5;


string str = "hola1";
string str2 = "adios";
PacketValue value(&str);

Packet paquete = {
    15,
    PacketValue<uint8_t>(&a,10),
    PacketValue<uint16_t>(&b,10),
    PacketValue<uint16_t>(&c,10),
    value
};
uint8_t* new_ptr = (uint8_t*)malloc(7 + str.size()+1);
Order orden = {
    16,
    on_received_order,
    PacketValue<uint8_t>(&a,10),
    PacketValue<uint16_t>(&b,10),
    PacketValue<uint16_t>(&c,10),
    PacketValue(&str)
};

cout << "Variables before:" << endl;
cout << "a: " << a << endl;
cout << "b: " << b << endl;
cout << "c: " << c << endl;
cout << "str: " << str << endl;

Packet<>::on_received[16]();

Order orden2(paquete);

orden2.set_callback(on_received_order);

Packet<>::on_received[15]();

new_ptr[0] = 16;
new_ptr[1] = 0;
new_ptr[2] = 32;
new_ptr[3] = 55;
new_ptr[4] = 0;
new_ptr[5] = 55;
new_ptr[6] = 0;
memcpy(&new_ptr[7],str2.data(),str2.size());

save_by_id[16](new_ptr);

cout << "Variables after:" << endl;
cout << "a: " << a << endl;
cout << "b: " << b << endl;
cout << "c: " << c << endl;
cout << "str: " <<  str << endl;
```
**Output:**
![image](https://user-images.githubusercontent.com/24866863/207169818-b0c777f1-5627-47a6-8da5-969bd764a032.png)

-Building a ton of times:
**Code:**
```cpp

    double a = 3.3;
    double b = 55;
    double c = 5.5;


    string str = "hola1";
    string str2 = "adios";
    PacketValue value(&str);

    Packet paquete = {
        15,
        PacketValue<uint8_t>(&a,10),
        PacketValue<uint16_t>(&b,10),
        PacketValue<uint16_t>(&c,10),
        value
    };

    paquete.build();

    cout << "Variables before:" << endl;
    cout << "a: " << a << endl;
    cout << "b: " << b << endl;
    cout << "c: " << c << endl;
    cout << "str: " << str << endl;


    cout << "Packet Buffer:" << endl;

    cout << "ASCII    BYTE" << endl;
    for (int i = 0; i < paquete.bffr_size; i++) {
        cout << (char)paquete.bffr[i] << "       ";
        cout <<(int)paquete.bffr[i] << endl;
    }

    cout << "El tamaño del paquete es " << paquete.bffr_size << endl;

    uint8_t* new_ptr = (uint8_t*)malloc(7 + str.size()+1);
    new_ptr[0] = 15;
    new_ptr[1] = 0;
    new_ptr[2] = 22;
    new_ptr[3] = 44;
    new_ptr[4] = 0;
    new_ptr[5] = 44;
    new_ptr[6] = 0;

    memcpy(&new_ptr[7], str2.data(), str2.size()+1);
    save_by_id[paquete.id](new_ptr);
    
    
    for (int i = 0; i < 10000000; i++) {
        paquete.build();
    }

    cout << "Variables after:" << endl;
    cout << "a: " << a << endl;
    cout << "b: " << b << endl;
    cout << "c: " << c << endl;
    cout << "str: " << str << endl;
```
**Output:**
![image](https://user-images.githubusercontent.com/24866863/207177008-dd7b0869-3e60-4cd0-98da-28af34179034.png)



