### PR TITLE
Fix/input capture start fix

### DIFF
--- a/Inc/HALAL/Models/TimerPeripheral/TimerPeripheral.hpp
+++ b/Inc/HALAL/Models/TimerPeripheral/TimerPeripheral.hpp
@@ -11,6 +11,7 @@
 #ifdef HAL_TIM_MODULE_ENABLED
 
 #include "C++Utilities/CppUtils.hpp"
+#include "ErrorHandler/ErrorHandler.hpp"
 
 class TimerPeripheral {
 public:
@@ -19,8 +20,8 @@ public:
 		uint32_t prescaler;
 		uint32_t period;
 		uint32_t deadtime;
-		vector<uint32_t> pwm_channels;
-		vector<pair<uint32_t, uint32_t>> input_capture_channels;
+		vector<uint32_t> pwm_channels = {};
+		vector<pair<uint32_t, uint32_t>> input_capture_channels = {};
 		InitData() = default;
 		InitData(TIM_TypeDef* timer, uint32_t prescaler = 275,
 				uint32_t period = 1000, uint32_t deadtime = 0);

--- a/Inc/HALAL/Services/InputCapture/InputCapture.hpp
+++ b/Inc/HALAL/Services/InputCapture/InputCapture.hpp
@@ -24,7 +24,7 @@ public:
 		uint8_t duty_cycle;
 
 		Instance() = default;
-		Instance(Pin pin, TimerPeripheral* peripheral, uint32_t channel_rising, uint32_t channel_falling);
+		Instance(Pin& pin, TimerPeripheral* peripheral, uint32_t channel_rising, uint32_t channel_falling);
 	};
 
 	static map<uint8_t, InputCapture::Instance> active_instances;

--- a/Src/HALAL/Models/TimerPeripheral/TimerPeripheral.cpp
+++ b/Src/HALAL/Models/TimerPeripheral/TimerPeripheral.cpp
@@ -46,6 +46,16 @@ void TimerPeripheral::init() {
 //		}
 
 		if (!init_data.input_capture_channels.empty()) {
+			if (HAL_TIM_Base_Init(handle) != HAL_OK)
+			{
+				ErrorHandler("Unable to init base clock on %d", name.c_str());
+			}
+			sClockSourceConfig.ClockSource = TIM_CLOCKSOURCE_INTERNAL;
+			if (HAL_TIM_ConfigClockSource(handle, &sClockSourceConfig) != HAL_OK)
+			{
+				ErrorHandler("Unable to config clock source on %d", name.c_str());
+			}
+
 			if (HAL_TIM_IC_Init(handle) != HAL_OK)
 			{
 				ErrorHandler("Unable to init input capture on %d", name.c_str());

--- a/Src/HALAL/Models/TimerPeripheral/TimerPeripheral.cpp
+++ b/Src/HALAL/Models/TimerPeripheral/TimerPeripheral.cpp
@@ -35,15 +35,6 @@ void TimerPeripheral::init() {
 		handle->Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
 		handle->Init.RepetitionCounter = 0;
 		handle->Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
-//		if (HAL_TIM_Base_Init(handle) != HAL_OK)
-//		{
-//			ErrorHandler("Unable to init base clock on %d", name.c_str());
-//		}
-//		sClockSourceConfig.ClockSource = TIM_CLOCKSOURCE_INTERNAL;
-//		if (HAL_TIM_ConfigClockSource(handle, &sClockSourceConfig) != HAL_OK)
-//		{
-//			ErrorHandler("Unable to config clock source on %d", name.c_str());
-//		}
 
 		if (!init_data.input_capture_channels.empty()) {
 			if (HAL_TIM_Base_Init(handle) != HAL_OK)

--- a/Src/HALAL/Models/TimerPeripheral/TimerPeripheral.cpp
+++ b/Src/HALAL/Models/TimerPeripheral/TimerPeripheral.cpp
@@ -22,6 +22,7 @@ TimerPeripheral::TimerPeripheral(
 		name(name){}
 
 void TimerPeripheral::init() {
+		TIM_ClockConfigTypeDef sClockSourceConfig = {0};
 		TIM_MasterConfigTypeDef sMasterConfig = {0};
 		TIM_IC_InitTypeDef sConfigIC = {0};
 		TIM_OC_InitTypeDef sConfigOC = {0};
@@ -34,6 +35,16 @@ void TimerPeripheral::init() {
 		handle->Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
 		handle->Init.RepetitionCounter = 0;
 		handle->Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
+//		if (HAL_TIM_Base_Init(handle) != HAL_OK)
+//		{
+//			ErrorHandler("Unable to init base clock on %d", name.c_str());
+//		}
+//		sClockSourceConfig.ClockSource = TIM_CLOCKSOURCE_INTERNAL;
+//		if (HAL_TIM_ConfigClockSource(handle, &sClockSourceConfig) != HAL_OK)
+//		{
+//			ErrorHandler("Unable to config clock source on %d", name.c_str());
+//		}
+
 		if (!init_data.input_capture_channels.empty()) {
 			if (HAL_TIM_IC_Init(handle) != HAL_OK)
 			{

--- a/Src/HALAL/Models/TimerPeripheral/TimerPeripheral.cpp
+++ b/Src/HALAL/Models/TimerPeripheral/TimerPeripheral.cpp
@@ -60,6 +60,7 @@ void TimerPeripheral::init() {
 				ErrorHandler("Unable to configure a IC channel on %d", name.c_str());
 			}
 
+			sConfigIC.ICPolarity = TIM_INPUTCHANNELPOLARITY_FALLING;
 			sConfigIC.ICSelection = TIM_ICSELECTION_INDIRECTTI;
 			if (HAL_TIM_IC_ConfigChannel(handle, &sConfigIC, channels_rising_falling.second) != HAL_OK) {
 				ErrorHandler("Unable to configure a IC channel on %d", name.c_str());

--- a/Src/HALAL/Models/TimerPeripheral/TimerPeripheral.cpp
+++ b/Src/HALAL/Models/TimerPeripheral/TimerPeripheral.cpp
@@ -12,9 +12,8 @@ TimerPeripheral::InitData::InitData(
 		timer(timer),
 		prescaler(prescaler),
 		period(period),
-		deadtime(deadtime),
-		pwm_channels({}),
-		input_capture_channels({}) {}
+		deadtime(deadtime)
+		{}
 
 TimerPeripheral::TimerPeripheral(
 		TIM_HandleTypeDef* handle, InitData init_data, string name) :
@@ -35,15 +34,38 @@ void TimerPeripheral::init() {
 		handle->Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
 		handle->Init.RepetitionCounter = 0;
 		handle->Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
+		if (!init_data.input_capture_channels.empty()) {
+			if (HAL_TIM_IC_Init(handle) != HAL_OK)
+			{
+				ErrorHandler("Unable to init input capture on %d", name.c_str());
+			}
+		}
+
 		if (HAL_TIM_PWM_Init(handle) != HAL_OK) {
-			//TODO: error handler
+			ErrorHandler("Unable to init PWM on %d", name.c_str());
 		}
 		sMasterConfig.MasterOutputTrigger = TIM_TRGO_RESET;
 		sMasterConfig.MasterOutputTrigger2 = TIM_TRGO2_RESET;
 		sMasterConfig.MasterSlaveMode = TIM_MASTERSLAVEMODE_DISABLE;
 		if (HAL_TIMEx_MasterConfigSynchronization(handle, &sMasterConfig) != HAL_OK) {
-			//TODO: error handler
+			ErrorHandler("Unable to configure master synchronization on %d", name.c_str());
 		}
+
+		sConfigIC.ICPolarity = TIM_INPUTCHANNELPOLARITY_RISING;
+		sConfigIC.ICPrescaler = TIM_ICPSC_DIV1;
+		sConfigIC.ICFilter = 0;
+		for (pair<uint32_t, uint32_t> channels_rising_falling : init_data.input_capture_channels) {
+			sConfigIC.ICSelection = TIM_ICSELECTION_DIRECTTI;
+			if (HAL_TIM_IC_ConfigChannel(handle, &sConfigIC, channels_rising_falling.first) != HAL_OK) {
+				ErrorHandler("Unable to configure a IC channel on %d", name.c_str());
+			}
+
+			sConfigIC.ICSelection = TIM_ICSELECTION_INDIRECTTI;
+			if (HAL_TIM_IC_ConfigChannel(handle, &sConfigIC, channels_rising_falling.second) != HAL_OK) {
+				ErrorHandler("Unable to configure a IC channel on %d", name.c_str());
+			}
+		}
+
 		sConfigOC.OCMode = TIM_OCMODE_PWM1;
 		sConfigOC.Pulse = 0;
 		sConfigOC.OCPolarity = TIM_OCPOLARITY_HIGH;
@@ -54,7 +76,7 @@ void TimerPeripheral::init() {
 
 		for (uint32_t channel : init_data.pwm_channels) {
 			if (HAL_TIM_PWM_ConfigChannel(handle, &sConfigOC, channel) != HAL_OK) {
-				//TODO: Error handler
+				ErrorHandler("Unable to configure a PWM channel on %d", name.c_str());
 			}
 		}
 
@@ -70,23 +92,10 @@ void TimerPeripheral::init() {
 		sBreakDeadTimeConfig.Break2Filter = 0;
 		sBreakDeadTimeConfig.AutomaticOutput = TIM_AUTOMATICOUTPUT_DISABLE;
 		if (HAL_TIMEx_ConfigBreakDeadTime(handle, &sBreakDeadTimeConfig) != HAL_OK) {
-			//TODO: Error Handler
+			ErrorHandler("Unable to configure break dead time on %d", name.c_str());
 		}
 
-		sConfigIC.ICPolarity = TIM_INPUTCHANNELPOLARITY_RISING;
-		sConfigIC.ICPrescaler = TIM_ICPSC_DIV1;
-		sConfigIC.ICFilter = 0;
-		for (pair<uint32_t, uint32_t> channels_rising_falling : init_data.input_capture_channels) {
-			sConfigIC.ICSelection = TIM_ICSELECTION_DIRECTTI;
-			if (HAL_TIM_IC_ConfigChannel(handle, &sConfigIC, channels_rising_falling.first) != HAL_OK) {
-				//TODO: Error handler
-			}
 
-			sConfigIC.ICSelection = TIM_ICSELECTION_INDIRECTTI;
-			if (HAL_TIM_IC_ConfigChannel(handle, &sConfigIC, channels_rising_falling.second) != HAL_OK) {
-				//TODO: Error handler
-			}
-		}
 }
 
 void TimerPeripheral::start() {

--- a/Src/HALAL/Services/InputCapture/InputCapture.cpp
+++ b/Src/HALAL/Services/InputCapture/InputCapture.cpp
@@ -125,6 +125,7 @@ void HAL_TIM_IC_CaptureCallback(TIM_HandleTypeDef *htim)
 		InputCapture::active_instances[instance.id].frequency = round(ref_clock / rising_value);
 		InputCapture::active_instances[instance.id].duty_cycle = round((falling_value * 100) / rising_value);
 	}
+
 }
 
 

--- a/Src/HALAL/Services/InputCapture/InputCapture.cpp
+++ b/Src/HALAL/Services/InputCapture/InputCapture.cpp
@@ -18,12 +18,16 @@ static map<uint32_t, uint32_t> channel_dict = {
 	{HAL_TIM_ACTIVE_CHANNEL_6, TIM_CHANNEL_6}
 };
 
-InputCapture::Instance::Instance(Pin pin, TimerPeripheral* peripheral, uint32_t channel_rising, uint32_t channel_falling) :
+InputCapture::Instance::Instance(Pin& pin, TimerPeripheral* peripheral, uint32_t channel_rising, uint32_t channel_falling) :
 	pin(pin),
 	peripheral(peripheral),
 	channel_rising(channel_rising),
 	channel_falling(channel_falling)
-	{ }
+	{
+		frequency = 0;
+		duty_cycle = 0;
+
+	}
 
 optional<uint8_t> InputCapture::inscribe(Pin& pin){
  	if (not available_instances.contains(pin)) {
@@ -49,6 +53,7 @@ void InputCapture::turn_on(uint8_t id){
 		return;
 	}
 	Instance instance = active_instances[id];
+
 	if (HAL_TIM_IC_Start_IT(instance.peripheral->handle, instance.channel_rising) != HAL_OK) {
 		ErrorHandler("Unable to start the %s Input Capture measurement in interrupt mode", instance.peripheral->name.c_str());
 	}
@@ -107,7 +112,7 @@ InputCapture::Instance InputCapture::find_instance_by_channel(uint32_t channel) 
 	return Instance();
 }
 
-void HAL_TIM_InputCapture_CaptureCallback(TIM_HandleTypeDef *htim)
+void HAL_TIM_IC_CaptureCallback(TIM_HandleTypeDef *htim)
 {
 	uint32_t& active_channel = channel_dict[htim->Channel];
 	InputCapture::Instance instance = InputCapture::find_instance_by_channel(active_channel);

--- a/Src/HALAL/Services/InputCapture/InputCapture.cpp
+++ b/Src/HALAL/Services/InputCapture/InputCapture.cpp
@@ -114,6 +114,7 @@ InputCapture::Instance InputCapture::find_instance_by_channel(uint32_t channel) 
 
 void HAL_TIM_IC_CaptureCallback(TIM_HandleTypeDef *htim)
 {
+	htim->Instance->CNT = 0;
 	uint32_t& active_channel = channel_dict[htim->Channel];
 	InputCapture::Instance instance = InputCapture::find_instance_by_channel(active_channel);
 


### PR DESCRIPTION
Se ha arreglado el start y el runes en el template project para que funcione el input capture y la interrucpión.

# Problemas pendientes

No se calcula correctamente el valor de la frecuencia y el duty cycle.