### PR TITLE
Fixed Ethernet start and inscribe methods

### DIFF
--- a/Src/HALAL/HALAL.cpp
+++ b/Src/HALAL/HALAL.cpp
@@ -10,7 +10,7 @@
 void HALAL::start(TARGET target, string ip, string subnet_mask, string gateway, UART::Peripheral& printf_peripheral) {
 
 #ifdef HAL_ETH_MODULE_ENABLED
-	//Ethernet::inscribe();
+	Ethernet::inscribe();
 #endif
 
 	HAL_Init();
@@ -55,7 +55,7 @@ void HALAL::start(TARGET target, string ip, string subnet_mask, string gateway, 
 #endif
 
 #ifdef HAL_ETH_MODULE_ENABLED
-	//Ethernet::start(ip, subnet_mask, gateway);
+	Ethernet::start(ip, subnet_mask, gateway);
 #endif
 
 #ifdef HAL_TIM_MODULE_ENABLED

--- a/Src/HALAL/Services/Communication/Ethernet/Ethernet.cpp
+++ b/Src/HALAL/Services/Communication/Ethernet/Ethernet.cpp
@@ -87,6 +87,7 @@ void Ethernet::inscribe(){
 		ErrorHandler("Unable to inscribe Ethernet because is already ready!");
 	}
 
+
 }
 
 void Ethernet::update(){
@@ -106,9 +107,7 @@ void Ethernet::update(){
 			netif_set_up(&gnetif);
 		}
 	}
-	else {
-		ErrorHandler("Unable to update Ethernet because is not running!");
-	}
+
 }
 
 #endif

--- a/Src/HALAL/Services/Communication/Ethernet/Ethernet.cpp
+++ b/Src/HALAL/Services/Communication/Ethernet/Ethernet.cpp
@@ -66,11 +66,6 @@ void Ethernet::start(IPV4 local_ip, IPV4 subnet_mask, IPV4 gateway){
 		return;
 	}
 
-	ipaddr = local_ip.address;
-	netmask = subnet_mask.address;
-	gw = gateway.address;
-	MX_LWIP_Init();
-	is_running = true;
 }
 
 void Ethernet::inscribe(){
@@ -92,19 +87,6 @@ void Ethernet::inscribe(){
 		ErrorHandler("Unable to inscribe Ethernet because is already ready!");
 	}
 
-	Pin::inscribe(PA1, ALTERNATIVE);
-	Pin::inscribe(PA2, ALTERNATIVE);
-	Pin::inscribe(PA7, ALTERNATIVE);
-	Pin::inscribe(PB13, ALTERNATIVE);
-	Pin::inscribe(PC1, ALTERNATIVE);
-	Pin::inscribe(PC4, ALTERNATIVE);
-	Pin::inscribe(PC5, ALTERNATIVE);
-	Pin::inscribe(PG11, ALTERNATIVE);
-	Pin::inscribe(PG13, ALTERNATIVE);
-	mpu_start();
-	SCB_EnableICache();
-	SCB_EnableDCache();
-	is_ready = true;
 }
 
 void Ethernet::update(){
@@ -124,7 +106,6 @@ void Ethernet::update(){
 			netif_set_up(&gnetif);
 		}
 	}
-
 	else {
 		ErrorHandler("Unable to update Ethernet because is not running!");
 	}

--- a/Src/ST-LIB.cpp
+++ b/Src/ST-LIB.cpp
@@ -16,6 +16,5 @@ void STLIB::start(TARGET target, string ip, string subnet_mask, string gateway, 
 
 void STLIB::update() {
     Ethernet::update();
-    MX_LWIP_Process();
 	ErrorHandlerModel::ErrorHandlerUpdate();
 }

--- a/Src/ST-LIB.cpp
+++ b/Src/ST-LIB.cpp
@@ -15,6 +15,7 @@ void STLIB::start(TARGET target, string ip, string subnet_mask, string gateway, 
 }
 
 void STLIB::update() {
-	Ethernet::update();
+    Ethernet::update();
+    MX_LWIP_Process();
 	ErrorHandlerModel::ErrorHandlerUpdate();
 }


### PR DESCRIPTION
Se ha arreglado lo que provocaba que el `Ethernet::start()` no funcionase.

# Problemas:

El metodo `Ethernet::update()` sigue sin funcionar.