### PR TITLE
Fix/handle errors in timer peripheral

### DIFF
--- a/Inc/HALAL/Models/TimerPeripheral/TimerPeripheral.hpp
+++ b/Inc/HALAL/Models/TimerPeripheral/TimerPeripheral.hpp
@@ -28,10 +28,11 @@ public:
 
 	TIM_HandleTypeDef* handle;
 	InitData init_data;
+	string name;
 	static vector<reference_wrapper<TimerPeripheral>> timers;
 
 	TimerPeripheral() = default;
-	TimerPeripheral(TIM_HandleTypeDef* handle, InitData init_data);
+	TimerPeripheral(TIM_HandleTypeDef* handle, InitData init_data, string name);
 
 	static void start();
 

--- a/Src/HALAL/Models/TimerPeripheral/TimerPeripheral.cpp
+++ b/Src/HALAL/Models/TimerPeripheral/TimerPeripheral.cpp
@@ -17,9 +17,10 @@ TimerPeripheral::InitData::InitData(
 		input_capture_channels({}) {}
 
 TimerPeripheral::TimerPeripheral(
-		TIM_HandleTypeDef* handle, InitData init_data) :
+		TIM_HandleTypeDef* handle, InitData init_data, string name) :
 		handle(handle),
-		init_data(init_data) {}
+		init_data(init_data),
+		name(name){}
 
 void TimerPeripheral::init() {
 		TIM_MasterConfigTypeDef sMasterConfig = {0};

--- a/Src/HALAL/Services/InputCapture/InputCapture.cpp
+++ b/Src/HALAL/Services/InputCapture/InputCapture.cpp
@@ -49,8 +49,14 @@ void InputCapture::turn_on(uint8_t id){
 		return;
 	}
 	Instance instance = active_instances[id];
-	HAL_TIM_IC_Start_IT(instance.peripheral->handle, instance.channel_rising);
-	HAL_TIM_IC_Start(instance.peripheral->handle, instance.channel_falling);
+	if (HAL_TIM_IC_Start_IT(instance.peripheral->handle, instance.channel_rising) != HAL_OK) {
+		ErrorHandler("Unable to start the %s Input Capture measurement in interrupt mode", instance.peripheral->name.c_str());
+	}
+
+	if (HAL_TIM_IC_Start(instance.peripheral->handle, instance.channel_falling) != HAL_OK) {
+		ErrorHandler("Unable to start the %s Input Capture measurement", instance.peripheral->name.c_str());
+	}
+
 }
 
 void InputCapture::turn_off(uint8_t id){
@@ -59,8 +65,14 @@ void InputCapture::turn_off(uint8_t id){
 		return;
 	}
 	Instance instance = active_instances[id];
-	HAL_TIM_IC_Stop_IT(instance.peripheral->handle, instance.channel_rising);
-	HAL_TIM_IC_Stop(instance.peripheral->handle, instance.channel_falling);
+	if (HAL_TIM_IC_Stop_IT(instance.peripheral->handle, instance.channel_rising) != HAL_OK) {
+		ErrorHandler("Unable to stop the %s Input Capture measurement in interrupt mode", instance.peripheral->name.c_str());
+	}
+
+	if (HAL_TIM_IC_Stop(instance.peripheral->handle, instance.channel_falling) != HAL_OK) {
+		ErrorHandler("Unable to stop the %s Input Capture measurement", instance.peripheral->name.c_str());
+	}
+
 }
 
 optional<uint32_t> InputCapture::read_frequency(uint8_t id) {


### PR DESCRIPTION
Se ha arreglado el manejo de los errores y se ha añadido un atributo `name` a los `timerperipheral` para poder obtener su nombre en runtime. Closes #178 .