### PR TITLE
Now only one parameter is necesary to call ErrorHandler

### DIFF
--- a/Inc/C++Utilities/CppUtils.hpp
+++ b/Inc/C++Utilities/CppUtils.hpp
@@ -33,6 +33,8 @@
 #include <cstring>
 #include <span>
 #include <ranges>
+#include <cstdarg>
+#include <stdarg.h>
 
 namespace chrono = std::chrono;
 

--- a/Inc/ST-LIB_LOW/ErrorHandler/ErrorHandler.hpp
+++ b/Inc/ST-LIB_LOW/ErrorHandler/ErrorHandler.hpp
@@ -29,8 +29,7 @@ public:
 	 * @param args   Arguments specifying data to print
 	 * @return uint8_t Id of the service.
 	 */
-	template<class... Args>
-	static void ErrorHandler( string format, Args... args);
+	static void ErrorHandlerTrigger(string format, ...);
 
 	 /**
 	 * @brief Get all metadata needed for the error message, including the line function and file.
@@ -51,31 +50,6 @@ public:
 
 };
 
-template<class... Args>
-void ErrorHandlerModel::ErrorHandler( string format, Args... args){
-	if (ErrorHandlerModel::error_triggered) {
-		return;
-	}
-
-	ErrorHandlerModel::error_triggered = 1.0;
-
-	if (format.length() != 0) {
-		description = "";
-	}
-
-	const int32_t size = snprintf(nullptr, 0, format.c_str(), args...) + 1;
-	const unique_ptr<char[]> buffer = make_unique<char[]>(size);
-
-	snprintf(buffer.get(), size, format.c_str(), args...);
-
-	description += string(buffer.get(), buffer.get() + size - 1) + " | Line: " + ErrorHandlerModel::line
-							+ " Function: \"" + ErrorHandlerModel::func + "\" File: " + ErrorHandlerModel::file ;
-
-#ifdef HAL_TIM_MODULE_ENABLED
-	 description += " | TimeStamp: " + to_string(Time::get_global_tick());
-#endif
-}
-
-#define ErrorHandler(x, args...) do { ErrorHandlerModel::SetMetaData(__LINE__, __FUNCTION__, __FILE__); \
-					                  ErrorHandlerModel::ErrorHandler(x, args);}while(0)
+#define ErrorHandler(x, ...) do { ErrorHandlerModel::SetMetaData(__LINE__, __FUNCTION__, __FILE__); \
+					           	   ErrorHandlerModel::ErrorHandlerTrigger(x, ##__VA_ARGS__);}while(0)
 

--- a/Src/ST-LIB_LOW/ErrorHandler/ErrorHandler.cpp
+++ b/Src/ST-LIB_LOW/ErrorHandler/ErrorHandler.cpp
@@ -19,6 +19,38 @@ void ErrorHandlerModel::SetMetaData(int line, const char * func, const char * fi
 		ErrorHandlerModel::file = string(file);
 }
 
+void ErrorHandlerModel::ErrorHandlerTrigger(string format, ... ){
+	if (ErrorHandlerModel::error_triggered) {
+		return;
+	}
+
+	ErrorHandlerModel::error_triggered = 1.0;
+
+	if (format.length() != 0) {
+		description = "";
+	}
+
+	va_list arguments;
+	va_start(arguments, format);
+	va_list arg_copy;
+	va_copy(arg_copy, arguments);
+
+	const int32_t size = vsnprintf(nullptr, 0, format.c_str(), arguments) + 1;
+	const unique_ptr<char[]> buffer = make_unique<char[]>(size);
+	va_end(arguments);
+
+	vsnprintf(buffer.get(), size, format.c_str(), arg_copy);
+	va_end(arg_copy);
+
+	description += string(buffer.get(), buffer.get() + size - 1) + " | Line: " + ErrorHandlerModel::line
+							+ " Function: \"" + ErrorHandlerModel::func + "\" File: " + ErrorHandlerModel::file ;
+
+#ifdef HAL_TIM_MODULE_ENABLED
+	 description += " | TimeStamp: " + to_string(Time::get_global_tick());
+#endif
+
+}
+
 void ErrorHandlerModel::ErrorHandlerUpdate(){
 	if (!ErrorHandlerModel::error_triggered) {
 		return;


### PR DESCRIPTION
# Solution:
First we need to use `...` because `args...` needs atleast 1 parameter. Next we ned to use `##__VA_ARGS__` to pass the arguments list. The `##` is needed because in case the arguments list is empty will swallow the preceding comma.
```cpp
#define ErrorHandler(x, ...) do { ErrorHandlerModel::SetMetaData(__LINE__, __FUNCTION__, __FILE__); \
			          ErrorHandlerModel::ErrorHandlerTrigger(x, ##__VA_ARGS__);}while(0)

```
Now we need to change the method `ErrorHandlerModel::ErrorHandler(string format, Args.. args)` to `ErrorHandlerModel::ErrorHandlerTrigger(string format, ...)` to avoid redefinition due to de macro function and to accept an empty argument list.
```cpp
static void ErrorHandlerTrigger(string format, ...);
```

Inside the method we need to handle the variable list using `va_lists` and we need to change normal `snprintf` to `vsnprintf` because it use `va_list` as argument. We need to have in mind that we need to copy the `va_list arguments` if we want to use it twice. Simplified function: 
```cpp
void error(string format, ...){
    va_list arguments;
    va_start(arguments, format);
    va_list arg_copy;
    va_copy(arg_copy, arguments);

    const int32_t size = snprintf(nullptr, 0, format.c_str(), arguments) + 1;
    const unique_ptr<char[]> buffer = make_unique<char[]>(size);
    va_end(arguments);

    snprintf(buffer.get(), size, format.c_str(), arg_copy);
    va_end(arg_copy);

    description += string(buffer.get(), buffer.get() + size - 1);
}
```