### PR TITLE
Fix/time

### DIFF
--- a/Src/HALAL/Services/Time/Time.cpp
+++ b/Src/HALAL/Services/Time/Time.cpp
@@ -140,9 +140,10 @@ bool Time::unregister_low_precision_alarm(uint16_t id){
 }
 
 void Time::set_timeout(int milliseconds, function<void()> callback){
-	Time::register_low_precision_alarm(milliseconds, [&,low_precision_ids](){
+	uint8_t id = low_precision_ids;
+	Time::register_low_precision_alarm(milliseconds, [&,id](){
 		callback();
-		Time::unregister_low_precision_alarm(low_precision_ids-1);
+		Time::unregister_low_precision_alarm(id);
 	});
 }
 


### PR DESCRIPTION
Seems that lambda expressions do not accept static values and these can break them sometimes (they don t throw an error but do warn you, and sometimes in run time they mess up when they use static values)

saved the static variable inside a variable on the function and it works. The test is in examples