### PR TITLE
Removed stlib include in UART

### DIFF
--- a/Inc/HALAL/Services/Communication/UART/UART.hpp
+++ b/Inc/HALAL/Services/Communication/UART/UART.hpp
@@ -6,8 +6,8 @@
  */
 #pragma once
 
-#include "ST-LIB.hpp"
 #include "C++Utilities/CppUtils.hpp"
+#include "PinModel/Pin.hpp"
 #include "Packets/RawPacket.hpp"
 
 #ifdef HAL_UART_MODULE_ENABLED


### PR DESCRIPTION
Removed the include of the ST-LIB in the UART that caused a circular dependency. This change resolves #149.