### PR TITLE
Features/sensor start

### DIFF
--- a/Inc/C++Utilities/CppUtils.hpp
+++ b/Inc/C++Utilities/CppUtils.hpp
@@ -34,4 +34,23 @@
 #include <span>
 #include <ranges>
 
-using namespace std;
+namespace chrono = std::chrono;
+
+using std::map;
+using std::optional;
+using std::vector;
+using std::array;
+using std::span;
+using std::pair;
+using std::function;
+using std::string;
+using std::to_string;
+using std::reference_wrapper;
+using std::unordered_map;
+using std::set;
+using std::stack;
+using std::nullopt;
+using std::is_integral;
+using std::is_same;
+using std::remove_reference;
+using std::integral_constant;

--- a/Inc/HALAL/HALAL.hpp
+++ b/Inc/HALAL/HALAL.hpp
@@ -12,3 +12,7 @@
 #include "EXTI/EXTI.hpp"
 #include "Communication/SPI/SPI.hpp"
 #include "Communication/UART/UART.hpp"
+#include "Communication/Ethernet/UDP/DatagramSocket.hpp"
+#include "Communication/Ethernet/TCP/ServerSocket.hpp"
+#include "Communication/Ethernet/TCP/Socket.hpp"
+#include "Communication/Ethernet/Ethernet.hpp"

--- a/Inc/HALAL/HALAL.hpp
+++ b/Inc/HALAL/HALAL.hpp
@@ -12,7 +12,3 @@
 #include "EXTI/EXTI.hpp"
 #include "Communication/SPI/SPI.hpp"
 #include "Communication/UART/UART.hpp"
-#include "Communication/Ethernet/UDP/DatagramSocket.hpp"
-#include "Communication/Ethernet/TCP/ServerSocket.hpp"
-#include "Communication/Ethernet/TCP/Socket.hpp"
-#include "Communication/Ethernet/Ethernet.hpp"

--- a/Inc/HALAL/Services/Communication/SPI/SPI.hpp
+++ b/Inc/HALAL/Services/Communication/SPI/SPI.hpp
@@ -22,9 +22,9 @@
 class SPI{
 private:
     /**
-     * @brief Struct wich defines all data refering to SPI peripherals. It is 
+     * @brief Struct which defines all data refering to SPI peripherals. It is
      *        declared private in order to prevent unwanted use. Only 
-     *        predefined instaces should be used. 
+     *        predefined instances should be used.
      *           
      */
     struct Instance{
@@ -48,7 +48,7 @@ private:
     };
 
     /**
-     * @brief Enum which abstracts the use of the Instance struct to facilitate the mocking of the HALAL.Struct
+     * @brief Enum that abstracts the use of the Instance struct to facilitate the mocking of the HALAL.
      *
      */
     enum Peripheral{
@@ -59,6 +59,9 @@ private:
  		peripheral5 = 4,
  		peripheral6 = 5,
      };
+
+    static void turn_on_chip_select(SPI::Instance* spi);
+    static void turn_off_chip_select(SPI::Instance* spi);
 
 public:
     static uint16_t id_counter;
@@ -78,10 +81,6 @@ public:
     static SPI::Peripheral spi5;
     static SPI::Peripheral spi6;
 
-    /**
-     * @brief SPI 3 instance of the STM32H723.
-     *
-     */
     static SPI::Instance instance1;
 	static SPI::Instance instance2;
 	static SPI::Instance instance3;
@@ -104,27 +103,96 @@ public:
      */
     static void start();
 
-    /**@brief	Transmits 1 SPIPacket of any size by polling.
-     * 			Handles the packet size automatically.
+    /**@brief	Transmits 1 byte by SPI.
      * 
      * @param id Id of the SPI
-     * @param packet Pakcet to be send
-     * @return bool Returns true if the request to send the packet has been done
-     *            successfully. Returns false if a problem
-     *            has occurred.
+     * @param data Data to be send
+     * @return bool Returns true if the data has been send successfully.
+     * 			    Returns false if a problem has occurred.
      */
-    static bool transmit_next_packet(uint8_t id, RawPacket& packet);
+    static bool transmit(uint8_t id, uint8_t data);
+
+    /**@brief	Transmits size bytes by SPI.
+	 *
+	 * @param id Id of the SPI
+	 * @param data Data to be send
+	 * @param size Size in bytes to be send
+	 * @return bool Returns true if the data has been send successfully.
+	 * 			    Returns false if a problem has occurred.
+	 */
+    template<size_t SIZE>
+    static bool transmit(uint8_t id, array<uint8_t, SIZE> data) {
+        if (!SPI::registered_spi.contains(id)) {
+            return false; //TODO: Error handler
+        }
+
+        SPI::Instance* spi = SPI::registered_spi[id];
+
+        turn_off_chip_select(spi);
+        if (HAL_SPI_Transmit(spi->hspi, data.data(), data.size(), 10) != HAL_OK){
+        	turn_on_chip_select(spi);
+        	return false; //TODO: Warning, Error during transmision
+        }
+    	turn_on_chip_select(spi);
+
+        return true;
+    }
 
     /**						
-     * @brief This method request the receive of a new SPIPacket of any size
-     *        by polling.
+     * @brief This method requests an array of data. The data
+     * 		  will be stored in data parameter. You must make sure you have
+     * 		  enough space
      * 
      * @param id Id of the SPI
-     * @param packet SPIPacket in which the data will be stored
-     * @return bool Return true if the order to receive a new packet has been
-     *            processed correctly. Return false if a problem has occurred.
+     * @param data Pointer where data will be stored
+     * @param size Size in bytes to receive.
+     * @return bool Returns true if the data have been read successfully.
+     * 			    Returns false if a problem has occurred.
      */
-    static bool receive_next_packet(uint8_t id, RawPacket& packet);
+    template<size_t SIZE>
+    static bool receive(uint8_t id, array<uint8_t, SIZE> data) {
+        if (!SPI::registered_spi.contains(id))
+            return false; //TODO: Error handler
+
+        SPI::Instance* spi = SPI::registered_spi[id];
+
+    	turn_off_chip_select(spi);
+        if (HAL_SPI_Receive(spi->hspi, data.data(), data.size(), 10) != HAL_OK) {
+        	turn_on_chip_select(spi);
+            return false; //TODO: Warning, Error during receive
+        }
+    	turn_on_chip_select(spi);
+
+        return true;
+    };
+
+    /**
+	 * @brief This method transmits one order of command_size bytes and
+	 * 		  then stores the data received after that order.
+	 *
+	 * @param id Id of the SPI
+	 * @param command_data Command
+	 * @param command_size Command size in bytes to receive
+	 * @param receive_data Pointer where data will be stored
+	 * @param receive_size Number of bytes to read
+	 * @return bool Returns true if the data have been read successfully.
+	 * 			    Returns false if a problem has occurred.
+	 */
+    static bool command_and_receive(uint8_t id, uint8_t* command_data, uint16_t command_size, uint8_t* receive_data, uint16_t receive_size);
+
+    /**
+     * @brief This method sets chip select to high level.
+     *
+     * @param spi Id of the SPI
+     */
+    static void chip_select_on(uint8_t id);
+
+    /**
+	 * @brief This method sets chip select to low level.
+	 *
+	 * @param spi Id of the SPI
+	 */
+    static void chip_select_off(uint8_t id);
 
 
 private:

--- a/Inc/ST-LIB_LOW/Sensors/AnalogSensor/AnalogSensor.hpp
+++ b/Inc/ST-LIB_LOW/Sensors/AnalogSensor/AnalogSensor.hpp
@@ -14,7 +14,6 @@
 class AnalogSensor : public Sensor<double>::Sensor{
 public:
 	virtual void read() = 0;
-	virtual void start() = 0;
 	virtual uint8_t get_id() = 0;
 
 protected:

--- a/Inc/ST-LIB_LOW/Sensors/DigitalSensor/DigitalSensor.hpp
+++ b/Inc/ST-LIB_LOW/Sensors/DigitalSensor/DigitalSensor.hpp
@@ -14,7 +14,7 @@
 class DigitalSensor : public Sensor<PinState>::Sensor{
 public:
 	DigitalSensor(Pin pin, PinState *value);
-	void exti_interruption(std::function<auto> lambda);
+	void exti_interruption(std::function<void()> &&action);
 	void start();
 	void read();
 	uint8_t get_id();
@@ -22,6 +22,7 @@ public:
 protected:
 	Pin pin;
 	uint8_t id;
+	uint8_t exti_id;
 	PinState *value;
 };
 

--- a/Inc/ST-LIB_LOW/Sensors/LinearSensor/LinearSensor.hpp
+++ b/Inc/ST-LIB_LOW/Sensors/LinearSensor/LinearSensor.hpp
@@ -13,7 +13,6 @@
 class LinearSensor : public AnalogSensor::AnalogSensor{
 public:
 	LinearSensor(Pin pin, double slope, double offset, double *value);
-	void start();
 	void read();
 	uint8_t get_id();
 

--- a/Inc/ST-LIB_LOW/Sensors/LookupSensor/LookupSensor.hpp
+++ b/Inc/ST-LIB_LOW/Sensors/LookupSensor/LookupSensor.hpp
@@ -15,7 +15,6 @@
 class LookupSensor : public AnalogSensor::AnalogSensor{
 public:
 	LookupSensor(Pin pin, double *table, int table_size, double *value);
-	void start();
 	void read();
 	uint8_t get_id();
 

--- a/Inc/ST-LIB_LOW/Sensors/Sensor/Sensor.hpp
+++ b/Inc/ST-LIB_LOW/Sensors/Sensor/Sensor.hpp
@@ -21,3 +21,10 @@ protected:
 	uint8_t id;
 	T *value;
 };
+
+class SensorStarter{
+public:
+	static void start();
+	static vector<uint8_t> adc_id_list;
+	static vector<uint8_t> EXTI_id_list;
+};

--- a/Src/HALAL/Services/Communication/SPI/SPI.cpp
+++ b/Src/HALAL/Services/Communication/SPI/SPI.cpp
@@ -39,39 +39,48 @@ void SPI::start(){
 	}
 }
 
-bool SPI::transmit_next_packet(uint8_t id, RawPacket& packet){
-    if (!SPI::registered_spi.contains(id))
-        return false; //TODO: Error handler
-
-    SPI::Instance* spi = SPI::registered_spi[id];
-
-    HAL_GPIO_WritePin(spi->SS->port, spi->SS->gpio_pin, (GPIO_PinState)PinState::OFF);
-    if (HAL_SPI_Transmit(spi->hspi, packet.get_data(), packet.get_size(), 10) != HAL_OK){
-    	HAL_GPIO_WritePin(spi->SS->port, spi->SS->gpio_pin, (GPIO_PinState)PinState::ON);
-        return false; //TODO: Warning, Error during transmision
-    }
-    HAL_GPIO_WritePin(spi->SS->port, spi->SS->gpio_pin, (GPIO_PinState)PinState::ON);
-
-    return true;
+bool SPI::transmit(uint8_t id, uint8_t data){
+	array<uint8_t, 1> data_array = {data};
+	SPI::transmit(id, data_array);
 }
 
-bool SPI::receive_next_packet(uint8_t id, RawPacket& packet){
-    if (!SPI::registered_spi.contains(id))
-        return false; //TODO: Error handler
+bool SPI::command_and_receive(uint8_t id, uint8_t* command_data, uint16_t command_size, uint8_t* receive_data, uint16_t receive_size){
+	 if (!SPI::registered_spi.contains(id))
+	        return false; //TODO: Error handler
 
-    SPI::Instance* spi = SPI::registered_spi[id];
+	SPI::Instance* spi = SPI::registered_spi[id];
 
-    *packet.get_data() = 0;
+	turn_off_chip_select(spi);
+	if (HAL_SPI_Transmit(spi->hspi, command_data, command_size, 10) != HAL_OK){
+    	turn_on_chip_select(spi);
+		return false; //TODO: Warning, Error during transmision
+	}
 
-    HAL_GPIO_WritePin(spi->SS->port, spi->SS->gpio_pin, (GPIO_PinState)PinState::OFF);
-    if (HAL_SPI_Receive(spi->hspi, packet.get_data(), packet.get_size(), 10) != HAL_OK) {
-    	HAL_GPIO_WritePin(spi->SS->port, spi->SS->gpio_pin, (GPIO_PinState)PinState::ON);
-        return false; //TODO: Warning, Error during receive
-    }
-    HAL_GPIO_WritePin(spi->SS->port, spi->SS->gpio_pin, (GPIO_PinState)PinState::ON);
+	if (HAL_SPI_Receive(spi->hspi, receive_data, receive_size, 10) != HAL_OK) {
+    	turn_on_chip_select(spi);
+		return false; //TODO: Warning, Error during receive
+	}
+	turn_on_chip_select(spi);
 
-    return true;
+	return true;
 }
+
+void SPI::chip_select_on(uint8_t id){
+	if (!SPI::registered_spi.contains(id))
+		return; //TODO: Error handler
+
+	SPI::Instance* spi = SPI::registered_spi[id];
+	turn_on_chip_select(spi);
+}
+
+void SPI::chip_select_off(uint8_t id){
+	if (!SPI::registered_spi.contains(id))
+		return; //TODO: Error handler
+
+	SPI::Instance* spi = SPI::registered_spi[id];
+	turn_off_chip_select(spi);
+}
+
 
 void HAL_SPI_ErrorCallback(SPI_HandleTypeDef *hspi){
     //TODO: Fault, SPI error
@@ -119,5 +128,14 @@ void SPI::init(SPI::Instance* spi){
 
 	spi->initialized = true;
 }
-#endif
 
+
+void SPI::turn_on_chip_select(SPI::Instance* spi) {
+	HAL_GPIO_WritePin(spi->SS->port, spi->SS->gpio_pin, (GPIO_PinState)PinState::ON);
+}
+
+void SPI::turn_off_chip_select(SPI::Instance* spi) {
+	HAL_GPIO_WritePin(spi->SS->port, spi->SS->gpio_pin, (GPIO_PinState)PinState::OFF);
+}
+
+#endif

--- a/Src/ST-LIB_LOW/Sensors/DigitalSensor/DigitalSensor.cpp
+++ b/Src/ST-LIB_LOW/Sensors/DigitalSensor/DigitalSensor.cpp
@@ -4,17 +4,14 @@
 
 DigitalSensor::DigitalSensor(Pin pin, PinState *value) : pin(pin), id(DigitalInput::inscribe(pin)), value(value){}
 
-void DigitalSensor::exti_interruption(std::function<auto> action){
-	optional<uint8_t> identification = ExternalInterrupt::inscribe(pin, action);
+void DigitalSensor::exti_interruption(std::function<void()> &&action){
+	optional<uint8_t> identification = ExternalInterrupt::inscribe(pin, std::move(action));
 	if (not identification) {
 		//TODO: add Error handler for register here (register returns empty optional)
 		return;
 	}
-	ExternalInterrupt::turn_on(identification.value());
-}
-
-void DigitalSensor::start(){
-	//TODO: discuss if it needs start for consistency or not (doesnt have a use for it)
+	exti_id = identification.value();
+	SensorStarter::EXTI_id_list.insert(SensorStarter::EXTI_id_list.begin(),exti_id);
 }
 
 void DigitalSensor::read(){

--- a/Src/ST-LIB_LOW/Sensors/LinearSensor/LinearSensor.cpp
+++ b/Src/ST-LIB_LOW/Sensors/LinearSensor/LinearSensor.cpp
@@ -1,4 +1,5 @@
 #include "ST-LIB_LOW/Sensors/LinearSensor/LinearSensor.hpp"
+#include "ST-LIB_LOW/Sensors/Sensor/Sensor.hpp"
 #include "ADC/ADC.hpp"
 
 LinearSensor::LinearSensor(Pin pin, double slope, double offset, double *value)
@@ -9,11 +10,8 @@ LinearSensor::LinearSensor(Pin pin, double slope, double offset, double *value)
 		return;
 	}
 	id = identification.value();
+	SensorStarter::adc_id_list.insert(SensorStarter::adc_id_list.begin(),id);
 
-}
-
-void LinearSensor::start(){
-	ADC::turn_on(id);
 }
 
 void LinearSensor::read(){

--- a/Src/ST-LIB_LOW/Sensors/LookupSensor/LookupSensor.cpp
+++ b/Src/ST-LIB_LOW/Sensors/LookupSensor/LookupSensor.cpp
@@ -1,4 +1,5 @@
 #include "ST-LIB_LOW/Sensors/LookupSensor/LookupSensor.hpp"
+#include "ST-LIB_LOW/Sensors/Sensor/Sensor.hpp"
 #include "ADC/ADC.hpp"
 #include "C++Utilities/CppUtils.hpp"
 #include <iostream>
@@ -11,10 +12,7 @@ LookupSensor::LookupSensor(Pin pin, double *table, int table_size, double *value
 		return;
 	}
 	id = identification.value();
-}
-
-void LookupSensor::start(){
-	ADC::turn_on(id);
+	SensorStarter::adc_id_list.insert(SensorStarter::adc_id_list.begin(),id);
 }
 
 void LookupSensor::read(){

--- a/Src/ST-LIB_LOW/Sensors/Sensor/Sensor.cpp
+++ b/Src/ST-LIB_LOW/Sensors/Sensor/Sensor.cpp
@@ -1,3 +1,17 @@
 #include "ST-LIB_LOW/Sensors/DigitalSensor/DigitalSensor.hpp"
+#include "ST-LIB_LOW/Sensors/LookupSensor/LookupSensor.hpp"
 #include "ST-LIB_LOW/Sensors/Sensor/Sensor.hpp"
+#include "ADC/ADC.hpp"
 
+vector<uint8_t> SensorStarter::adc_id_list{};
+vector<uint8_t> SensorStarter::EXTI_id_list{};
+
+void SensorStarter::start(){
+	for(uint8_t adc_id : adc_id_list){
+		ADC::turn_on(adc_id);
+	}
+	for(uint8_t exti_id : EXTI_id_list){
+		ExternalInterrupt::turn_on(exti_id);
+	}
+
+}


### PR DESCRIPTION
Added a new class with a new method inside Sensor.hpp 

The method start() inside the SensorStarter class does what the name implies, starts every sensor object already constructed. 
Its use is very simple:

Before:

```
LinearSensor mySensor1 = LinearSensor(myPin1, 1, 3, myValue1);
LinearSensor mySensor2 = LinearSensor(myPin2, 1, 3, myValue2);
LinearSensor mySensor3 = LinearSensor(myPin3, 1, 3, myValue3);

....

mySensor1.start();
mySensor2.start();
mySensor3.start();
```

Now:
```
LinearSensor mySensor1 = LinearSensor(myPin1, 1, 3, myValue1);
LinearSensor mySensor2 = LinearSensor(myPin2, 1, 3, myValue2);
LinearSensor mySensor3 = LinearSensor(myPin3, 1, 3, myValue3);

...

SensorStarter::start();
```

It works for EXTI's, Linear and Lookup Sensors. DigitalSensor without EXTI's don t need it and the EncoderSensor needs to get the time since it has started on the start method, after the timers have been started.
So you still need to start every EncoderSensor object, but for any other type of sensor the SensorStarter would cover you up.