### PR TITLE
supress warnings

### DIFF
--- a/.cproject
+++ b/.cproject
@@ -113,6 +113,9 @@
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/ST-LIB/Inc/ST-LIB_HIGH}&quot;"/>
 								</option>
 								<option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.languagestandard.1092333469" name="Language standard" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.languagestandard" useByScannerDiscovery="true" value="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.languagestandard.value.gnupp20" valueType="enumerated"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.otherflags.1591762140" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.otherflags" useByScannerDiscovery="true" valueType="stringList">
+									<listOptionValue builtIn="false" value="-Wno-volatile"/>
+								</option>
 								<inputType id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.input.cpp.2042651219" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.input.cpp"/>
 							</tool>
 							<tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker.1252531761" name="MCU GCC Linker" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker"/>

--- a/.cproject
+++ b/.cproject
@@ -113,9 +113,7 @@
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/ST-LIB/Inc/ST-LIB_HIGH}&quot;"/>
 								</option>
 								<option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.languagestandard.1092333469" name="Language standard" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.languagestandard" useByScannerDiscovery="true" value="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.languagestandard.value.gnupp20" valueType="enumerated"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.otherflags.1591762140" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.otherflags" useByScannerDiscovery="true" valueType="stringList">
-									<listOptionValue builtIn="false" value="-Wno-volatile"/>
-								</option>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.otherflags.1591762140" name="Other flags" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.otherflags" useByScannerDiscovery="true" valueType="stringList"/>
 								<inputType id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.input.cpp.2042651219" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.input.cpp"/>
 							</tool>
 							<tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker.1252531761" name="MCU GCC Linker" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker"/>

--- a/.cproject
+++ b/.cproject
@@ -113,7 +113,6 @@
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/ST-LIB/Inc/ST-LIB_HIGH}&quot;"/>
 								</option>
 								<option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.languagestandard.1092333469" name="Language standard" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.languagestandard" useByScannerDiscovery="true" value="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.languagestandard.value.gnupp20" valueType="enumerated"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.otherflags.1591762140" name="Other flags" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.otherflags" useByScannerDiscovery="true" valueType="stringList"/>
 								<inputType id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.input.cpp.2042651219" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.input.cpp"/>
 							</tool>
 							<tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker.1252531761" name="MCU GCC Linker" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker"/>

--- a/.cproject
+++ b/.cproject
@@ -356,3 +356,4 @@
 	</storageModule>
 	<storageModule moduleId="refreshScope"/>
 </cproject>
+

--- a/Drivers/CMSIS/Device/ST/STM32H7xx/Include/stm32h7xx.h
+++ b/Drivers/CMSIS/Device/ST/STM32H7xx/Include/stm32h7xx.h
@@ -203,9 +203,9 @@ typedef enum
 /** @addtogroup Exported_macros
   * @{
   */
-#define SET_BIT(REG, BIT)     ((REG) |= (BIT))
+#define SET_BIT(REG, BIT)     ((REG) = (REG|BIT))
 
-#define CLEAR_BIT(REG, BIT)   ((REG) &= ~(BIT))
+#define CLEAR_BIT(REG, BIT)   ((REG) = (REG) & ~(BIT))
 
 #define READ_BIT(REG, BIT)    ((REG) & (BIT))
 

--- a/Drivers/CMSIS/Include/core_cm7.h
+++ b/Drivers/CMSIS/Include/core_cm7.h
@@ -2248,7 +2248,7 @@ __STATIC_FORCEINLINE void SCB_EnableICache (void)
     SCB->ICIALLU = 0UL;                     /* invalidate I-Cache */
     __DSB();
     __ISB();
-    SCB->CCR |=  (uint32_t)SCB_CCR_IC_Msk;  /* enable I-Cache */
+    SCB->CCR = SCB->CCR |  (uint32_t)SCB_CCR_IC_Msk;  /* enable I-Cache */
     __DSB();
     __ISB();
   #endif
@@ -2264,7 +2264,7 @@ __STATIC_FORCEINLINE void SCB_DisableICache (void)
   #if defined (__ICACHE_PRESENT) && (__ICACHE_PRESENT == 1U)
     __DSB();
     __ISB();
-    SCB->CCR &= ~(uint32_t)SCB_CCR_IC_Msk;  /* disable I-Cache */
+    SCB->CCR = SCB->CCR & ~(uint32_t)SCB_CCR_IC_Msk;  /* disable I-Cache */
     SCB->ICIALLU = 0UL;                     /* invalidate I-Cache */
     __DSB();
     __ISB();
@@ -2350,7 +2350,7 @@ __STATIC_FORCEINLINE void SCB_EnableDCache (void)
     } while(sets-- != 0U);
     __DSB();
 
-    SCB->CCR |=  (uint32_t)SCB_CCR_DC_Msk;  /* enable D-Cache */
+    SCB->CCR = SCB->CCR |  (uint32_t)SCB_CCR_DC_Msk;  /* enable D-Cache */
 
     __DSB();
     __ISB();
@@ -2372,7 +2372,7 @@ __STATIC_FORCEINLINE void SCB_DisableDCache (void)
     SCB->CSSELR = 0U;                       /* select Level 1 data cache */
     __DSB();
 
-    SCB->CCR &= ~(uint32_t)SCB_CCR_DC_Msk;  /* disable D-Cache */
+    SCB->CCR = SCB->CCR & ~(uint32_t)SCB_CCR_DC_Msk;  /* disable D-Cache */
     __DSB();
 
     ccsidr = SCB->CCSIDR;

--- a/Drivers/CMSIS/Include/mpu_armv7.h
+++ b/Drivers/CMSIS/Include/mpu_armv7.h
@@ -192,7 +192,7 @@ __STATIC_INLINE void ARM_MPU_Enable(uint32_t MPU_Control)
 {
   MPU->CTRL = MPU_Control | MPU_CTRL_ENABLE_Msk;
 #ifdef SCB_SHCSR_MEMFAULTENA_Msk
-  SCB->SHCSR |= SCB_SHCSR_MEMFAULTENA_Msk;
+  SCB->SHCSR = SCB->SHCSR | SCB_SHCSR_MEMFAULTENA_Msk;
 #endif
   __DSB();
   __ISB();
@@ -204,9 +204,9 @@ __STATIC_INLINE void ARM_MPU_Disable(void)
 {
   __DMB();
 #ifdef SCB_SHCSR_MEMFAULTENA_Msk
-  SCB->SHCSR &= ~SCB_SHCSR_MEMFAULTENA_Msk;
+  SCB->SHCSR = SCB->SHCSR & ~SCB_SHCSR_MEMFAULTENA_Msk;
 #endif
-  MPU->CTRL  &= ~MPU_CTRL_ENABLE_Msk;
+  MPU->CTRL  = MPU->CTRL & ~MPU_CTRL_ENABLE_Msk;
 }
 
 /** Clear and disable the given MPU region.

--- a/Drivers/STM32H7xx_HAL_Driver/Inc/stm32h7xx_ll_adc.h
+++ b/Drivers/STM32H7xx_HAL_Driver/Inc/stm32h7xx_ll_adc.h
@@ -3228,7 +3228,7 @@ __STATIC_INLINE void LL_ADC_SetChannelPreSelection(ADC_TypeDef *ADCx, uint32_t C
     if (ADCx != ADC3)
     {
       /* ADC channels preselection */
-      ADCx->PCSEL_RES0 |= (1UL << (__LL_ADC_CHANNEL_TO_DECIMAL_NB(Channel) & 0x1FUL));
+      ADCx->PCSEL_RES0 = ADCx->PCSEL_RES0 | (1UL << (__LL_ADC_CHANNEL_TO_DECIMAL_NB(Channel) & 0x1FUL));
     }
 #else
     /* ADC channels preselection */

--- a/Inc/HALAL/Models/TimerPeripheral/TimerPeripheral.hpp
+++ b/Inc/HALAL/Models/TimerPeripheral/TimerPeripheral.hpp
@@ -40,4 +40,4 @@ public:
 
 };
 
-#endif HAL_TIM_MODULE_ENABLED
+#endif

--- a/Src/HALAL/Services/InputCapture/InputCapture.cpp
+++ b/Src/HALAL/Services/InputCapture/InputCapture.cpp
@@ -85,6 +85,9 @@ InputCapture::Instance InputCapture::find_instance_by_channel(uint32_t channel) 
 			return id_instance.second;
 		}
 	}
+
+	//TODO: Error handler
+	return Instance();
 }
 
 void HAL_TIM_InputCapture_CaptureCallback(TIM_HandleTypeDef *htim)


### PR DESCRIPTION
# The Dream is Real
![image](https://user-images.githubusercontent.com/59616818/209724968-ba0db6c3-3d99-422c-b035-21d3efbc7ab0.png)

This PR corrects two warnings in the ST-LIB and silences the deprecated |= operator warning, which de-deprecated in C++23.