### PR TITLE
LPTIM INIT function

### DIFF
--- a/.settings/language.settings.xml
+++ b/.settings/language.settings.xml
@@ -5,7 +5,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" console="false" env-hash="1371485357837070907" id="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" keep-relative-paths="false" name="MCU ARM GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" console="false" env-hash="-372582332750405876" id="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" keep-relative-paths="false" name="MCU ARM GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>
@@ -16,7 +16,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" console="false" env-hash="1371485357837070907" id="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" keep-relative-paths="false" name="MCU ARM GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" console="false" env-hash="-372582332750405876" id="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" keep-relative-paths="false" name="MCU ARM GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>

--- a/.settings/language.settings.xml
+++ b/.settings/language.settings.xml
@@ -5,7 +5,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" console="false" env-hash="-351752561309212436" id="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" keep-relative-paths="false" name="MCU ARM GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" console="false" env-hash="1371485357837070907" id="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" keep-relative-paths="false" name="MCU ARM GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>
@@ -16,7 +16,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" console="false" env-hash="-351752561309212436" id="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" keep-relative-paths="false" name="MCU ARM GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" console="false" env-hash="1371485357837070907" id="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" keep-relative-paths="false" name="MCU ARM GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>

--- a/.settings/language.settings.xml
+++ b/.settings/language.settings.xml
@@ -5,7 +5,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" console="false" env-hash="-372582332750405876" id="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" keep-relative-paths="false" name="MCU ARM GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" console="false" env-hash="-351752561309212436" id="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" keep-relative-paths="false" name="MCU ARM GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>
@@ -16,7 +16,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" console="false" env-hash="-372582332750405876" id="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" keep-relative-paths="false" name="MCU ARM GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" console="false" env-hash="-351752561309212436" id="com.st.stm32cube.ide.mcu.toolchain.armnone.setup.CrossBuiltinSpecsDetector" keep-relative-paths="false" name="MCU ARM GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>

--- a/Inc/HALAL/Models/LowPowerTimer/LowPowerTimer.hpp
+++ b/Inc/HALAL/Models/LowPowerTimer/LowPowerTimer.hpp
@@ -6,16 +6,21 @@
  */
 
 #pragma once
-#ifdef HAL_LPTIM_MODULE_ENABLED
 
+//#ifdef HAL_LPTIM_MODULE_ENABLED
 
-struct LowPowerTimer {
+#include "stm32h7xx_hal.h"
+
+class LowPowerTimer {
 public:
-	LPTIM_HandleTypeDef* handle;
+	LPTIM_TypeDef instance;
+	LPTIM_HandleTypeDef handle;
 	uint16_t period;
 
 	LowPowerTimer() = default;
-	LowPowerTimer(LPTIM_HandleTypeDef* handle, uint16_t period) : handle(handle), period(period) {};
+	LowPowerTimer(LPTIM_HandleTypeDef& handle, uint16_t period) : handle(handle), period(period) {};
+
+	void init();
 };
 
-#endif
+//#endif

--- a/Inc/HALAL/Models/LowPowerTimer/LowPowerTimer.hpp
+++ b/Inc/HALAL/Models/LowPowerTimer/LowPowerTimer.hpp
@@ -7,9 +7,9 @@
 
 #pragma once
 
-//#ifdef HAL_LPTIM_MODULE_ENABLED
-
 #include "stm32h7xx_hal.h"
+
+#ifdef HAL_LPTIM_MODULE_ENABLED
 
 class LowPowerTimer {
 public:
@@ -24,4 +24,4 @@ public:
 	void init();
 };
 
-//#endif
+#endif

--- a/Inc/HALAL/Models/LowPowerTimer/LowPowerTimer.hpp
+++ b/Inc/HALAL/Models/LowPowerTimer/LowPowerTimer.hpp
@@ -13,7 +13,7 @@
 
 class LowPowerTimer {
 public:
-	LPTIM_TypeDef instance;
+	LPTIM_TypeDef& instance;
 	LPTIM_HandleTypeDef& handle;
 	uint16_t period;
 

--- a/Inc/HALAL/Models/LowPowerTimer/LowPowerTimer.hpp
+++ b/Inc/HALAL/Models/LowPowerTimer/LowPowerTimer.hpp
@@ -14,11 +14,12 @@
 class LowPowerTimer {
 public:
 	LPTIM_TypeDef instance;
-	LPTIM_HandleTypeDef handle;
+	LPTIM_HandleTypeDef& handle;
 	uint16_t period;
 
 	LowPowerTimer() = default;
-	LowPowerTimer(LPTIM_HandleTypeDef& handle, uint16_t period) : handle(handle), period(period) {};
+	LowPowerTimer(LPTIM_TypeDef& instance, LPTIM_HandleTypeDef& handle, uint16_t period) :
+		instance(instance), handle(handle), period(period) {};
 
 	void init();
 };

--- a/Src/HALAL/Models/LowPowerTimer/LowPowerTimer.cpp
+++ b/Src/HALAL/Models/LowPowerTimer/LowPowerTimer.cpp
@@ -1,0 +1,24 @@
+/*
+ * LowPowerTimer.cpp
+ *
+ *  Created on: 5 ene. 2023
+ *      Author: aleja
+ */
+
+#include "LowPowerTimer/LowPowerTimer.hpp"
+
+void LowPowerTimer::init() {
+	  handle.Instance = &instance;
+	  handle.Init.Clock.Source = LPTIM_CLOCKSOURCE_APBCLOCK_LPOSC;
+	  handle.Init.Clock.Prescaler = LPTIM_PRESCALER_DIV1;
+	  handle.Init.Trigger.Source = LPTIM_TRIGSOURCE_SOFTWARE;
+	  handle.Init.OutputPolarity = LPTIM_OUTPUTPOLARITY_HIGH;
+	  handle.Init.UpdateMode = LPTIM_UPDATE_IMMEDIATE;
+	  handle.Init.CounterSource = LPTIM_COUNTERSOURCE_INTERNAL;
+	  handle.Init.Input1Source = LPTIM_INPUT1SOURCE_GPIO;
+	  handle.Init.Input2Source = LPTIM_INPUT2SOURCE_GPIO;
+
+	  if (HAL_LPTIM_Init(&handle) != HAL_OK) {
+		  //TODO: Error Handler
+	  }
+}

--- a/Src/HALAL/Models/Runes/Runes.cpp
+++ b/Src/HALAL/Models/Runes/Runes.cpp
@@ -180,9 +180,9 @@ uint16_t adc_buf1[ADC_BUF_LEN];
 uint16_t adc_buf2[ADC_BUF_LEN];
 uint16_t adc_buf3[ADC_BUF_LEN];
 
-LowPowerTimer lptim1 = LowPowerTimer(&hlptim1, LPTIM1_PERIOD);
-LowPowerTimer lptim2 = LowPowerTimer(&hlptim2, LPTIM2_PERIOD);
-LowPowerTimer lptim3 = LowPowerTimer(&hlptim3, LPTIM3_PERIOD);
+LowPowerTimer lptim1 = LowPowerTimer(hlptim1, LPTIM1_PERIOD);
+LowPowerTimer lptim2 = LowPowerTimer(hlptim2, LPTIM2_PERIOD);
+LowPowerTimer lptim3 = LowPowerTimer(hlptim3, LPTIM3_PERIOD);
 
 vector<uint32_t> channels1 = {};
 vector<uint32_t> channels2 = {};

--- a/Src/HALAL/Models/Runes/Runes.cpp
+++ b/Src/HALAL/Models/Runes/Runes.cpp
@@ -180,9 +180,9 @@ uint16_t adc_buf1[ADC_BUF_LEN];
 uint16_t adc_buf2[ADC_BUF_LEN];
 uint16_t adc_buf3[ADC_BUF_LEN];
 
-LowPowerTimer lptim1 = LowPowerTimer(hlptim1, LPTIM1_PERIOD);
-LowPowerTimer lptim2 = LowPowerTimer(hlptim2, LPTIM2_PERIOD);
-LowPowerTimer lptim3 = LowPowerTimer(hlptim3, LPTIM3_PERIOD);
+LowPowerTimer lptim1 = LowPowerTimer(*LPTIM1, hlptim1, LPTIM1_PERIOD);
+LowPowerTimer lptim2 = LowPowerTimer(*LPTIM2, hlptim2, LPTIM2_PERIOD);
+LowPowerTimer lptim3 = LowPowerTimer(*LPTIM3, hlptim3, LPTIM3_PERIOD);
 
 vector<uint32_t> channels1 = {};
 vector<uint32_t> channels2 = {};

--- a/Src/HALAL/Services/ADC/ADC.cpp
+++ b/Src/HALAL/Services/ADC/ADC.cpp
@@ -63,7 +63,7 @@ void ADC::turn_on(uint8_t id){
 	}
 
 	LowPowerTimer& timer = peripheral->timer;
-	if (HAL_LPTIM_TimeOut_Start_IT(timer.handle, timer.period, timer.period / 2) != HAL_OK) {
+	if (HAL_LPTIM_TimeOut_Start_IT(&timer.handle, timer.period, timer.period / 2) != HAL_OK) {
 		return; //TODO: Error handler
 	}
 	peripheral->is_on = true;
@@ -131,4 +131,6 @@ void ADC::init(Peripheral& peripheral) {
 	  	  }
 	  	  counter++;
 	  }
+
+	  peripheral.timer.init();
 }


### PR DESCRIPTION
#  ⌛ LPTIM INIT function ⏳ 
This PR introduces the LPTIM init function inside the ADC init function, which overloads the HAL init.

## Before
```cpp
Pin::start();
MX_DMA_Init();
ADC::start();
MX_LPTIM1_Init();
MX_LPTIM2_Init();
MX_LPTIM3_Init();
```


## After
```cpp
Pin::start();
MX_DMA_Init();
ADC::start();
```

## Testing:
It has been tested with the same testcase of the ADC, deleting the HAL inits and checking that it still works correctly