### PR TITLE
State Machine Rework

### DIFF
--- a/Inc/ST-LIB_LOW/StateMachine/StateMachine.hpp
+++ b/Inc/ST-LIB_LOW/StateMachine/StateMachine.hpp
@@ -12,7 +12,7 @@ public:
 	uint32_t microseconds;
 
 	TimedAction() = default;
-	TimedAction(function<void()> action, uint32_t microseconds, bool high_precision);
+	TimedAction(function<void()> action, uint32_t microseconds);
 };
 
 class State {
@@ -36,11 +36,10 @@ public:
 	void add_state(uint8_t state);
 	void add_transition(uint8_t old_state, uint8_t new_state, function<bool()> transition);
 
-	void add_cyclic_action_in_microseconds(function<void()> action, uint32_t microseconds);
-	void add_cyclic_action_in_microseconds(function<void()> action, uint32_t microseconds, uint8_t state);
-
-	void add_cyclic_action_in_milliseconds(function<void()> action, uint32_t milliseconds);
-	void add_cyclic_action_in_milliseconds(function<void()> action, uint32_t milliseconds, uint8_t state);
+	template<class TimeUnit>
+	void add_cyclic_action(function<void()> action, chrono::duration<int64_t, TimeUnit> period);
+	template<class TimeUnit>
+	void add_cyclic_action(function<void()> action, chrono::duration<int64_t, TimeUnit> period, uint8_t state);
 
 	void add_enter_action(function<void()> action);
 	void add_enter_action(function<void()> action, uint8_t state);

--- a/Inc/ST-LIB_LOW/StateMachine/StateMachine.hpp
+++ b/Inc/ST-LIB_LOW/StateMachine/StateMachine.hpp
@@ -6,14 +6,18 @@
 #include <C++Utilities/CppUtils.hpp>
 #include "Time/Time.hpp"
 
-class Action {
+class TimedAction {
+public:
 	function<void()> action;
-	uint16_t time_in_;
+	uint32_t microseconds;
+
+	TimedAction() = default;
+	TimedAction(function<void()> action, uint32_t microseconds, bool high_precision);
 };
 
 class State {
 public:
-	vector<function<void()>> on_update_actions = {};
+	vector<TimedAction> cyclic_actions = {};
 	vector<function<void()>> on_enter_actions = {};
 	vector<function<void()>> on_exit_actions = {};
 	void enter();
@@ -32,11 +36,11 @@ public:
 	void add_state(uint8_t state);
 	void add_transition(uint8_t old_state, uint8_t new_state, function<bool()> transition);
 
-	void add_cyclic_action_in_microseconds(function<void()> action, uint8_t microseconds);
-	void add_cyclic_action_in_microseconds(function<void()> action, uint8_t state, uint8_t microseconds);
+	void add_cyclic_action_in_microseconds(function<void()> action, uint32_t microseconds);
+	void add_cyclic_action_in_microseconds(function<void()> action, uint32_t microseconds, uint8_t state);
 
-	void add_cyclic_action_in_milliseconds(function<void()> action, uint8_t microseconds);
-	void add_cyclic_action_in_milliseconds(function<void()> action, uint8_t state, uint8_t microseconds);
+	void add_cyclic_action_in_milliseconds(function<void()> action, uint32_t milliseconds);
+	void add_cyclic_action_in_milliseconds(function<void()> action, uint32_t milliseconds, uint8_t state);
 
 	void add_enter_action(function<void()> action);
 	void add_enter_action(function<void()> action, uint8_t state);
@@ -44,13 +48,13 @@ public:
 	void add_exit_action(function<void()> action);
 	void add_exit_action(function<void()> action, uint8_t state);
 
-	void update();
-	void check_transitions();
 	void force_change_state(uint8_t new_state);
+	void check_transitions();
 
 private:
 	unordered_map<uint8_t, State> states;
 	unordered_map<uint8_t, unordered_map<uint8_t, function<bool()>>> transitions;
 
-	vector<uint8_t> actions;
+	vector<uint8_t> current_state_timed_actions_in_milliseconds;
+	vector<uint8_t> current_state_timed_actions_in_microseconds;
 };

--- a/Inc/ST-LIB_LOW/StateMachine/StateMachine.hpp
+++ b/Inc/ST-LIB_LOW/StateMachine/StateMachine.hpp
@@ -57,3 +57,33 @@ private:
 	vector<uint8_t> current_state_timed_actions_in_milliseconds;
 	vector<uint8_t> current_state_timed_actions_in_microseconds;
 };
+
+template<class TimeUnit>
+void StateMachine::add_cyclic_action(function<void()> action, chrono::duration<int64_t, TimeUnit> period, uint8_t state) {
+	if (not state) {
+		return; //TODO: Error handler
+	}
+
+	uint32_t microseconds = (uint32_t)chrono::duration_cast<chrono::microseconds>(period).count();
+	TimedAction timed_action(action, microseconds);
+	states[state].cyclic_actions.push_back(timed_action);
+
+	if (state == current_state) {
+		if (microseconds % 1000) {
+			optional<uint8_t> optional_id = Time::register_high_precision_alarm(microseconds, action);
+			if (not optional_id) {
+				return; //TODO: Error handler
+			}
+			current_state_timed_actions_in_microseconds.push_back(optional_id.value());
+		}
+		else {
+			uint8_t id = Time::register_low_precision_alarm(microseconds, action);
+			current_state_timed_actions_in_milliseconds.push_back(id);
+		}
+	}
+}
+
+template<class TimeUnit>
+void StateMachine::add_cyclic_action(function<void()> action, chrono::duration<int64_t, TimeUnit> period){
+	add_cyclic_action(action, period, current_state);
+}

--- a/Inc/ST-LIB_LOW/StateMachine/StateMachine.hpp
+++ b/Inc/ST-LIB_LOW/StateMachine/StateMachine.hpp
@@ -4,14 +4,18 @@
 
 #pragma once
 #include <C++Utilities/CppUtils.hpp>
+#include "Time/Time.hpp"
 
+class Action {
+	function<void()> action;
+	uint16_t time_in_;
+};
 
 class State {
 public:
 	vector<function<void()>> on_update_actions = {};
 	vector<function<void()>> on_enter_actions = {};
 	vector<function<void()>> on_exit_actions = {};
-	void update();
 	void enter();
 	void exit();
 };
@@ -28,8 +32,11 @@ public:
 	void add_state(uint8_t state);
 	void add_transition(uint8_t old_state, uint8_t new_state, function<bool()> transition);
 
-	void add_update_action(function<void()> action);
-	void add_update_action(function<void()> action, uint8_t state);
+	void add_cyclic_action_in_microseconds(function<void()> action, uint8_t microseconds);
+	void add_cyclic_action_in_microseconds(function<void()> action, uint8_t state, uint8_t microseconds);
+
+	void add_cyclic_action_in_milliseconds(function<void()> action, uint8_t microseconds);
+	void add_cyclic_action_in_milliseconds(function<void()> action, uint8_t state, uint8_t microseconds);
 
 	void add_enter_action(function<void()> action);
 	void add_enter_action(function<void()> action, uint8_t state);
@@ -44,4 +51,6 @@ public:
 private:
 	unordered_map<uint8_t, State> states;
 	unordered_map<uint8_t, unordered_map<uint8_t, function<bool()>>> transitions;
+
+	vector<uint8_t> actions;
 };

--- a/Src/ST-LIB_LOW/StateMachine/StateMachine.cpp
+++ b/Src/ST-LIB_LOW/StateMachine/StateMachine.cpp
@@ -36,36 +36,6 @@ void StateMachine::add_state(uint8_t state) {
 	states[state] = State();
 }
 
-template<class TimeUnit>
-void StateMachine::add_cyclic_action(function<void()> action, chrono::duration<int64_t, TimeUnit> period){
-	add_cyclic_action(action, period, current_state);
-}
-
-template<class TimeUnit>
-void StateMachine::add_cyclic_action(function<void()> action, chrono::duration<int64_t, TimeUnit> period, uint8_t state) {
-	if (not state) {
-		return; //TODO: Error handler
-	}
-
-	uint32_t microseconds = (uint32_t)chrono::duration_cast<chrono::microseconds>(period).count();
-	TimedAction timed_action(action, microseconds);
-	states[state].cyclic_actions.push_back(timed_action);
-
-	if (state == current_state) {
-		if (microseconds % 1000) {
-			optional<uint8_t> optional_id = Time::register_high_precision_alarm(microseconds, action);
-			if (not optional_id) {
-				return; //TODO: Error handler
-			}
-			current_state_timed_actions_in_microseconds.push_back(optional_id.value());
-		}
-		else {
-			uint8_t id = Time::register_low_precision_alarm(microseconds, action);
-			current_state_timed_actions_in_milliseconds.push_back(id);
-		}
-	}
-}
-
 void StateMachine::add_enter_action(function<void()> action) {
 	if (not current_state) {
 		return; //TODO: Error handler

--- a/Src/ST-LIB_LOW/StateMachine/StateMachine.cpp
+++ b/Src/ST-LIB_LOW/StateMachine/StateMachine.cpp
@@ -2,13 +2,7 @@
  * Created by Alejandro
  */
 
-#include <StateMachine/StateMachine.hpp>
-
-void State::update() {
-	for (function<void()> action : on_update_actions) {
-		action();
-	}
-}
+#include "StateMachine/StateMachine.hpp"
 
 void State::enter() {
 	for (function<void()> action : on_enter_actions) {


### PR DESCRIPTION
# State Machine Rework
This PW reworks the State Machine to use cyclic actions using Time HALAL Service.

# Usage:
``` cpp
  state_machine.add_cyclic_action_in_microseconds([&]() {
	  adc_value = ADC::get_value(adc1).value();
  }, 700us ,on);
```

## Testing:
Both microseconds and milliseconds actions have been tested.