### PR TITLE
Fix/linear sensor double

### DIFF
--- a/Inc/ST-LIB_LOW/Sensors/LinearSensor/LinearSensor.hpp
+++ b/Inc/ST-LIB_LOW/Sensors/LinearSensor/LinearSensor.hpp
@@ -11,15 +11,15 @@
 
 class LinearSensor{
 public:
-	LinearSensor(Pin &pin, double slope, double offset, double *value);
-	LinearSensor(Pin &pin, double slope, double offset, double &value);
+	LinearSensor(Pin &pin, float *value, float slope=1, float offset=0);
+	LinearSensor(Pin &pin, float &value, float slope=1, float offset=0);
 	void read();
 	uint8_t get_id();
 
 protected:
 	Pin &pin;
 	uint8_t id;
-	double slope;
-	double offset;
-	double *value;
+	float slope;
+	float offset;
+	float *value;
 };

--- a/Src/ST-LIB_LOW/Sensors/LinearSensor/LinearSensor.cpp
+++ b/Src/ST-LIB_LOW/Sensors/LinearSensor/LinearSensor.cpp
@@ -1,7 +1,7 @@
 #include "Sensors/LinearSensor/LinearSensor.hpp"
 #include "Sensors/Sensor/Sensor.hpp"
 
-LinearSensor::LinearSensor(Pin &pin, double slope, double offset, double *value)
+LinearSensor::LinearSensor(Pin &pin, float *value, float slope, float offset)
 : pin(pin), slope(slope), offset(offset), value(value){
 	optional<uint8_t> identification = ADC::inscribe(pin);
 	if(not identification){
@@ -13,7 +13,7 @@ LinearSensor::LinearSensor(Pin &pin, double slope, double offset, double *value)
 
 }
 
-LinearSensor::LinearSensor(Pin &pin, double slope, double offset, double &value):LinearSensor::LinearSensor(pin,slope,offset,&value){}
+LinearSensor::LinearSensor(Pin &pin, float &value, float slope, float offset) : LinearSensor::LinearSensor(pin, &value, slope,offset){}
 
 void LinearSensor::read(){
 	optional<float> val = ADC::get_value(id);

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+/opt/st/stm32cubeide_1.12.0/headless-build.sh -data /home/alejandro/projects -build ST-LIB/Debug


### PR DESCRIPTION
Arreglo constructor para aceptar floats. Nuestros ADCs no tienen tanta resolucion para usar doubles. Luego cambio el constructor para llamar que tenga valores por defecto.