### PR TITLE
math+cordic bug solving

### DIFF
--- a/Inc/HALAL/HALAL.hpp
+++ b/Inc/HALAL/HALAL.hpp
@@ -16,3 +16,4 @@
 #include "Communication/Ethernet/TCP/ServerSocket.hpp"
 #include "Communication/Ethernet/TCP/Socket.hpp"
 #include "Communication/Ethernet/Ethernet.hpp"
+#include "CORDIC/CORDIC.hpp"

--- a/Inc/HALAL/Services/CORDIC/CORDIC.hpp
+++ b/Inc/HALAL/Services/CORDIC/CORDIC.hpp
@@ -56,6 +56,7 @@ enum Operation_Computation{
 
 class RotationComputer{
 public:
+	static void start();
 	/**
 	 * @brief Cosine function. Receives size angles and output size results
 	 * @param Angle the pointer to the angle array with size "size". input

--- a/Inc/ST-LIB_LOW/Math/Math.hpp
+++ b/Inc/ST-LIB_LOW/Math/Math.hpp
@@ -31,9 +31,5 @@ public:
     static inline int32_t tg_to_unitary(int32_t tg_in);
     static inline int32_t unitary_to_tg(int32_t in);
 private:
-    static int32_t array[4];
-    static int32_t *pointer1;
-    static int32_t *pointer2;
-    static int32_t *pointer3;
-    static int32_t *pointer4;
+    static array<int32_t,4> pointers;
 };

--- a/Inc/ST-LIB_LOW/Math/Math.hpp
+++ b/Inc/ST-LIB_LOW/Math/Math.hpp
@@ -2,7 +2,7 @@
  * CORDIC.hpp
  *
  * Created on: 13 dic. 2022
- * 		Author: Ricardo
+ *         Author: Ricardo
  */
 
 #pragma once
@@ -10,32 +10,30 @@
 #define TG_DECIMAL_BITS 16
 #define SQ_DECIMAL_BITS 16
 #define MAX_INT 2147483647
-#define HALF_INT MAX_INT/2
+#define MIN_COS_MARGIN_TG (MAX_INT >> (TG_DECIMAL_BITS-1))
 #define MAX_MOD_MARGIN 2147483392
 #define MAX_MARGIN 2147483392
-#define HALF_MARGIN MAX_MARGIN/2
-#define SHALF_MARGIN INT_MAX - HALF_MARGIN
 #define Q31_MASK 0x7FFFFFFF
 
 
 class Math{
 public:
-	static int32_t sin(int32_t angle);
-	static int32_t cos(int32_t angle);
-	static int32_t tg(int32_t angle);
-	static int32_t phase(int32_t x, int32_t y);
-	static uint32_t modulus(int32_t x, int32_t y);
-	static int32_t atg(int32_t tg_in);
-	static int32_t sqrt(int32_t sq_in);
+    static int32_t sin(int32_t angle);
+    static int32_t cos(int32_t angle);
+    static int32_t tg(int32_t angle);
+    static int32_t phase(int32_t x, int32_t y);
+    static uint32_t modulus(int32_t x, int32_t y);
+    static int32_t atg(int32_t tg_in);
+    static int32_t sqrt(int32_t sq_in);
 
-	static inline int32_t sq_to_unitary(int32_t sq_in);
-	static inline int32_t unitary_to_sq(int32_t in);
-	static inline int32_t tg_to_unitary(int32_t tg_in);
-	static inline int32_t unitary_to_tg(int32_t in);
+    static inline int32_t sq_to_unitary(int32_t sq_in);
+    static inline int32_t unitary_to_sq(int32_t in);
+    static inline int32_t tg_to_unitary(int32_t tg_in);
+    static inline int32_t unitary_to_tg(int32_t in);
 private:
-	static int32_t array[4];
-	static int32_t *pointer1;
-	static int32_t *pointer2;
-	static int32_t *pointer3;
-	static int32_t *pointer4;
+    static int32_t array[4];
+    static int32_t *pointer1;
+    static int32_t *pointer2;
+    static int32_t *pointer3;
+    static int32_t *pointer4;
 };

--- a/Inc/ST-LIB_LOW/ST-LIB_LOW.hpp
+++ b/Inc/ST-LIB_LOW/ST-LIB_LOW.hpp
@@ -6,3 +6,4 @@
 #include "Actuator/PWM/PWM.hpp"
 #include "Actuator/DigitalOutput/DigitalOutput.hpp"
 #include "Actuator/HalfBridge/HalfBridge.hpp"
+#include "Math/Math.hpp"

--- a/Src/HALAL/Services/CORDIC/CORDIC.cpp
+++ b/Src/HALAL/Services/CORDIC/CORDIC.cpp
@@ -10,7 +10,9 @@
 
 Operation_Computation RotationComputer::mode = NONE;
 
-
+void RotationComputer::start(){
+	__HAL_RCC_CORDIC_CLK_ENABLE();
+}
 
 void RotationComputer::cos(int32_t *angle, int32_t *out, int32_t size){
 	if(RotationComputer::mode != COSINE){

--- a/Src/ST-LIB_LOW/Math/Math.cpp
+++ b/Src/ST-LIB_LOW/Math/Math.cpp
@@ -1,64 +1,60 @@
 #include "ST-LIB_LOW/Math/Math.hpp"
 #include "CORDIC/CORDIC.hpp"
 
-int32_t Math::array[4] = {0,0,0,0};
-int32_t *Math::pointer1 = array;
-int32_t *Math::pointer2 = (int32_t *) array + 1;
-int32_t *Math::pointer3 = (int32_t *) array + 2;
-int32_t *Math::pointer4 = (int32_t *) array + 3;
+array<int32_t, 4> Math::pointers = {0,0,0,0};
 
 int32_t Math::sin(int32_t angle){
-	*pointer1 = angle;
-	RotationComputer::sin(pointer1,pointer2,1);
-	return *pointer2;
+	pointers[0] = angle;
+	RotationComputer::sin(&pointers[0],&pointers[1],1);
+	return pointers[1];
 }
 
 int32_t Math::cos(int32_t angle){
-	*pointer1 = angle;
-	RotationComputer::cos(pointer1,pointer2,1);
-	return *pointer2;
+	pointers[0] = angle;
+	RotationComputer::cos(&pointers[0],&pointers[1],1);
+	return pointers[1];
 }
 
 int32_t Math::tg(int32_t angle){
-    *pointer1 = angle;
-    RotationComputer::cos_and_sin(pointer1,pointer2,pointer3,1);
-    if(*pointer2 < MIN_COS_MARGIN_TG && *pointer2 > -MIN_COS_MARGIN_TG){
-        if((*pointer2 >= 0 && *pointer3 >= 0) || ((*pointer2 < 0 && *pointer3 < 0))){
+	pointers[0] = angle;
+    RotationComputer::cos_and_sin(&pointers[0],&pointers[1],&pointers[2],1);
+    if(pointers[1] < MIN_COS_MARGIN_TG && pointers[1] > -MIN_COS_MARGIN_TG){
+        if((pointers[1] >= 0 && pointers[2] >= 0) || ((pointers[1] < 0 && pointers[2] < 0))){
             return MAX_INT;
         }else{
             return -MAX_INT-1;
         }
     }
-    return *pointer3 / (*pointer2 >> TG_DECIMAL_BITS);
+    return pointers[2] / (pointers[1] >> TG_DECIMAL_BITS);
 }
 
 int32_t Math::phase(int32_t x, int32_t y){
-	*pointer1 = x;
-	*pointer2 = y;
-	RotationComputer::phase(pointer1, pointer2, pointer3, 1);
-	return *pointer3;
+	pointers[0] = x;
+	pointers[1] = y;
+	RotationComputer::phase(&pointers[0], &pointers[1], &pointers[2], 1);
+	return pointers[2];
 }
 
 uint32_t Math::modulus(int32_t x, int32_t y){
 	if(((uint32_t) x -4 + y) > MAX_MOD_MARGIN){
-		*pointer1 = (x >> 1);
-		*pointer2 = (y >> 1);
-		RotationComputer::modulus(pointer1, pointer2, pointer3, 1);
-		uint32_t mod= *pointer3;
+		pointers[0] = (x >> 1);
+		pointers[1] = (y >> 1);
+		RotationComputer::modulus(&pointers[0], &pointers[1], &pointers[2], 1);
+		uint32_t mod= pointers[2];
 		mod = (mod << 1);
 		return mod;
 	}
-	*pointer1 = x;
-	*pointer2 = y;
-	RotationComputer::modulus(pointer1, pointer2, pointer3, 1);
-	return *pointer3;
+	pointers[0] = x;
+	pointers[1] = y;
+	RotationComputer::modulus(&pointers[0], &pointers[1], &pointers[2], 1);
+	return pointers[2];
 }
 
 int32_t Math::atg(int32_t in){
-	*pointer1 = 1 << TG_DECIMAL_BITS;
-	*pointer2 = in;
-	RotationComputer::phase(pointer1, pointer2, pointer3, 1);
-	return *pointer3;
+	pointers[0] = 1 << TG_DECIMAL_BITS;
+	pointers[1] = in;
+	RotationComputer::phase(&pointers[0], &pointers[1], &pointers[2], 1);
+	return pointers[2];
 }
 
 

--- a/Src/ST-LIB_LOW/Math/Math.cpp
+++ b/Src/ST-LIB_LOW/Math/Math.cpp
@@ -1,7 +1,7 @@
 #include "ST-LIB_LOW/Math/Math.hpp"
 #include "CORDIC/CORDIC.hpp"
 
-array<int32_t, 4> Math::pointers = {0,0,0,0};
+array<int32_t, 4> Math::pointers = {0};
 
 int32_t Math::sin(int32_t angle){
 	pointers[0] = angle;
@@ -18,14 +18,13 @@ int32_t Math::cos(int32_t angle){
 int32_t Math::tg(int32_t angle){
 	pointers[0] = angle;
     RotationComputer::cos_and_sin(&pointers[0],&pointers[1],&pointers[2],1);
-    if(pointers[1] < MIN_COS_MARGIN_TG && pointers[1] > -MIN_COS_MARGIN_TG){
-        if((pointers[1] >= 0 && pointers[2] >= 0) || ((pointers[1] < 0 && pointers[2] < 0))){
-            return MAX_INT;
-        }else{
-            return -MAX_INT-1;
-        }
+    if(pointers[1] > MIN_COS_MARGIN_TG || pointers[1] < -MIN_COS_MARGIN_TG){
+    	return pointers[2] / (pointers[1] >> TG_DECIMAL_BITS);
     }
-    return pointers[2] / (pointers[1] >> TG_DECIMAL_BITS);
+    if((pointers[1] >= 0) == (pointers[2]>=0)){
+    	return MAX_INT;
+    }
+    return -MAX_INT-1;
 }
 
 int32_t Math::phase(int32_t x, int32_t y){

--- a/Src/ST-LIB_LOW/Math/Math.cpp
+++ b/Src/ST-LIB_LOW/Math/Math.cpp
@@ -20,20 +20,16 @@ int32_t Math::cos(int32_t angle){
 }
 
 int32_t Math::tg(int32_t angle){
-	if((angle & Q31_MASK) >= HALF_MARGIN){
-		if((angle & Q31_MASK) >= SHALF_MARGIN){
-			angle = angle - MAX_INT;
-		}else{
-			if(angle > 0){
-				return MAX_INT;
-			}else{
-				return -MAX_INT-1;
-			}
-		}
-	}
-	*pointer1 = angle;
-	RotationComputer::cos_and_sin(pointer1,pointer2,pointer3,1);
-	return *pointer3 / (*pointer2 >> TG_DECIMAL_BITS);
+    *pointer1 = angle;
+    RotationComputer::cos_and_sin(pointer1,pointer2,pointer3,1);
+    if(*pointer2 < MIN_COS_MARGIN_TG && *pointer2 > -MIN_COS_MARGIN_TG){
+        if((*pointer2 >= 0 && *pointer3 >= 0) || ((*pointer2 < 0 && *pointer3 < 0))){
+            return MAX_INT;
+        }else{
+            return -MAX_INT-1;
+        }
+    }
+    return *pointer3 / (*pointer2 >> TG_DECIMAL_BITS);
 }
 
 int32_t Math::phase(int32_t x, int32_t y){
@@ -44,7 +40,7 @@ int32_t Math::phase(int32_t x, int32_t y){
 }
 
 uint32_t Math::modulus(int32_t x, int32_t y){
-	if(((uint32_t) x + y) > MAX_MOD_MARGIN){
+	if(((uint32_t) x -4 + y) > MAX_MOD_MARGIN){
 		*pointer1 = (x >> 1);
 		*pointer2 = (y >> 1);
 		RotationComputer::modulus(pointer1, pointer2, pointer3, 1);

--- a/Src/ST-LIB_LOW/Math/Math.cpp
+++ b/Src/ST-LIB_LOW/Math/Math.cpp
@@ -1,5 +1,5 @@
 #include "ST-LIB_LOW/Math/Math.hpp"
-#include "CORDIC/CORDIC.hpp"
+
 
 array<int32_t, 4> Math::pointers = {0};
 


### PR DESCRIPTION
### Bugs solved:

the tangent did a division by 0 on some arbitrary numbers that were out of the safe guard. Now it s tested for every possible bit value and it does not divide by 0 (and the sample results were as precise as expected)

the module on the negative limit didn t go inside of the handler for results higher than one, giving a less-than-one result.

### Bugs known (not solved):

using at max speed multiple different math functions without anything in between may cause the configuration to not be correctly applied and some of the results being aberrant. To be exact seems that cosine, sine, and tangent are affected. Maybe changing the CORDIC code to a single shot structure (math does only single shot anyway) could solve the issue. 