### PR TITLE
Features/math

### DIFF
--- a/Inc/HALAL/Services/CORDIC/CORDIC.hpp
+++ b/Inc/HALAL/Services/CORDIC/CORDIC.hpp
@@ -66,13 +66,13 @@ public:
 	 * If the angle or the out parameter has less size than the size parameter, it will throw an exception
 	 * If one or both angle and out parameters have more size than size, it will just calculate until size and leave the rest as it is
 	 */
-	static void cos(int32_t *angle,int32_t *out,int size);
+	static void cos(int32_t *angle,int32_t *out,int32_t size);
 
 
 	/*
 	 * @brief sine function. virtually the same as the cosine function
 	 */
-	static void sin(int32_t *angle,int32_t *out,int size);
+	static void sin(int32_t *angle,int32_t *out,int32_t size);
 
 
 	/*
@@ -89,7 +89,7 @@ public:
 	 * The exact time it takes is around 4 cycles more than the cos function, which is around 30-40. So 10% more as it needs to read one more register.
 	 * The reads are protected to give the correct result, thats why it needs 4 cycles for the read (on average) and not just one
 	 */
-	static void cos_and_sin(int32_t *angle, int32_t *cos_out, int32_t *sin_out, int size);
+	static void cos_and_sin(int32_t *angle, int32_t *cos_out, int32_t *sin_out, int32_t size);
 
 
 	/*
@@ -98,7 +98,7 @@ public:
 	 * @param y. The array of values y of each vector with size "size". input.
 	 * @param angle_out. The array where the functions puts its output, which is an angle. output.
 	 */
-	static void phase(int32_t *x, int32_t *y, int32_t *angle_out, int size);
+	static void phase(int32_t *x, int32_t *y, int32_t *angle_out, int32_t size);
 
 
 	/*
@@ -111,7 +111,7 @@ public:
 	 * If it were to give a value higher than 2147483392, the value that it would return would be absurd.
 	 * Avoiding to get near the limits of the euclidean space described (no more than 70% on both of the axis) is advised.
 	 */
-	static void modulus(int32_t *x, int32_t *y, int32_t *out, int size);
+	static void modulus(int32_t *x, int32_t *y, int32_t *out, int32_t size);
 
 	/*
 	 * @brief modulus and phase function. Does both while only needing the time that one takes
@@ -124,7 +124,7 @@ public:
 	 * The modulus returned by this function shares weaknesses with the modulus function.
 	 * Avoiding getting near the 70% of the maximun (~ 1518500000) on both x and y at the same time is advised, unless modulus is handled.
 	 */
-	static void phase_and_modulus(int32_t *x, int32_t *y, int32_t *angle_out, int32_t *mod_out, int size);
+	static void phase_and_modulus(int32_t *x, int32_t *y, int32_t *angle_out, int32_t *mod_out, int32_t size);
 	/*
 	 * @brief Testing function that translates the angle to a float in radians, to make reading easier. Its slow, not intended to use on continous calculations
 	 */

--- a/Inc/ST-LIB_LOW/Math/Math.hpp
+++ b/Inc/ST-LIB_LOW/Math/Math.hpp
@@ -8,6 +8,7 @@
 #pragma once
 #include "ST-LIB.hpp"
 #define TG_DECIMAL_BITS 16
+#define SQ_DECIMAL_BITS 16
 #define MAX_INT 2147483647
 #define HALF_INT MAX_INT/2
 #define MAX_MOD_MARGIN 2147483392
@@ -23,8 +24,12 @@ public:
 	static int32_t cos(int32_t angle);
 	static int32_t tg(int32_t angle);
 	static int32_t phase(int32_t x, int32_t y);
-	static int32_t modulus(int32_t x, int32_t y);
+	static uint32_t modulus(int32_t x, int32_t y);
 	static int32_t atg(int32_t tg_in);
+	static int32_t sqrt(int32_t sq_in);
+
+	static inline int32_t sq_to_unitary(int32_t sq_in);
+	static inline int32_t unitary_to_sq(int32_t in);
 	static inline int32_t tg_to_unitary(int32_t tg_in);
 	static inline int32_t unitary_to_tg(int32_t in);
 private:

--- a/Inc/ST-LIB_LOW/Math/Math.hpp
+++ b/Inc/ST-LIB_LOW/Math/Math.hpp
@@ -1,0 +1,24 @@
+/*
+ * CORDIC.hpp
+ *
+ * Created on: 13 dic. 2022
+ * 		Author: Ricardo
+ */
+
+#pragma once
+#include "ST-LIB.hpp"
+
+class Math{
+public:
+	static uint32_t sin(uint32_t angle);
+	static uint32_t cos(uint32_t angle);
+	static uint32_t tg(uint32_t angle);
+	static uint32_t phase(uint32_t x, uint32_t y);
+	static uint32_t modulus(uint32_t x, uint32_t y);
+private:
+	uint32_t array [4];
+	uint32_t *pointer1;
+	uint32_t *pointer2;
+	uint32_t *pointer3;
+	uint32_t *pointer4;
+};

--- a/Inc/ST-LIB_LOW/Math/Math.hpp
+++ b/Inc/ST-LIB_LOW/Math/Math.hpp
@@ -7,18 +7,21 @@
 
 #pragma once
 #include "ST-LIB.hpp"
+#define TG_DECIMAL_BITS 16
+#define INT_MAX 2147483647
+
 
 class Math{
 public:
-	static uint32_t sin(uint32_t angle);
-	static uint32_t cos(uint32_t angle);
-	static uint32_t tg(uint32_t angle);
-	static uint32_t phase(uint32_t x, uint32_t y);
-	static uint32_t modulus(uint32_t x, uint32_t y);
+	static int32_t sin(int32_t angle);
+	static int32_t cos(int32_t angle);
+	static int32_t tg(int32_t angle);
+	static int32_t phase(int32_t x, int32_t y);
+	static int32_t modulus(int32_t x, int32_t y);
 private:
-	uint32_t array [4];
-	uint32_t *pointer1;
-	uint32_t *pointer2;
-	uint32_t *pointer3;
-	uint32_t *pointer4;
+	static int32_t array[4];
+	static int32_t *pointer1;
+	static int32_t *pointer2;
+	static int32_t *pointer3;
+	static int32_t *pointer4;
 };

--- a/Inc/ST-LIB_LOW/Math/Math.hpp
+++ b/Inc/ST-LIB_LOW/Math/Math.hpp
@@ -8,7 +8,13 @@
 #pragma once
 #include "ST-LIB.hpp"
 #define TG_DECIMAL_BITS 16
-#define INT_MAX 2147483647
+#define MAX_INT 2147483647
+#define HALF_INT MAX_INT/2
+#define MAX_MOD_MARGIN 2147483392
+#define MAX_MARGIN 2147483392
+#define HALF_MARGIN MAX_MARGIN/2
+#define SHALF_MARGIN INT_MAX - HALF_MARGIN
+#define Q31_MASK 0x7FFFFFFF
 
 
 class Math{
@@ -18,6 +24,9 @@ public:
 	static int32_t tg(int32_t angle);
 	static int32_t phase(int32_t x, int32_t y);
 	static int32_t modulus(int32_t x, int32_t y);
+	static int32_t atg(int32_t tg_in);
+	static inline int32_t tg_to_unitary(int32_t tg_in);
+	static inline int32_t unitary_to_tg(int32_t in);
 private:
 	static int32_t array[4];
 	static int32_t *pointer1;

--- a/Src/ST-LIB_LOW/Math/Math.cpp
+++ b/Src/ST-LIB_LOW/Math/Math.cpp
@@ -1,2 +1,44 @@
 #include "ST-LIB_LOW/Math/Math.hpp"
 #include "CORDIC/CORDIC.hpp"
+
+int32_t Math::array[4] = {0,0,0,0};
+int32_t *Math::pointer1 = array;
+int32_t *Math::pointer2 = (int32_t *) array + 1;
+int32_t *Math::pointer3 = (int32_t *) array + 2;
+int32_t *Math::pointer4 = (int32_t *) array + 3;
+
+int32_t Math::sin(int32_t angle){
+	*pointer1 = angle;
+	RotationComputer::sin(pointer1,pointer2,1);
+	return *pointer2;
+}
+
+int32_t Math::cos(int32_t angle){
+	*pointer1 = angle;
+	RotationComputer::cos(pointer1,pointer2,1);
+	return *pointer2;
+}
+
+int32_t Math::tg(int32_t angle){
+	*pointer1 = angle;
+	RotationComputer::cos_and_sin(pointer1,pointer2,pointer3,1);
+	return *pointer3 / (*pointer2 >> TG_DECIMAL_BITS);
+}
+
+int32_t Math::phase(int32_t x, int32_t y){
+	*pointer1 = x;
+	*pointer2 = y;
+	RotationComputer::phase(pointer1, pointer2, pointer3, 1);
+	return *pointer3;
+}
+
+int32_t Math::modulus(int32_t x, int32_t y){
+	if(x + y > INT_MAX){
+		//TODO: calculate efficiently in case the CORDIC is estimated to fail
+		return INT_MAX;
+	}
+	*pointer1 = x;
+	*pointer2 = y;
+	RotationComputer::modulus(pointer1, pointer2, pointer3, 1);
+	return *pointer3;
+}

--- a/Src/ST-LIB_LOW/Math/Math.cpp
+++ b/Src/ST-LIB_LOW/Math/Math.cpp
@@ -43,10 +43,14 @@ int32_t Math::phase(int32_t x, int32_t y){
 	return *pointer3;
 }
 
-int32_t Math::modulus(int32_t x, int32_t y){
-	if(x + y > MAX_MOD_MARGIN){
-		//TODO: calculate efficiently in case the CORDIC is estimated to fail
-		return MAX_INT;
+uint32_t Math::modulus(int32_t x, int32_t y){
+	if(((uint32_t) x + y) > MAX_MOD_MARGIN){
+		*pointer1 = (x >> 1);
+		*pointer2 = (y >> 1);
+		RotationComputer::modulus(pointer1, pointer2, pointer3, 1);
+		uint32_t mod= *pointer3;
+		mod = (mod << 1);
+		return mod;
 	}
 	*pointer1 = x;
 	*pointer2 = y;
@@ -61,11 +65,34 @@ int32_t Math::atg(int32_t in){
 	return *pointer3;
 }
 
+
+int32_t Math::sqrt(int32_t sq_in){
+	int32_t sol = 0;
+	int32_t temp = 0;
+	int32_t over = sq_in >> SQ_DECIMAL_BITS;
+	for(int32_t i = 0x8000 >> (SQ_DECIMAL_BITS >> 1); i >= 1; i = i >> 1){
+		temp = (sol + i);
+		if(((temp*temp)) <= over){
+			sol = sol + i;
+		}
+	}
+
+	return sol<<SQ_DECIMAL_BITS;
+}
+
+int32_t Math::sq_to_unitary(int32_t sq_in){
+	return sq_in << (32 - SQ_DECIMAL_BITS);
+}
+
+int32_t Math::unitary_to_sq(int32_t in){
+	return in >> (32 - SQ_DECIMAL_BITS);
+}
+
 int32_t Math::tg_to_unitary(int32_t tg_in){
-	return tg_in >> TG_DECIMAL_BITS;
+	return tg_in << (32 - TG_DECIMAL_BITS);
 }
 
 int32_t Math::unitary_to_tg(int32_t in){
-	return in << TG_DECIMAL_BITS;
+	return in >> (32 - TG_DECIMAL_BITS);
 }
 

--- a/Src/ST-LIB_LOW/Math/Math.cpp
+++ b/Src/ST-LIB_LOW/Math/Math.cpp
@@ -1,0 +1,2 @@
+#include "ST-LIB_LOW/Math/Math.hpp"
+#include "CORDIC/CORDIC.hpp"

--- a/Src/ST-LIB_LOW/Math/Math.cpp
+++ b/Src/ST-LIB_LOW/Math/Math.cpp
@@ -20,6 +20,17 @@ int32_t Math::cos(int32_t angle){
 }
 
 int32_t Math::tg(int32_t angle){
+	if((angle & Q31_MASK) >= HALF_MARGIN){
+		if((angle & Q31_MASK) >= SHALF_MARGIN){
+			angle = angle - MAX_INT;
+		}else{
+			if(angle > 0){
+				return MAX_INT;
+			}else{
+				return -MAX_INT-1;
+			}
+		}
+	}
 	*pointer1 = angle;
 	RotationComputer::cos_and_sin(pointer1,pointer2,pointer3,1);
 	return *pointer3 / (*pointer2 >> TG_DECIMAL_BITS);
@@ -33,12 +44,28 @@ int32_t Math::phase(int32_t x, int32_t y){
 }
 
 int32_t Math::modulus(int32_t x, int32_t y){
-	if(x + y > INT_MAX){
+	if(x + y > MAX_MOD_MARGIN){
 		//TODO: calculate efficiently in case the CORDIC is estimated to fail
-		return INT_MAX;
+		return MAX_INT;
 	}
 	*pointer1 = x;
 	*pointer2 = y;
 	RotationComputer::modulus(pointer1, pointer2, pointer3, 1);
 	return *pointer3;
 }
+
+int32_t Math::atg(int32_t in){
+	*pointer1 = 1 << TG_DECIMAL_BITS;
+	*pointer2 = in;
+	RotationComputer::phase(pointer1, pointer2, pointer3, 1);
+	return *pointer3;
+}
+
+int32_t Math::tg_to_unitary(int32_t tg_in){
+	return tg_in >> TG_DECIMAL_BITS;
+}
+
+int32_t Math::unitary_to_tg(int32_t in){
+	return in << TG_DECIMAL_BITS;
+}
+


### PR DESCRIPTION
New class math

Receives int numbers that represent what is convenient for the calculations and outputs the result of such. 

Angle: goes from [-pi,pi] across all ints values. So MAX_INT would be pi.
Coordinates: goes from [-limit_space,limit_space] on both directions. MAX_INT would fall on the limit of the space, and one more would overflow into the -limit_space coordinate.
Unitary: goes from [-1,1], used as returns of cos and sine. 
tg: Units used on tg, goes from [-65536,65535] and has 16 bits for decimals. If we wanted higher decimal precision or higher amplitude of results we would need to trade one for the other, changing the TG_DECIMAL_BITS constant. No more changes would be needed.
sq: Same as tg, but you can change it separately. in case we want different compromises for each operation. 

The sin, cos, phase and modulus functions just use cordic and handle errors before they happen. 

The tan function uses sine and cosine and makes the division taking advantage of the tan = sin/cos property. 
It works on all four quadrants and handles division by 0 by returning the max value tg can have. (So technically the range of tg is a bit lower, as only the handle can return the max value).

The arctan uses the phase and draws the vector that tan defines.