### PR TITLE
fixed id_counter instansialization

### DIFF
--- a/Src/HALAL/Services/DigitalInputService/DigitalInputService.cpp
+++ b/Src/HALAL/Services/DigitalInputService/DigitalInputService.cpp
@@ -7,7 +7,7 @@
 
 #include "DigitalInputService/DigitalInputService.hpp"
 
-uint8_t id_counter = 0;
+uint8_t DigitalInput::id_counter = 0;
 map<uint8_t,Pin> DigitalInput::service_ids = {};
 
 uint8_t DigitalInput::inscribe(Pin& pin){


### PR DESCRIPTION
Había un error en la clase DigitalInputService.cpp ya que se accedia a id_counter en inscribe sin inicializarlo. 

Los hpp y cpp son bastante simplones en su forma de funcionar, así que si al dar un valor inicial en el cpp a una variable del hpp **no se le indica explicitamente** que es la del hpp, lo que hace es crear una variable nueva con el mismo nombre en el cpp e inicializar esa _(En lugar de inicializar la del hpp)_.
Luego cuando la usas mas tarde, incluso sin indicarle explicitamente que es del hpp con DigitalInput:: ..., sigue usando la del hpp _(en lugar de la nueva que creo e inicializo)_, pero no esta inicializada. 

Osea se, que si haces:

```
#include "DigitalInputService/DigitalInputService.hpp"
uint8_t id_counter = 0;

uint8_t DigitalInput::inscribe(Pin& pin){
		Pin::inscribe(pin, INPUT);
		DigitalInput::service_ids[id_counter] = pin;
		return id_counter++;
}
```

y hay un id_counter en el hpp que has importado da error porque se trato de acceder a id_counter en el return de inscribe sin haberlo inicializado, porque el cpp crea una nueva variable id_counter con el mismo nombre en lugar de inicializar la que ya tiene en el hpp, y luego cuando la usas para algo prefiere la del hpp. 

Se puede arreglar usando uint8_t **DigitalInput**::id_counter = 0; al darle valor en el cpp o añadiendo **extern** a la declaracion de id_counter en el hpp. Hice lo primero por cohesion con la variable de abajo en el cpp, que ya hacia eso. 