### PR TITLE
explicit std usages

### DIFF
--- a/Inc/C++Utilities/CppUtils.hpp
+++ b/Inc/C++Utilities/CppUtils.hpp
@@ -31,5 +31,22 @@
 #include <forward_list>
 #include <ostream>
 #include <cstring>
+#include <span>
+#include <ranges>
 
-using namespace std;
+namespace chrono = std::chrono;
+
+using std::map;
+using std::optional;
+using std::vector;
+using std::array;
+using std::span;
+using std::pair;
+using std::function;
+using std::string;
+using std::to_string;
+using std::reference_wrapper;
+using std::unordered_map;
+using std::set;
+using std::stack;
+using std::nullopt;

--- a/Inc/C++Utilities/CppUtils.hpp
+++ b/Inc/C++Utilities/CppUtils.hpp
@@ -50,3 +50,7 @@ using std::unordered_map;
 using std::set;
 using std::stack;
 using std::nullopt;
+using std::is_integral;
+using std::is_same;
+using std::remove_reference;
+using std::integral_constant;


### PR DESCRIPTION
# Explicit STD usages :warning: 

## Motivation
Today I had a conflict in my PCB code. I use iota function, but the compiler conflicts between std::iota and std::views::iota. In order to prevent this and future errors, I think the best solution is to explicitly state which functions and types we are using from the STD library.

Having namespace usages in a global file is already a very dangerous practice for a static library and probably the best solution would be to explicitly put the using statements in the corresponding file, as it avoids possible lateral effects and it is more transparent for the reader, as it knows what resources are being used in the class. Still this is a design decision out of the scope of this PR.

For now, we can at least improve the library by not having `using namespace std;` and instead having the explicit statements like this:

### Before:
```cpp
using namespace std;
```

### After:
```cpp
namespace chrono = std::chrono;

using std::map;
using std::optional;
using std::vector;
using std::array;
using std::span;
using std::pair;
using std::function;
using std::string;
using std::to_string;
using std::reference_wrapper;
using std::unordered_map;
using std::set;
using std::stack;
using std::nullopt;
```