### PR TITLE
General fixes and Printf Fix

### DIFF
--- a/Inc/HALAL/Models/Packets/Packet.hpp
+++ b/Inc/HALAL/Models/Packets/Packet.hpp
@@ -209,5 +209,3 @@ decltype(Packet<Type,Types...>::id) Packet<Type, Types...>::get_id() {
     return this->id;
 }
 
-map<decltype(Packet<>::id), function<void(uint8_t*)>> Packet<>::save_by_id = {};
-map<decltype(Packet<>::id), void(*)()> Packet<>::on_received = {};

--- a/Inc/HALAL/Services/Communication/UART/UART.hpp
+++ b/Inc/HALAL/Services/Communication/UART/UART.hpp
@@ -14,6 +14,8 @@
 
 #define TXBUSYMASK 0b1
 #define RXBUSYMASK 0b10
+
+#define endl "\n\r"
 /**
  * @brief UART service class. Abstracts the use of the UART service of the HAL library.
  * 
@@ -55,12 +57,17 @@ private:
 		peripheral10 = 9
     };
 
+
+
 public:
     static uint16_t id_counter;
     
     static unordered_map<uint8_t, UART::Instance* > registered_uart;
 
     static unordered_map<UART::Peripheral, UART::Instance*> available_uarts;
+
+    static uint8_t printf_uart;
+    static bool printf_ready;
 
     /**
 	* @brief UART  wrapper enum of the STM32H723.
@@ -108,22 +115,57 @@ public:
      */
     static void start();
 
-    /**@brief	Transmits 1 RawPacket of any size by DMA and
-     *          interrupts. Handles the packet size automatically. To
-     *          to send various packets in a row you must check if the UART is busy
-     *          using is_busy().
+    /**@brief	Transmits 1 byte by DMA and interrupts.
+     *          To send various packets in a row you must check if the UART is busy
+     *          using is_busy(). All calls to this functions previous
+     *          the bus is ready be ignored.
      * 
      * @param id Id of the UART
-     * @param packet Packet to be send
+     * @param data data to be send
      * @return bool Returns true if the request to send the packet has been done
      *            successfully. Returns false if the UART is busy or a problem
      *            has occurred.
      */
-    static bool transmit_next_packet(uint8_t id, RawPacket& packet);
+    static bool transmit_next_packet(uint8_t id, uint8_t data);
+
+    /**@brief	Transmits size number of bytes by DMA and interrupts.
+	 *          To send various packets in a row you must check if the UART is busy
+	 *          using is_busy(). All calls to this functions previous
+     *          the bus is ready be ignored.
+	 *
+	 * @param id Id of the UART
+	 * @param data Data to be sent.
+	 * @param size Size of the data
+	 * @return bool Returns true if the request to send the packet has been done
+	 *            successfully. Returns false if the UART is busy or a problem
+	 *            has occurred.
+	 */
+    static bool transmit_next_packet(uint8_t id, uint8_t* data, int16_t size);
+
+    /**@brief	Transmits 1 byte by polling.
+	 *
+	 * @param id Id of the UART
+	 * @param data Data to be sent.
+	 * @param size Size of the data
+	 * @return bool Returns true if the request to send the packet has been done
+	 *            successfully. Returns false if the UART is busy or a problem
+	 *            has occurred.
+	 */
+    static bool transmit_next_packet_polling(uint8_t id, uint8_t data);
+
+    /**@brief	Transmits size bytes by polling.
+	 *
+	 * @param id Id of the UART
+	 * @param data Data to be sent.
+	 * @param size Size of the data
+	 * @return bool Returns true if the packet has been send successfully.
+	 * 			    Returns false if the UART is busy or a problem has occurred.
+	 */
+    static bool transmit_next_packet_polling(uint8_t id, uint8_t* data, int16_t size);
 
     /**						
-     * @brief This method request the receive of a new RawPacket of any size
-     *        by DMA and interrupts. Thus the packet should not be used until
+     * @brief This method request the receive of size bytes
+     *        by DMA and interrupts. Thus the data should not be used until
      *        you have checked that the value is already available using the 
      *        method has_next_paclet(). All calls to this functions previous
      *        the last packet is ready will be ignored.
@@ -131,12 +173,26 @@ public:
      * @see   UART::has_next_packet()
      * 
      * @param id Id of the UART
-     * @param packet RawPacket in which the data will be stored
+     * @param data Where data will be stored
+     * @param size Number of bytes to read
      * @return bool Return true if the order to receive a new packet has been
      *            processed correctly. Return false if the UART is busy or a
      *            problem has occurred.
      */
-    static bool receive_next_packet(uint8_t id, RawPacket& packet);
+    static bool receive_next_packet(uint8_t id, uint8_t* data, uint16_t size);
+
+    /**
+	* @brief This method receive size number of bytes by polling.
+	*
+	* @see   UART::has_next_packet()
+	*
+	* @param id Id of the UART
+	* @param data Where data will be stored
+	* @param size Number of bytes to read
+	* @return bool Return true if the data has been read successfully.
+	* 			   Return false if the UART is busy or a problem has occurred.
+	*/
+    static bool receive_next_packet_polling(uint8_t id, uint8_t* data, uint16_t size);
 
     /**
      * @brief This method is used to check if the UART receive operation has finished and data is ready.
@@ -154,6 +210,25 @@ public:
      */
     static bool is_busy(uint8_t id);
 
+    /**
+	 * @brief This method is used to set up the printf. It's inscribe and configure the selected UART to work
+	 * 		  as standard and error output.
+	 *
+	 * @param uart Uart peripheral to be configured.
+	 * @return bool True if everything went well. False if something has gone wrong.
+	 */
+    static bool set_up_printf(UART::Peripheral& uart);
+
+    /**
+  	 * @brief This method is used to print a message through the uart configured for printf.
+  	 * 		  It only works if it has been configured correctly.
+  	 *
+  	 * @param ptr Pointer to the character string.
+  	 * @param len Length of the message.
+  	 * @return bool True if everything went well. False if something has gone wrong.
+  	 */
+    static void print_by_uart(char *ptr, int len);
+
     private:
     /**
      * @brief This method initializes the UART peripheral that is passed to it as a parameter.
@@ -161,6 +236,7 @@ public:
      * @param uart Peripheral instance to be initialized.
      */
     static void init(UART::Instance* uart);
+
 };
 
 #endif

--- a/Inc/HALAL/Services/Communication/UART/UART.hpp
+++ b/Inc/HALAL/Services/Communication/UART/UART.hpp
@@ -57,13 +57,10 @@ private:
 		peripheral10 = 9
     };
 
-
-
 public:
     static uint16_t id_counter;
     
     static unordered_map<uint8_t, UART::Instance* > registered_uart;
-
     static unordered_map<UART::Peripheral, UART::Instance*> available_uarts;
 
     static uint8_t printf_uart;

--- a/Inc/HALAL/Services/Communication/UART/UART.hpp
+++ b/Inc/HALAL/Services/Communication/UART/UART.hpp
@@ -126,7 +126,7 @@ public:
      *            successfully. Returns false if the UART is busy or a problem
      *            has occurred.
      */
-    static bool transmit_next_packet(uint8_t id, uint8_t data);
+    static bool transmit(uint8_t id, uint8_t data);
 
     /**@brief	Transmits size number of bytes by DMA and interrupts.
 	 *          To send various packets in a row you must check if the UART is busy
@@ -140,7 +140,7 @@ public:
 	 *            successfully. Returns false if the UART is busy or a problem
 	 *            has occurred.
 	 */
-    static bool transmit_next_packet(uint8_t id, uint8_t* data, int16_t size);
+    static bool transmit(uint8_t id, uint8_t* data, int16_t size);
 
     /**@brief	Transmits 1 byte by polling.
 	 *
@@ -151,7 +151,7 @@ public:
 	 *            successfully. Returns false if the UART is busy or a problem
 	 *            has occurred.
 	 */
-    static bool transmit_next_packet_polling(uint8_t id, uint8_t data);
+    static bool transmit_polling(uint8_t id, uint8_t data);
 
     /**@brief	Transmits size bytes by polling.
 	 *
@@ -161,7 +161,7 @@ public:
 	 * @return bool Returns true if the packet has been send successfully.
 	 * 			    Returns false if the UART is busy or a problem has occurred.
 	 */
-    static bool transmit_next_packet_polling(uint8_t id, uint8_t* data, int16_t size);
+    static bool transmit_polling(uint8_t id, uint8_t* data, int16_t size);
 
     /**						
      * @brief This method request the receive of size bytes
@@ -179,7 +179,7 @@ public:
      *            processed correctly. Return false if the UART is busy or a
      *            problem has occurred.
      */
-    static bool receive_next_packet(uint8_t id, uint8_t* data, uint16_t size);
+    static bool receive(uint8_t id, uint8_t* data, uint16_t size);
 
     /**
 	* @brief This method receive size number of bytes by polling.
@@ -192,7 +192,7 @@ public:
 	* @return bool Return true if the data has been read successfully.
 	* 			   Return false if the UART is busy or a problem has occurred.
 	*/
-    static bool receive_next_packet_polling(uint8_t id, uint8_t* data, uint16_t size);
+    static bool receive_polling(uint8_t id, uint8_t* data, uint16_t size);
 
     /**
      * @brief This method is used to check if the UART receive operation has finished and data is ready.

--- a/Inc/ST-LIB_LOW/StateMachine/StateMachine.hpp
+++ b/Inc/ST-LIB_LOW/StateMachine/StateMachine.hpp
@@ -6,6 +6,8 @@
 #include <C++Utilities/CppUtils.hpp>
 #include "Time/Time.hpp"
 
+#ifdef HAL_TIM_MODULE_ENABLED
+
 class TimedAction {
 public:
 	function<void()> action;
@@ -87,3 +89,5 @@ template<class TimeUnit>
 void StateMachine::add_cyclic_action(function<void()> action, chrono::duration<int64_t, TimeUnit> period){
 	add_cyclic_action(action, period, current_state);
 }
+
+#endif

--- a/Src/HALAL/Models/Runes/Runes.cpp
+++ b/Src/HALAL/Models/Runes/Runes.cpp
@@ -44,6 +44,9 @@ unordered_map<UART::Peripheral, UART::Instance*> UART::available_uarts = {
 	{UART::uart2, &UART::instance2}
 };
 
+uint8_t UART::printf_uart = 0;
+bool UART::printf_ready = false;
+
 #endif
 /************************************************
  *              Communication-I2C

--- a/Src/HALAL/Services/Communication/Ethernet/UDP/DatagramSocket.cpp
+++ b/Src/HALAL/Services/Communication/Ethernet/UDP/DatagramSocket.cpp
@@ -7,6 +7,9 @@
 #ifdef HAL_ETH_MODULE_ENABLED
 #include "Communication/Ethernet/UDP/DatagramSocket.hpp"
 
+map<decltype(Packet<>::id), function<void(uint8_t*)>> Packet<>::save_by_id = {};
+map<decltype(Packet<>::id), void(*)()> Packet<>::on_received = {};
+
 DatagramSocket::DatagramSocket() = default;
 
 DatagramSocket::DatagramSocket(IPV4 local_ip, uint32_t local_port, IPV4 remote_ip, uint32_t remote_port): local_ip(local_ip), local_port(local_port), remote_ip(remote_ip), remote_port(remote_port){

--- a/Src/HALAL/Services/Communication/UART/UART.cpp
+++ b/Src/HALAL/Services/Communication/UART/UART.cpp
@@ -35,7 +35,7 @@ void UART::start(){
 		}
 }
 
-bool UART::transmit_next_packet(uint8_t id, uint8_t data){
+bool UART::transmit(uint8_t id, uint8_t data){
     if (not UART::registered_uart.contains(id))
         return false; //TODO: Error handler
 
@@ -51,7 +51,7 @@ bool UART::transmit_next_packet(uint8_t id, uint8_t data){
     return true;
 }
 
-bool UART::transmit_next_packet(uint8_t id, uint8_t* data, int16_t size){
+bool UART::transmit(uint8_t id, uint8_t* data, int16_t size){
     if (not UART::registered_uart.contains(id))
         return false; //TODO: Error handler
 
@@ -67,7 +67,7 @@ bool UART::transmit_next_packet(uint8_t id, uint8_t* data, int16_t size){
     return true;
 }
 
-bool UART::transmit_next_packet_polling(uint8_t id, uint8_t data){
+bool UART::transmit_polling(uint8_t id, uint8_t data){
     if (not UART::registered_uart.contains(id))
         return false; //TODO: Error handler
 
@@ -83,7 +83,7 @@ bool UART::transmit_next_packet_polling(uint8_t id, uint8_t data){
     return true;
 }
 
-bool UART::transmit_next_packet_polling(uint8_t id, uint8_t* data, int16_t size){
+bool UART::transmit_polling(uint8_t id, uint8_t* data, int16_t size){
     if (not UART::registered_uart.contains(id))
         return false; //TODO: Error handler
 
@@ -99,7 +99,7 @@ bool UART::transmit_next_packet_polling(uint8_t id, uint8_t* data, int16_t size)
     return true;
 }
 
-bool UART::receive_next_packet(uint8_t id, uint8_t* data, uint16_t size){
+bool UART::receive(uint8_t id, uint8_t* data, uint16_t size){
     if (not UART::registered_uart.contains(id))
         return false; //TODO: Error handler
 
@@ -118,7 +118,7 @@ bool UART::receive_next_packet(uint8_t id, uint8_t* data, uint16_t size){
     return true;
 }
 
-bool UART::receive_next_packet_polling(uint8_t id, uint8_t* data, uint16_t size){
+bool UART::receive_polling(uint8_t id, uint8_t* data, uint16_t size){
     if (not UART::registered_uart.contains(id))
         return false; //TODO: Error handler
 
@@ -190,7 +190,7 @@ void UART::print_by_uart(char *ptr, int len){
 			return;
 		}
 
-		UART::transmit_next_packet_polling(UART::printf_uart, (uint8_t*)ptr, static_cast<uint16_t>(len));
+		UART::transmit_polling(UART::printf_uart, (uint8_t*)ptr, static_cast<uint16_t>(len));
 }
 
 


### PR DESCRIPTION
### General fixes

- Added TIM guard in StateMachine
- Moved som code from .hpp to .cpp to avoid weird bugs

### Printf 

Se han arreglado los `printf` y simplicado su uso. Ahora forman parte del servicio de UART y se puede ver como utilizarlos a continuación.

```cpp
  UART::set_up_printf(UART::uart3);
  UART::start();

  printf("123456789%s", endl);
  fprintf(stderr, "Error xD!%s", endl);
```

Ya no hace falta configurar nada para hacerlos funcionar, por tanto el articulo sobre los printf ha quedado desactualizado. Se modificará lo antes posible.