### PR TITLE
Features/sensor start

### DIFF
--- a/Inc/ST-LIB_LOW/Sensors/DigitalSensor/DigitalSensor.hpp
+++ b/Inc/ST-LIB_LOW/Sensors/DigitalSensor/DigitalSensor.hpp
@@ -14,7 +14,7 @@
 class DigitalSensor : public Sensor<PinState>::Sensor{
 public:
 	DigitalSensor(Pin pin, PinState *value);
-	void exti_interruption(std::function<auto> lambda);
+	void exti_interruption(std::function<void()> &&action);
 	void start();
 	void read();
 	uint8_t get_id();
@@ -22,6 +22,8 @@ public:
 protected:
 	Pin pin;
 	uint8_t id;
+	uint8_t exti_id;
 	PinState *value;
 };
+
 

--- a/Inc/ST-LIB_LOW/Sensors/LinearSensor/LinearSensor.hpp
+++ b/Inc/ST-LIB_LOW/Sensors/LinearSensor/LinearSensor.hpp
@@ -13,7 +13,6 @@
 class LinearSensor : public AnalogSensor::AnalogSensor{
 public:
 	LinearSensor(Pin pin, double slope, double offset, double *value);
-	void start();
 	void read();
 	uint8_t get_id();
 

--- a/Inc/ST-LIB_LOW/Sensors/LookupSensor/LookupSensor.hpp
+++ b/Inc/ST-LIB_LOW/Sensors/LookupSensor/LookupSensor.hpp
@@ -15,7 +15,6 @@
 class LookupSensor : public AnalogSensor::AnalogSensor{
 public:
 	LookupSensor(Pin pin, double *table, int table_size, double *value);
-	void start();
 	void read();
 	uint8_t get_id();
 

--- a/Inc/ST-LIB_LOW/Sensors/Sensor/Sensor.hpp
+++ b/Inc/ST-LIB_LOW/Sensors/Sensor/Sensor.hpp
@@ -21,3 +21,11 @@ protected:
 	uint8_t id;
 	T *value;
 };
+
+class SensorStarter{
+public:
+	static void start();
+	static vector<uint8_t> adc_id_list;
+	static vector<uint8_t> EXTI_id_list;
+};
+

--- a/Src/ST-LIB_LOW/Sensors/DigitalSensor/DigitalSensor.cpp
+++ b/Src/ST-LIB_LOW/Sensors/DigitalSensor/DigitalSensor.cpp
@@ -4,17 +4,14 @@
 
 DigitalSensor::DigitalSensor(Pin pin, PinState *value) : pin(pin), id(DigitalInput::inscribe(pin)), value(value){}
 
-void DigitalSensor::exti_interruption(std::function<auto> action){
-	optional<uint8_t> identification = ExternalInterrupt::inscribe(pin, action);
+void DigitalSensor::exti_interruption(std::function<void()> &&action){
+	optional<uint8_t> identification = ExternalInterrupt::inscribe(pin, std::move(action));
 	if (not identification) {
 		//TODO: add Error handler for register here (register returns empty optional)
 		return;
 	}
-	ExternalInterrupt::turn_on(identification.value());
-}
-
-void DigitalSensor::start(){
-	//TODO: discuss if it needs start for consistency or not (doesnt have a use for it)
+	exti_id = identification.value();
+	SensorStarter::EXTI_id_list.insert(SensorStarter::EXTI_id_list.begin(),exti_id);
 }
 
 void DigitalSensor::read(){
@@ -24,8 +21,4 @@ void DigitalSensor::read(){
 		return;
 	}
 	*value = val.value();
-}
-
-uint8_t DigitalSensor::get_id(){
-	return id;
 }

--- a/Src/ST-LIB_LOW/Sensors/LinearSensor/LinearSensor.cpp
+++ b/Src/ST-LIB_LOW/Sensors/LinearSensor/LinearSensor.cpp
@@ -1,4 +1,5 @@
 #include "ST-LIB_LOW/Sensors/LinearSensor/LinearSensor.hpp"
+#include "ST-LIB_LOW/Sensors/Sensor/Sensor.hpp"
 #include "ADC/ADC.hpp"
 
 LinearSensor::LinearSensor(Pin pin, double slope, double offset, double *value)
@@ -9,11 +10,8 @@ LinearSensor::LinearSensor(Pin pin, double slope, double offset, double *value)
 		return;
 	}
 	id = identification.value();
+	SensorStarter::adc_id_list.insert(SensorStarter::adc_id_list.begin(),id);
 
-}
-
-void LinearSensor::start(){
-	ADC::turn_on(id);
 }
 
 void LinearSensor::read(){

--- a/Src/ST-LIB_LOW/Sensors/LookupSensor/LookupSensor.cpp
+++ b/Src/ST-LIB_LOW/Sensors/LookupSensor/LookupSensor.cpp
@@ -1,4 +1,5 @@
 #include "ST-LIB_LOW/Sensors/LookupSensor/LookupSensor.hpp"
+#include "ST-LIB_LOW/Sensors/Sensor/Sensor.hpp"
 #include "ADC/ADC.hpp"
 #include "C++Utilities/CppUtils.hpp"
 #include <iostream>
@@ -11,10 +12,7 @@ LookupSensor::LookupSensor(Pin pin, double *table, int table_size, double *value
 		return;
 	}
 	id = identification.value();
-}
-
-void LookupSensor::start(){
-	ADC::turn_on(id);
+	SensorStarter::adc_id_list.insert(SensorStarter::adc_id_list.begin(),id);
 }
 
 void LookupSensor::read(){

--- a/Src/ST-LIB_LOW/Sensors/Sensor/Sensor.cpp
+++ b/Src/ST-LIB_LOW/Sensors/Sensor/Sensor.cpp
@@ -1,3 +1,17 @@
 #include "ST-LIB_LOW/Sensors/DigitalSensor/DigitalSensor.hpp"
+#include "ST-LIB_LOW/Sensors/LookupSensor/LookupSensor.hpp"
 #include "ST-LIB_LOW/Sensors/Sensor/Sensor.hpp"
+#include "ADC/ADC.hpp"
 
+vector<uint8_t> SensorStarter::adc_id_list{};
+vector<uint8_t> SensorStarter::EXTI_id_list{};
+
+void SensorStarter::start(){
+	for(uint8_t adc_id : adc_id_list){
+		ADC::turn_on(adc_id);
+	}
+	for(uint8_t exti_id : EXTI_id_list){
+		ExternalInterrupt::turn_on(exti_id);
+	}
+
+}


### PR DESCRIPTION
Added a new class with a new method inside Sensor.hpp 

The method start() inside the SensorStarter class does what the name implies, starts every sensor object already constructed. 
Its use is very simple:

Before:

```cpp
LinearSensor mySensor1 = LinearSensor(myPin1, 1, 3, myValue1);
LinearSensor mySensor2 = LinearSensor(myPin2, 1, 3, myValue2);
LinearSensor mySensor3 = LinearSensor(myPin3, 1, 3, myValue3);

....

mySensor1.start();
mySensor2.start();
mySensor3.start();
```

Now:
```cpp
LinearSensor mySensor1 = LinearSensor(myPin1, 1, 3, myValue1);
LinearSensor mySensor2 = LinearSensor(myPin2, 1, 3, myValue2);
LinearSensor mySensor3 = LinearSensor(myPin3, 1, 3, myValue3);

...

SensorStarter::start();
```

It works for EXTI's, Linear and Lookup Sensors. DigitalSensor without EXTI's don t need it and the EncoderSensor needs to get the time since it has started on the start method, after the timers have been started.

The point of this is that as SensorStarter::start() is static, it can just be summoned by the HALAL.start() (after the Pin::Start(), EXTI::start() and ADC::start()), which makes it way easier to use

**You still need to start every EncoderSensor object**, but for any other type of sensor the SensorStarter would cover you up.