### PR TITLE
change constant name to be less ambigous

### DIFF
--- a/Inc/HALAL/Services/ADC/ADC.hpp
+++ b/Inc/HALAL/Services/ADC/ADC.hpp
@@ -21,7 +21,7 @@ using std::string;
 #define LPTIM2_PERIOD 3000
 #define LPTIM3_PERIOD 3000
 
-#define MAX_VOLTAGE 3.3
+#define ADC_MAX_VOLTAGE 3.3
 #define MAX_12BIT 4095.0
 #define MAX_16BIT 65535.0
 

--- a/Src/HALAL/Services/ADC/ADC.cpp
+++ b/Src/HALAL/Services/ADC/ADC.cpp
@@ -83,10 +83,10 @@ optional<float> ADC::get_value(uint8_t id) {
 	Instance& instance = active_instances[id];
 	uint16_t raw = instance.peripheral->dma_stream[instance.rank];
 	if(instance.peripheral->handle == &hadc3) {
-		return raw / MAX_12BIT * MAX_VOLTAGE;
+		return raw / MAX_12BIT * ADC_MAX_VOLTAGE;
 	}
 	else {
-		return raw / MAX_16BIT * MAX_VOLTAGE;
+		return raw / MAX_16BIT * ADC_MAX_VOLTAGE;
 	}
 
 	return nullopt;

--- a/Src/ST-LIB_HIGH/Protections/Protection.cpp
+++ b/Src/ST-LIB_HIGH/Protections/Protection.cpp
@@ -1,4 +1,5 @@
 #include "Protections/Protection.hpp"
+#include "ErrorHandler/ErrorHandler.hpp"
 
 Protection::Protection(double* src): src(src) {}
 


### PR DESCRIPTION
This PR changes ADC name so it doesn't conflict with external libraries like the BMS code