### PR TITLE
Features/sntp

### DIFF
--- a/Inc/HALAL/HALAL.hpp
+++ b/Inc/HALAL/HALAL.hpp
@@ -19,6 +19,7 @@
 #include "Communication/Ethernet/TCP/Socket.hpp"
 #include "Communication/Ethernet/Ethernet.hpp"
 #include "Communication/FDCAN/FDCAN.hpp"
+#include "Communication/SNTP/SNTP.hpp"
 #include "CORDIC/CORDIC.hpp"
 
 namespace HALAL {

--- a/Inc/HALAL/Services/Communication/SNTP/SNTP.hpp
+++ b/Inc/HALAL/Services/Communication/SNTP/SNTP.hpp
@@ -5,10 +5,6 @@
  *      Author: Ricardo
  */
 
-//https://community.st.com/s/question/0D53W00000j5I4aSAE/how-set-up-pretty-presice-and-detailed-rtc-on-stm32h743zi2
-
-//tontos usando sntp para configurar rtc
-
 #pragma once
 
 #include "C++Utilities/CppUtils.hpp"

--- a/Inc/HALAL/Services/Communication/SNTP/SNTP.hpp
+++ b/Inc/HALAL/Services/Communication/SNTP/SNTP.hpp
@@ -1,0 +1,10 @@
+/*
+ * SNTP.hpp
+ *
+ *  Created on: 21 feb. 2023
+ *      Author: Ricardo
+ */
+
+//https://community.st.com/s/question/0D53W00000j5I4aSAE/how-set-up-pretty-presice-and-detailed-rtc-on-stm32h743zi2
+
+//tontos usando sntp para configurar rtc

--- a/Inc/HALAL/Services/Communication/SNTP/SNTP.hpp
+++ b/Inc/HALAL/Services/Communication/SNTP/SNTP.hpp
@@ -8,3 +8,15 @@
 //https://community.st.com/s/question/0D53W00000j5I4aSAE/how-set-up-pretty-presice-and-detailed-rtc-on-stm32h743zi2
 
 //tontos usando sntp para configurar rtc
+
+#pragma once
+
+#include <lwip/ip_addr.h>
+#include "sntp.h"
+
+class SNTP{
+public:
+	static void sntp_update();
+	static const ip4_addr *sntp_server;
+
+};

--- a/Inc/HALAL/Services/Communication/SNTP/SNTP.hpp
+++ b/Inc/HALAL/Services/Communication/SNTP/SNTP.hpp
@@ -11,11 +11,7 @@
 
 #pragma once
 
-#define SNTP_STARTUP_DELAY 0
-
-#include <lwip/ip_addr.h>
-#include "sntp.h"
-#include "IPV4/IPV4.hpp"
+#include "C++Utilities/CppUtils.hpp"
 
 class SNTP{
 public:

--- a/Inc/HALAL/Services/Communication/SNTP/SNTP.hpp
+++ b/Inc/HALAL/Services/Communication/SNTP/SNTP.hpp
@@ -11,12 +11,15 @@
 
 #pragma once
 
+#define SNTP_STARTUP_DELAY 0
+
 #include <lwip/ip_addr.h>
 #include "sntp.h"
+#include "IPV4/IPV4.hpp"
 
 class SNTP{
 public:
-	static void sntp_update();
-	static const ip4_addr *sntp_server;
+	static void sntp_update(uint8_t address_head, uint8_t address_second, uint8_t address_third, uint8_t address_last);
+	static ip4_addr_t *sntp_server;
 
 };

--- a/Inc/HALAL/Services/Communication/SNTP/SNTP.hpp
+++ b/Inc/HALAL/Services/Communication/SNTP/SNTP.hpp
@@ -12,5 +12,6 @@
 class SNTP{
 public:
 	static void sntp_update(uint8_t address_head, uint8_t address_second, uint8_t address_third, uint8_t address_last);
+	static void sntp_update(string ip);
 
 };

--- a/Inc/HALAL/Services/Communication/SNTP/SNTP.hpp
+++ b/Inc/HALAL/Services/Communication/SNTP/SNTP.hpp
@@ -20,6 +20,5 @@
 class SNTP{
 public:
 	static void sntp_update(uint8_t address_head, uint8_t address_second, uint8_t address_third, uint8_t address_last);
-	static ip4_addr_t *sntp_server;
 
 };

--- a/Inc/HALAL/Services/Time/Time.hpp
+++ b/Inc/HALAL/Services/Time/Time.hpp
@@ -9,7 +9,7 @@
 
 #include "stm32h7xx_hal.h"
 
-#define RTC_max_counter 32767
+#define RTC_MAX_COUNTER 32767
 
 #ifdef HAL_TIM_MODULE_ENABLED
 
@@ -104,7 +104,7 @@ public:
 	static void set_timeout(int milliseconds, function<void()> callback);
 
 #ifdef HAL_RTC_MODULE_ENABLED
-	struct rtc_data{
+	struct RTCData{
 		uint16_t counter;
 		uint8_t second;
 		uint8_t minute;
@@ -114,9 +114,9 @@ public:
 		uint16_t year;
 	};
 
-	static void start_RTC();
-	static rtc_data get_RTC_data();
-	static void set_RTC_data(uint16_t counter, uint8_t second, uint8_t minute, uint8_t hour, uint8_t day, uint8_t month, uint16_t year);
+	static void start_rtc();
+	static RTCData get_rtc_data();
+	static void set_rtc_data(uint16_t counter, uint8_t second, uint8_t minute, uint8_t hour, uint8_t day, uint8_t month, uint16_t year);
 
 	static RTC_HandleTypeDef hrtc;
 #endif

--- a/Inc/HALAL/Services/Time/Time.hpp
+++ b/Inc/HALAL/Services/Time/Time.hpp
@@ -9,6 +9,8 @@
 
 #include "stm32h7xx_hal.h"
 
+#define RTC_max_counter 32767
+
 #ifdef HAL_TIM_MODULE_ENABLED
 
 #include "C++Utilities/CppUtils.hpp"
@@ -100,6 +102,24 @@ public :
 	* @return void
 	*/
 	static void set_timeout(int milliseconds, function<void()> callback);
+
+#ifdef HAL_RTC_MODULE_ENABLED
+	struct rtc_data{
+		uint16_t counter;
+		uint8_t second;
+		uint8_t minute;
+		uint8_t hour;
+		uint8_t day;
+		uint8_t month;
+		uint16_t year;
+	};
+
+	static void start_RTC();
+	static rtc_data get_RTC_data();
+	static void set_RTC_data(uint16_t counter, uint8_t second, uint8_t minute, uint8_t hour, uint8_t day, uint8_t month, uint16_t year);
+
+	static RTC_HandleTypeDef hrtc;
+#endif
 };
 
 #endif

--- a/Src/HALAL/HALAL.cpp
+++ b/Src/HALAL/HALAL.cpp
@@ -60,7 +60,7 @@ void HALAL::start(TARGET target, string ip, string subnet_mask, string gateway, 
 
 #ifdef HAL_TIM_MODULE_ENABLED
 	Encoder::start();
-	Time::start_RTC();
+	Time::start_rtc();
 	TimerPeripheral::start();
 	Time::start();
 #endif

--- a/Src/HALAL/Services/Communication/SNTP/SNTP.cpp
+++ b/Src/HALAL/Services/Communication/SNTP/SNTP.cpp
@@ -1,0 +1,6 @@
+/*
+ * SNTP.cpp
+ *
+ *  Created on: 21 feb. 2023
+ *      Author: Ricardo
+ */

--- a/Src/HALAL/Services/Communication/SNTP/SNTP.cpp
+++ b/Src/HALAL/Services/Communication/SNTP/SNTP.cpp
@@ -32,7 +32,7 @@ extern "C" u32_t get_rtc_s(){
 	time_t nowtime = 0;
 	struct tm *nowtm;
 	nowtm = gmtime(&nowtime);
-	nowtm->tm_year	= rtc_time.year;
+	nowtm->tm_year	= rtc_time.year -1900;
 	nowtm->tm_mon	= rtc_time.month - 1;
 	nowtm->tm_mday	= rtc_time.day;
 	nowtm->tm_hour	= rtc_time.hour;

--- a/Src/HALAL/Services/Communication/SNTP/SNTP.cpp
+++ b/Src/HALAL/Services/Communication/SNTP/SNTP.cpp
@@ -7,8 +7,10 @@
 
 #include "Communication/SNTP/SNTP.hpp"
 #include <lwip/ip_addr.h>
+#include "sntp_opts.h"
 #include "sntp.h"
 #include "IPV4/IPV4.hpp"
+#include "Time/Time.hpp"
 
 void SNTP::sntp_update(uint8_t address_head, uint8_t address_second, uint8_t address_third, uint8_t address_last){
 	sntp_setoperatingmode(SNTP_OPMODE_POLL);
@@ -16,4 +18,8 @@ void SNTP::sntp_update(uint8_t address_head, uint8_t address_second, uint8_t add
 	IP_ADDR4(address,address_head,address_second,address_third,address_last);
 	sntp_setserver(0,address);
 	sntp_init();
+}
+
+extern "C" void set_rtc(uint16_t counter, uint8_t second, uint8_t minute, uint8_t hour, uint8_t day, uint8_t month, uint16_t year){
+	Time::set_RTC_data(counter, second, minute, hour, day, month, year);
 }

--- a/Src/HALAL/Services/Communication/SNTP/SNTP.cpp
+++ b/Src/HALAL/Services/Communication/SNTP/SNTP.cpp
@@ -4,3 +4,13 @@
  *  Created on: 21 feb. 2023
  *      Author: Ricardo
  */
+
+#include "Communication/SNTP/SNTP.hpp"
+
+const ip4_addr *SNTP::sntp_server;
+
+void SNTP::sntp_update(){
+	sntp_setoperatingmode(SNTP_OPMODE_POLL);
+	sntp_setserver(0,SNTP::sntp_server);
+	sntp_init();
+}

--- a/Src/HALAL/Services/Communication/SNTP/SNTP.cpp
+++ b/Src/HALAL/Services/Communication/SNTP/SNTP.cpp
@@ -7,10 +7,12 @@
 
 #include "Communication/SNTP/SNTP.hpp"
 
-const ip4_addr *SNTP::sntp_server;
+ip4_addr_t *SNTP::sntp_server;
 
-void SNTP::sntp_update(){
+void SNTP::sntp_update(uint8_t address_head, uint8_t address_second, uint8_t address_third, uint8_t address_last){
 	sntp_setoperatingmode(SNTP_OPMODE_POLL);
-	sntp_setserver(0,SNTP::sntp_server);
+	ip4_addr_t* address;
+	IP_ADDR4(address,address_head,address_second,address_third,address_last);
+	sntp_setserver(0,address);
 	sntp_init();
 }

--- a/Src/HALAL/Services/Communication/SNTP/SNTP.cpp
+++ b/Src/HALAL/Services/Communication/SNTP/SNTP.cpp
@@ -23,6 +23,13 @@ void SNTP::sntp_update(uint8_t address_head, uint8_t address_second, uint8_t add
 	sntp_init();
 }
 
+void SNTP::sntp_update(string ip) {
+	sntp_setoperatingmode(SNTP_OPMODE_POLL);
+	IPV4 target(ip);
+	sntp_setserver(0,&target.address);
+	sntp_init();
+}
+
 extern "C" void set_rtc(uint16_t counter, uint8_t second, uint8_t minute, uint8_t hour, uint8_t day, uint8_t month, uint16_t year){
 	Time::set_rtc_data(counter, second, minute, hour, day, month, year);
 }

--- a/Src/HALAL/Services/Communication/SNTP/SNTP.cpp
+++ b/Src/HALAL/Services/Communication/SNTP/SNTP.cpp
@@ -24,11 +24,11 @@ void SNTP::sntp_update(uint8_t address_head, uint8_t address_second, uint8_t add
 }
 
 extern "C" void set_rtc(uint16_t counter, uint8_t second, uint8_t minute, uint8_t hour, uint8_t day, uint8_t month, uint16_t year){
-	Time::set_RTC_data(counter, second, minute, hour, day, month, year);
+	Time::set_rtc_data(counter, second, minute, hour, day, month, year);
 }
 
 extern "C" u32_t get_rtc_s(){
-	Time::rtc_data rtc_time = Time::get_RTC_data();
+	Time::RTCData rtc_time = Time::get_rtc_data();
 	time_t nowtime = 0;
 	struct tm *nowtm;
 	nowtm = gmtime(&nowtime);
@@ -43,6 +43,6 @@ extern "C" u32_t get_rtc_s(){
 }
 
 extern "C" u32_t get_rtc_us(){
-	Time::rtc_data rtc_time = Time::get_RTC_data();
+	Time::RTCData rtc_time = Time::get_rtc_data();
 	return rtc_time.counter/TRANSFORMATION_FACTOR;
 }

--- a/Src/HALAL/Services/Communication/SNTP/SNTP.cpp
+++ b/Src/HALAL/Services/Communication/SNTP/SNTP.cpp
@@ -12,6 +12,9 @@
 #include "IPV4/IPV4.hpp"
 #include "Time/Time.hpp"
 
+#define SUBSECONDS_PER_SECOND 32767
+#define TRANSFORMATION_FACTOR (SUBSECONDS_PER_SECOND/999999.0)
+
 void SNTP::sntp_update(uint8_t address_head, uint8_t address_second, uint8_t address_third, uint8_t address_last){
 	sntp_setoperatingmode(SNTP_OPMODE_POLL);
 	ip4_addr_t* address;
@@ -22,4 +25,24 @@ void SNTP::sntp_update(uint8_t address_head, uint8_t address_second, uint8_t add
 
 extern "C" void set_rtc(uint16_t counter, uint8_t second, uint8_t minute, uint8_t hour, uint8_t day, uint8_t month, uint16_t year){
 	Time::set_RTC_data(counter, second, minute, hour, day, month, year);
+}
+
+extern "C" u32_t get_rtc_s(){
+	Time::rtc_data rtc_time = Time::get_RTC_data();
+	time_t nowtime = 0;
+	struct tm *nowtm;
+	nowtm = gmtime(&nowtime);
+	nowtm->tm_year	= rtc_time.year;
+	nowtm->tm_mon	= rtc_time.month - 1;
+	nowtm->tm_mday	= rtc_time.day;
+	nowtm->tm_hour	= rtc_time.hour;
+	nowtm->tm_min	= rtc_time.minute;
+	nowtm->tm_sec	= rtc_time.second;
+	u32_t sec = mktime(nowtm);
+	return sec;
+}
+
+extern "C" u32_t get_rtc_us(){
+	Time::rtc_data rtc_time = Time::get_RTC_data();
+	return rtc_time.counter/TRANSFORMATION_FACTOR;
 }

--- a/Src/HALAL/Services/Communication/SNTP/SNTP.cpp
+++ b/Src/HALAL/Services/Communication/SNTP/SNTP.cpp
@@ -7,8 +7,6 @@
 
 #include "Communication/SNTP/SNTP.hpp"
 
-ip4_addr_t *SNTP::sntp_server;
-
 void SNTP::sntp_update(uint8_t address_head, uint8_t address_second, uint8_t address_third, uint8_t address_last){
 	sntp_setoperatingmode(SNTP_OPMODE_POLL);
 	ip4_addr_t* address;

--- a/Src/HALAL/Services/Communication/SNTP/SNTP.cpp
+++ b/Src/HALAL/Services/Communication/SNTP/SNTP.cpp
@@ -6,6 +6,9 @@
  */
 
 #include "Communication/SNTP/SNTP.hpp"
+#include <lwip/ip_addr.h>
+#include "sntp.h"
+#include "IPV4/IPV4.hpp"
 
 void SNTP::sntp_update(uint8_t address_head, uint8_t address_second, uint8_t address_third, uint8_t address_last){
 	sntp_setoperatingmode(SNTP_OPMODE_POLL);

--- a/Src/HALAL/Services/Time/Time.cpp
+++ b/Src/HALAL/Services/Time/Time.cpp
@@ -276,7 +276,7 @@ Time::rtc_data Time::get_RTC_data(){
 	ret.hour = gTime.Hours;
 	ret.day = gDate.Date;
 	ret.month = gDate.Month;
-	ret.year = gDate.Year;
+	ret.year = 2000 + gDate.Year;
 	return ret;
 }
 
@@ -291,7 +291,7 @@ void Time::set_RTC_data(uint16_t counter, uint8_t second, uint8_t minute, uint8_
 	gTime.StoreOperation = RTC_STOREOPERATION_RESET;
 	gDate.Date = day;
 	gDate.Month = month;
-	gDate.Year = year;
+	gDate.Year = year - 2000;
 	if (HAL_RTC_SetTime(&hrtc, &gTime, RTC_FORMAT_BIN) != HAL_OK)
 	{
 		ErrorHandler("Error on writing Time on the RTC");
@@ -300,5 +300,4 @@ void Time::set_RTC_data(uint16_t counter, uint8_t second, uint8_t minute, uint8_
 	{
 		ErrorHandler("Error on writing Date on the RTC");
 	}
-	HAL_RTCEx_BKUPWrite(&hrtc, RTC_BKP_DR1, 0x32F2); // backup register
 }

--- a/Src/HALAL/Services/Time/Time.cpp
+++ b/Src/HALAL/Services/Time/Time.cpp
@@ -209,63 +209,45 @@ void Time::ConfigTimer(TIM_HandleTypeDef* tim, uint32_t period_in_us){
 
 }
 
-void Time::start_RTC(){
+void Time::start_rtc(){
+	RTC_TimeTypeDef sTime = { 0 };
+	RTC_DateTypeDef sDate = { 0 };
 
+	hrtc.Instance = RTC;
+	hrtc.Init.HourFormat = RTC_HOURFORMAT_24;
+	hrtc.Init.AsynchPrediv = 0;
+	hrtc.Init.SynchPrediv = 32767;
+	hrtc.Init.OutPut = RTC_OUTPUT_DISABLE;
+	hrtc.Init.OutPutPolarity = RTC_OUTPUT_POLARITY_HIGH;
+	hrtc.Init.OutPutType = RTC_OUTPUT_TYPE_OPENDRAIN;
+	hrtc.Init.OutPutRemap = RTC_OUTPUT_REMAP_NONE;
 
-	RTC_TimeTypeDef sTime = {0};
-		  RTC_DateTypeDef sDate = {0};
+	if (HAL_RTC_Init(&hrtc) != HAL_OK) {
+		ErrorHandler("Error on RTC Init");
+	}
+	sTime.Hours = 0x0;
+	sTime.Minutes = 0x0;
+	sTime.Seconds = 0x0;
+	sTime.DayLightSaving = RTC_DAYLIGHTSAVING_NONE;
+	sTime.StoreOperation = RTC_STOREOPERATION_RESET;
 
-		  /* USER CODE BEGIN RTC_Init 1 */
+	if (HAL_RTC_SetTime(&hrtc, &sTime, RTC_FORMAT_BIN) != HAL_OK) {
+		ErrorHandler("Error while setting time at RTC start");
+	}
 
-		  /* USER CODE END RTC_Init 1 */
+	sDate.WeekDay = RTC_WEEKDAY_MONDAY;
+	sDate.Month = RTC_MONTH_JANUARY;
+	sDate.Date = 0x1;
+	sDate.Year = 23;
 
-		  /** Initialize RTC Only
-		  */
-		  hrtc.Instance = RTC;
-		  hrtc.Init.HourFormat = RTC_HOURFORMAT_24;
-		  hrtc.Init.AsynchPrediv = 0;
-		  hrtc.Init.SynchPrediv = 32767;
-		  hrtc.Init.OutPut = RTC_OUTPUT_DISABLE;
-		  hrtc.Init.OutPutPolarity = RTC_OUTPUT_POLARITY_HIGH;
-		  hrtc.Init.OutPutType = RTC_OUTPUT_TYPE_OPENDRAIN;
-		  hrtc.Init.OutPutRemap = RTC_OUTPUT_REMAP_NONE;
-		  if (HAL_RTC_Init(&hrtc) != HAL_OK)
-		  {
-			  ErrorHandler("Error on RTC Init");
-		  }
-
-		  /* USER CODE BEGIN Check_RTC_BKUP */
-
-		  /* USER CODE END Check_RTC_BKUP */
-
-		  /** Initialize RTC and set the Time and Date
-		  */
-		  sTime.Hours = 0x0;
-		  sTime.Minutes = 0x0;
-		  sTime.Seconds = 0x0;
-		  sTime.DayLightSaving = RTC_DAYLIGHTSAVING_NONE;
-		  sTime.StoreOperation = RTC_STOREOPERATION_RESET;
-		  if (HAL_RTC_SetTime(&hrtc, &sTime, RTC_FORMAT_BIN) != HAL_OK)
-		  {
-			  ErrorHandler("Error while setting time at RTC start");
-		  }
-		  sDate.WeekDay = RTC_WEEKDAY_MONDAY;
-		  sDate.Month = RTC_MONTH_JANUARY;
-		  sDate.Date = 0x1;
-		  sDate.Year = 0x0;
-
-		  if (HAL_RTC_SetDate(&hrtc, &sDate, RTC_FORMAT_BIN) != HAL_OK)
-		  {
-			  ErrorHandler("Error while setting date at RTC start");
-		  }
-		  /* USER CODE BEGIN RTC_Init 2 */
-
-		  /* USER CODE END RTC_Init 2 */
+	if (HAL_RTC_SetDate(&hrtc, &sDate, RTC_FORMAT_BIN) != HAL_OK) {
+		ErrorHandler("Error while setting date at RTC start");
+	}
 }
 
 
-Time::rtc_data Time::get_RTC_data(){
-	rtc_data ret;
+Time::RTCData Time::get_rtc_data(){
+	RTCData ret;
 	RTC_TimeTypeDef gTime;
 	RTC_DateTypeDef gDate;
 	HAL_RTC_GetTime(&hrtc, &gTime, RTC_FORMAT_BIN);
@@ -280,7 +262,7 @@ Time::rtc_data Time::get_RTC_data(){
 	return ret;
 }
 
-void Time::set_RTC_data(uint16_t counter, uint8_t second, uint8_t minute, uint8_t hour, uint8_t day, uint8_t month, uint16_t year){
+void Time::set_rtc_data(uint16_t counter, uint8_t second, uint8_t minute, uint8_t hour, uint8_t day, uint8_t month, uint16_t year){
 	RTC_TimeTypeDef gTime;
 	RTC_DateTypeDef gDate;
 	gTime.SubSeconds = counter;

--- a/Src/HALAL/Services/Time/Time.cpp
+++ b/Src/HALAL/Services/Time/Time.cpp
@@ -289,6 +289,7 @@ void Time::set_RTC_data(uint16_t counter, uint8_t second, uint8_t minute, uint8_
 	gTime.Hours = hour;
 	gTime.DayLightSaving = RTC_DAYLIGHTSAVING_NONE;
 	gTime.StoreOperation = RTC_STOREOPERATION_RESET;
+	gDate.WeekDay = 0;
 	gDate.Date = day;
 	gDate.Month = month;
 	gDate.Year = year - 2000;


### PR DESCRIPTION
SNTP working

you need to change the configuration on the .ioc lwip to enable sntp, which will generate a sntp.c in Middlewares/ThirdParty/lwip/src/apps/sntp/sntp.c

Then you will need to add a piece of code which configurates the sntp in Middlewares/ThirdParty/lwip/include/lwip/apps/sntp_opts.h just below the includes. This is the code:

```
static void set_time(uint32_t sec, uint32_t us);
static void set_rtc(uint16_t counter, uint8_t second, uint8_t minute, uint8_t hour, uint8_t day, uint8_t month, uint16_t year);
static u32_t get_rtc_s();
static u32_t get_rtc_us();

#define SNTP_STARTUP_DELAY 0
#define SNTP_SET_SYSTEM_TIME_US(sec,us) set_time(sec,us)
#define SUBSECONDS_PER_SECOND 32767
#define TRANSFORMATION_FACTOR (SUBSECONDS_PER_SECOND/999999.0)
#define SNTP_COMP_ROUNDTRIP 1
#define SNTP_UPDATE_DELAY 3600000

void set_time(uint32_t sec, uint32_t us){
	struct timeval tv;
	tv.tv_sec = sec;
	tv.tv_usec = us;
	time_t nowtime = sec;
	struct tm *nowtm = localtime(&nowtime);
	uint32_t subsecond = (uint32_t)(TRANSFORMATION_FACTOR * tv.tv_usec);
	set_rtc(subsecond, nowtm->tm_sec, nowtm->tm_min, nowtm->tm_hour, nowtm->tm_mday, 1+nowtm->tm_mon, 1900+(nowtm->tm_year));
}

#define SNTP_GET_SYSTEM_TIME(sec, us) do {(sec) = get_rtc_s(); (us) = get_rtc_us(); } while (0)

```

Also you will need to follow the Ethernet configuration (step 7 and below) as you will need to generate code so the sntp.c is created, which will remove the Ethernet configuration (and it is needed for sntp)