### PR TITLE
Packets rework and minor fixes

### DIFF
--- a/Inc/HALAL/Models/IPV4/IPV4.hpp
+++ b/Inc/HALAL/Models/IPV4/IPV4.hpp
@@ -24,8 +24,10 @@ public:
 	string string_address;
 
 	IPV4();
+	IPV4(const char* address);
 	IPV4(string address);
 
+	void operator=(const char* address);
 };
 
 #endif

--- a/Inc/HALAL/Models/Packets/Packet.hpp
+++ b/Inc/HALAL/Models/Packets/Packet.hpp
@@ -2,279 +2,261 @@
 
 #include "PacketValue.hpp"
 
-struct empty_type {};
+template<class... Types> class stack_tuple;
 
-template<class... ValueTypes> class Packet;
-
-template<>
-class Packet<>
-{
+template<> 
+class stack_tuple<> {
 public:
-    uint16_t id;
-    using value_type = empty_type;
-    static constexpr size_t number_of_values = 0;
-    using base_type = empty_type;
-    static map<decltype(Packet<>::id), function<void(uint8_t*)>> save_by_id;
-    static map<decltype(Packet<>::id), void(*)()> on_received;
-
-public:
-    Packet(uint16_t id) : id(static_cast<decltype(this->id)>(id)) {}
-    Packet() = default;
-
-    void fill_buffer(uint8_t* buffer, size_t& ptr_loc) {}
-    void calculate_sizes(bool& has_container_values , size_t& bffr_size) {}
-    void load_data(uint8_t* new_data, size_t& ptr_loc) {}
-
-    static uint16_t get_id(uint8_t* new_data) {
-        return *(decltype(id)*)new_data;
-    }
+    stack_tuple() = default;
+    template<class FunctionType>
+    void for_each(FunctionType function) {}
 };
 
 template<class Type, class... Types>
-class Packet<Type, Types...> : public Packet<Types...>
-{
+class stack_tuple<Type, Types...>: public stack_tuple<Types...> {
 public:
-    uint16_t id = 0;
-    uint8_t* buffer = nullptr;
-    using value_type = Type;
-    static constexpr size_t number_of_values = 1 + sizeof...(Types);
-    using base_type = Packet<Types...>;
+    Type value;
+    stack_tuple() = default;
+    stack_tuple(Type value, Types... values): stack_tuple<Types...>(values...), value(value) {}
+    template<class FunctionType>
+    void for_each(FunctionType function) {
+        function(value);
+        stack_tuple<Types...>::for_each(function);
+    }
+};
 
+class Packet{
+public:
+    size_t size;
+    virtual uint8_t* build() = 0;
+    virtual void parse(void* data) = 0;
+    virtual size_t get_size() = 0;
+    virtual uint16_t get_id() = 0; 
+    static uint16_t get_id(void* data) {
+        return *((uint16_t*)data);
+    }
+    static void parse_data(void* data){
+        uint16_t id = get_id(data);
+        if(packets.contains(id)) packets[id]->parse(data);
+    }
 protected:
-    PacketValue<value_type> value;
+    static map<uint16_t, Packet*> packets;
+};
 
+template<size_t BufferLength, class... Types> 
+class StackPacket : Packet{
 public:
-    Packet();
-    Packet(uint16_t id);
-    Packet(uint16_t id, PacketValue<Type> value, PacketValue<Types>... args);
-    Packet(PacketValue<Type> value, PacketValue<Types>... args);
-    ~Packet();
+    uint16_t id;
+    PacketValue<>* values[sizeof...(Types)];
+    uint8_t buffer[BufferLength + sizeof(id)];
+    const size_t size = BufferLength + sizeof(id);
+    stack_tuple<PacketValue<Types>...> packetvalue_warehouse;
+    StackPacket(uint16_t id, Types*... values): id(id), packetvalue_warehouse{PacketValue<Types>(values)...} {
+        int i = 0;
+        packetvalue_warehouse.for_each([this, &i](auto& value) {
+            this->values[i++] = &value;
+        });
+        packets[id] = this;
+    }
+    void parse(void* data) override {
+        data+=sizeof(id);
+        for (PacketValue<>* value : values) {
+            value->parse(data);
+            data += value->get_size();
+        }
+    }
+    size_t get_size() override {
+        return size;
+    }
+    uint8_t* build() override {
+        uint8_t* data = buffer;
+        memcpy(data, &id, sizeof(id));
+        data += sizeof(id);
+        for (PacketValue<>* value : values) {
+            value->copy_to(data);
+            data += value->get_size();
+        }
+        return buffer;
+    }
 
-    template<int I>
-    const auto& get() const;
+    uint16_t get_id() override {
+        return id;
+    }
+};
 
-    template<int I>
-    auto& get();
-
-    uint8_t* build();
-
-    void calculate_sizes();
-
-    void calculate_sizes(bool& has_container_values, size_t& buffer_size);
-
-    void fill_buffer();
-
-    void fill_buffer(uint8_t* buffer, size_t& ptr_loc) requires NotContainer<Type>;
-
-    void fill_buffer(uint8_t* buffer, size_t& ptr_loc) requires Container<Type>;
-
-    bool check_id(uint8_t* new_data);
-
-    decltype(Packet<Type, Types...>::id) get_id();
-
-    void load_data(uint8_t* new_data);
-
-    void load_data(uint8_t* new_data, size_t& ptr_loc);
-
-    void save_data(uint8_t* new_data);
-
-    template <class FunctionType>
-    void for_each(FunctionType& callback);
-
-    template <class FunctionType>
-    void for_each(FunctionType&& callback);
-
+template<class... Types>
+class StackPacket<0, Types...> : Packet{
 public:
-    size_t buffer_size = sizeof(id);
-    size_t ptr_loc = sizeof(id);
-    bool has_been_built = false;
-    bool has_container_values = false;
+    uint16_t id;
+    PacketValue<>* values[sizeof...(Types)];
+    stack_tuple<PacketValue<Types>...> packetvalue_warehouse;
+    size_t buffer_size = 0;
+    size_t& data_size = Packet::size;
+    uint8_t* buffer = nullptr;
+
+    StackPacket(uint16_t id, Types*... values): id(id), packetvalue_warehouse{PacketValue<Types>(values)...} {
+        int i = 0;
+        packetvalue_warehouse.for_each([this, &i](auto& value) {
+            this->values[i++] = &value;
+        });
+        packets[id] = this;
+    }
+
+    void parse(void* data) override {
+        data+=sizeof(id);
+        for (PacketValue<>* value : values) {
+            value->parse(data);
+            data += value->get_size();
+        }
+    }
+
+    size_t get_size()override {
+        size_t new_size = 0;
+        for (PacketValue<>* value : values) {
+            new_size += value->get_size();
+        }
+        return new_size + sizeof(id);
+    }
+
+    uint8_t* build() override {
+        data_size = get_size();
+        if (buffer != nullptr && (data_size > buffersize || data_size < buffer_size/2)){
+            delete[] buffer;
+            buffer = new uint8_t[data_size]; 
+            buffer_size = data_size;
+        }
+        else if (buffer == nullptr) {
+            buffer = new uint8_t[data_size];
+            buffer_size = data_size;
+        }
+
+        uint8_t* data = buffer;
+        memcpy(data, &id, sizeof(id));
+        data += sizeof(id);
+        for (PacketValue<>* value : values) {
+            value->copy_to(data);
+            data += value->get_size();
+        }
+        return buffer;
+    }
+
+    uint16_t get_id() override {
+        return id;
+    }
+
+    ~StackPacket() {
+        if (buffer != nullptr) delete[] buffer;
+    }
+};
+
+template<>
+class StackPacket<0> : public Packet{
+public:
+    uint16_t id;
+    const size_t size = sizeof(id);
+    StackPacket() = default;
+    StackPacket(uint16_t id) : id(id){packets[id] = this;}
+    void parse(void* data) override {}
+    uint8_t* build() override {
+        return (uint8_t*)&id;
+    }
+    uint16_t get_id() override {
+        return id;
+    }
+    size_t get_size() override {
+        return sizeof(id); 
+    }
+};
+
+template<class... Types> struct has_container;
+
+template<class Type, class... Types>
+struct has_container<Type, Types...>{
+public:
+    static constexpr bool value = Container<Type> || has_container<Types...>::value;
+};
+
+template<>
+struct has_container<>{
+public:
+    static constexpr bool value = false;
+};
+
+template<class... Types> struct total_sizeof;
+
+template<class Type, class... Types>
+struct total_sizeof<Type,Types...>{
+public:
+    static constexpr size_t value = sizeof(Type) + total_sizeof<Types...>::value;
+};
+
+template<>
+struct total_sizeof<>{
+public:
+    static constexpr size_t value = 0;
 };
 
 #if __cpp_deduction_guides >= 201606
-template<class Type, class... Types>
-Packet(uint16_t id, PacketValue<Type> value, PacketValue<Types>... args)->Packet<Type, Types...>;
-template<class Type>
-Packet(uint16_t id, PacketValue<Type> value)->Packet<Type>;
-Packet(uint16_t id)->Packet<>;
+template<class... Types>
+StackPacket(uint16_t, Types*... values)->StackPacket<(!has_container<Types...>::value)*total_sizeof<Types...>::value, Types...>;
+
+StackPacket()->StackPacket<0>;
 #endif
 
-template<class Type, class... Types>
-Packet<Type, Types...>::Packet(): value(*(PacketValue<Type>*)(0)) {}
+class HeapPacket : Packet{
+public:
+    uint16_t id;
+    vector<PacketValue<>*> values;
+    uint8_t* buffer = nullptr;
+    size_t& data_size = Packet::size;
+    size_t buffer_size = 0;
+    HeapPacket() = default;
 
-template<class Type, class... Types>
-Packet<Type, Types...>::Packet(uint16_t id) : id(id) {}
+    template<class... Types>
+    HeapPacket(uint16_t id, Types*... values): id(id), values{new PacketValue<Types>(values)...} {packets[id] = this;}
 
-template<class Type, class... Types>
-Packet<Type, Types...>::Packet(uint16_t id, PacketValue<Type> value, PacketValue<Types>... args) : Packet<Type,Types...>(value,args...) {
-    this->id = id;
-    Packet<>::save_by_id[this->id] = [this](uint8_t* new_data) {save_data(new_data); };
-}
-
-template<class Type, class... Types>
-Packet<Type, Types...>::Packet(PacketValue<Type> value, PacketValue<Types>... args) : Packet<Types...>(args...), value(value) {}
-
-template<class Type, class... Types>
-Packet<Type, Types...>::~Packet(){
-    if(buffer != nullptr){
-        free(buffer);
-    }
-}
-
-template<class Type, class... Types> template<int I>
-const auto& Packet<Type, Types...>::get() const {
-    if constexpr (I == 0) {
-        return this->value;
-    }
-    else if constexpr (I > 0) {
-        return static_cast<const base_type&>(*this). template get<I - 1>();
-    }
-}
-
-template<class Type, class... Types> template<int I>
-auto& Packet<Type, Types...>::get() {
-    if constexpr (I == 0) {
-        return this->value;
-    }
-    else if constexpr (I > 0) {
-        return static_cast<base_type&>(*this). template get<I - 1>();
-    }
-}
-
-template<class Type, class... Types>
-void Packet<Type, Types...>::calculate_sizes() {
-    calculate_sizes(has_container_values, buffer_size);
-}
-
-template<class Type, class... Types>
-void Packet<Type, Types...>::calculate_sizes(bool& has_container_values, size_t& buffer_size) {
-    if constexpr (number_of_values <= 0) {
-        return;
-    }
-    else {
-        using cast_type = remove_reference<decltype(this->value)>::type::value_type;
-        if constexpr (is_container<cast_type>::value) {
-            has_container_values = true;
+    void parse(void* data) override {
+        data+=sizeof(id);
+        for (PacketValue<>* value : values) {
+            value->parse(data);
+            data += value->get_size();
         }
-        buffer_size += this->value.size();
-        static_cast<base_type*>(this)->calculate_sizes(has_container_values, buffer_size);
     }
-}
 
-template<class Type, class... Types>
-void Packet<Type, Types...>::fill_buffer() {
-    fill_buffer(buffer, ptr_loc);
-}
-
-template<class Type, class... Types>
-void Packet<Type, Types...>::fill_buffer(uint8_t* buffer,size_t& ptr_loc) requires NotContainer<Type> {
-    if constexpr (number_of_values <= 0) {
-        return;
-    }
-    else {
-        using cast_type = remove_reference<decltype(this->value)>::type::value_type;
-        *((cast_type*)(buffer + ptr_loc)) = *(this->value).convert();
-        ptr_loc += this->value.size();
-        static_cast<base_type*>(this)->fill_buffer(buffer, ptr_loc);
-    }
-}
-
-template<class Type, class... Types>
-void Packet<Type, Types...>::fill_buffer(uint8_t* buffer, size_t& ptr_loc)  requires Container<Type>{
-    if constexpr (number_of_values <= 0) {
-        return;
-    }
-    else {
-        memcpy(buffer + ptr_loc, this->value.convert(), this->value.size());
-        ptr_loc += this->value.size();
-        static_cast<base_type*>(this)->fill_buffer(buffer, ptr_loc);
-    }
-}
-
-template<class Type, class... Types>
-uint8_t* Packet<Type, Types...>::build() {
-    if (!has_been_built || has_container_values) {
-        buffer_size = sizeof(id);
-        calculate_sizes();
-        if (buffer != nullptr) {
-            free(buffer);
+    size_t get_size() override {
+        size_t new_size = 0;
+        for (PacketValue<>* value : values) {
+            new_size += value->get_size();
         }
-        buffer = (uint8_t*)malloc(buffer_size);
-        memcpy(buffer, &id, sizeof(id));
+        return new_size + sizeof(id);
     }
-    fill_buffer();
-    ptr_loc = sizeof(id);
-    has_been_built = true;
-    return this->buffer;
-}
 
-template<class Type, class... Types>
-void Packet<Type, Types...>::load_data(uint8_t* new_data) {
-    load_data(new_data, ptr_loc);
-}
+    uint8_t* build() override {
+        data_size = get_size();
+        if (buffer != nullptr && (data_size > buffer_size || data_size < buffer_size/2)){
+            delete[] buffer;
+            buffer = new uint8_t[data_size]; 
+            buffer_size = data_size;
+        }
+        else if (buffer == nullptr) {
+            buffer = new uint8_t[data_size];
+            buffer_size = data_size;
+        }
+        uint8_t* data = buffer;
+        memcpy(data, &id, sizeof(id));
+        data += sizeof(id);
+        for (PacketValue<>* value : values) {
+            value->copy_to(data);
+            data += value->get_size();
+        }
+        return buffer;
+    }
+    uint16_t get_id() override {
+        return id;
+    }
 
-template<class Type, class... Types>
-void Packet<Type, Types...>::load_data(uint8_t * new_data, size_t& ptr_loc) {
-    if constexpr (number_of_values <= 0) {
-        return;
+    ~HeapPacket() {
+        if(buffer != nullptr) delete[] buffer;
+        for(PacketValue<>* value : values) delete value;
     }
-    else {
-        using cast_type = remove_reference<decltype(this->value)>::type::value_type;
-        this->value.load((cast_type*)(new_data + ptr_loc));
-        ptr_loc += this->value.size();
-        static_cast<base_type*>(this)->load_data(new_data,ptr_loc);
-    }
-}
-
-template<class Type, class ... Types>
-bool Packet<Type, Types...>::check_id(uint8_t* new_data) {
-    if (id != *(uint16_t*)new_data) {
-        return false;
-    }
-    return true;
-}
-
-template<class Type, class... Types>
-void Packet<Type, Types...>::save_data(uint8_t * new_data) {
-    if (!check_id(new_data)) {
-        return;
-    }
-    load_data(new_data);
-    ptr_loc = sizeof(id);
-}
-
-
-template<class Type, class... Types>
-uint16_t Packet<Type, Types...>::get_id() {
-    return this->id;
-}
-
-template<class Type, class... Types> template<class FunctionType>
-void Packet<Type, Types...>::for_each(FunctionType& callback) {
-    if constexpr (number_of_values <= 0) {
-        return;
-    }
-    else if constexpr (number_of_values == 1) {
-        callback(this->value);
-        return;
-    }
-    else {
-        callback(this->value);
-        static_cast<base_type*>(this)->for_each(callback);
-    }
-}
-
-template<class Type, class... Types> template<class FunctionType>
-void Packet<Type, Types...>::for_each(FunctionType&& callback) {
-    if constexpr (number_of_values <= 0) {
-        return;
-    }
-    else if constexpr (number_of_values == 1) {
-        invoke(callback, this->value);
-        return;
-    }
-    else {
-        invoke(callback, this->value);
-        static_cast<base_type*>(this)->for_each(callback);
-    }
-}
+};

--- a/Inc/HALAL/Models/Packets/PacketValue.hpp
+++ b/Inc/HALAL/Models/Packets/PacketValue.hpp
@@ -2,131 +2,116 @@
 
 #include "C++Utilities/CppUtils.hpp"
 
-template<typename T>
-struct has_const_iterator
+template <class T>
+concept Container = requires(T a, const T b)
 {
-private:
-    typedef char                      yes;
-    typedef struct { char array[2]; } no;
-
-    template<typename C> static yes test(typename C::const_iterator*);
-    template<typename C> static no  test(...);
-public:
-    static const bool value = sizeof(test<T>(0)) == sizeof(yes);
-    typedef T type;
+    requires std::regular<T>;
+    requires std::swappable<T>;
+    requires std::same_as<typename T::reference, typename T::value_type &>;
+    requires std::same_as<typename T::const_reference, const typename T::value_type &>;
+    requires std::forward_iterator<typename T::iterator>;
+    requires std::forward_iterator<typename T::const_iterator>;
+    requires std::signed_integral<typename T::difference_type>;
+    requires std::same_as<typename T::difference_type, typename std::iterator_traits<typename T::iterator>::difference_type>;
+    requires std::same_as<typename T::difference_type, typename std::iterator_traits<typename T::const_iterator>::difference_type>;
+    { a.begin() } -> std::same_as<typename T::iterator>;
+    { a.end() } -> std::same_as<typename T::iterator>;
+    { b.begin() } -> std::same_as<typename T::const_iterator>;
+    { b.end() } -> std::same_as<typename T::const_iterator>;
+    { a.cbegin() } -> std::same_as<typename T::const_iterator>;
+    { a.cend() } -> std::same_as<typename T::const_iterator>;
+    { a.size() } -> std::same_as<typename T::size_type>;
+    { a.max_size() } -> std::same_as<typename T::size_type>;
+    { a.empty() } -> std::convertible_to<bool>;
 };
 
-template <typename T>
-struct has_begin_end
-{
-    template<typename C> static char(&f(typename std::enable_if<
-        std::is_same<decltype(static_cast<typename C::const_iterator(C::*)() const>(&C::begin)),
-        typename C::const_iterator(C::*)() const>::value, void>::type*))[1];
+template <class T>
+concept NotContainer = !Container<T>;
 
-    template<typename C> static char(&f(...))[2];
+struct empty_type {};
 
-    template<typename C> static char(&g(typename std::enable_if<
-        std::is_same<decltype(static_cast<typename C::const_iterator(C::*)() const>(&C::end)),
-        typename C::const_iterator(C::*)() const>::value, void>::type*))[1];
+template <class... Types> class PacketValue;
 
-    template<typename C> static char(&g(...))[2];
-
-    static bool const beg_value = sizeof(f<T>(0)) == 1;
-    static bool const end_value = sizeof(g<T>(0)) == 1;
-};
-
-template<typename T>
-struct is_container : integral_constant<bool, has_const_iterator<T>::value&& has_begin_end<T>::beg_value&& has_begin_end<T>::end_value> {};
-
-template<class Type>
-concept Container = is_container<Type>::value;
-
-template<class Type>
-concept NotContainer = !is_container<Type>::value;
-
-template<class BaseType>
-concept CustomButNotContainer = NotContainer<BaseType> && NotIntegral<BaseType>;
-
-template<class... Types> class PacketValue;
-
-template<class ConversionType>
-class PacketValue<ConversionType> {
+template<>
+class PacketValue<> {
 public:
-    using value_type = ConversionType;
-    double* src;
-    double factor;
-    ConversionType converted_value;
-
+    using value_type = empty_type;
     PacketValue() = default;
-    PacketValue(double* src, double factor) :src(src), factor(factor != 0 ? factor : 1) {}
-
-    ConversionType* convert() {
-        converted_value = static_cast<ConversionType>((*src) * factor);
-        return &converted_value;
-    }
-
-    void load(ConversionType* new_data) {
-        *src = static_cast<double>(*new_data / factor);
-    }
-
-    inline constexpr size_t size() const {
-        return sizeof(ConversionType);
-    }
+    virtual void* get_pointer() = 0;
+    virtual size_t get_size() = 0;
+    virtual void parse(void* data) = 0;
+    virtual void copy_to(void* data) = 0;
 };
 
-template<class BaseType> requires CustomButNotContainer<BaseType>
-class PacketValue<BaseType> {
+template<class Type> requires NotContainer<Type>
+class PacketValue<Type>: public PacketValue<> {
 public:
-    using value_type = BaseType;
-    BaseType* src;
-
+    using value_type = Type;
+    Type* src = nullptr;
     PacketValue() = default;
-    PacketValue(BaseType* src) : src(src) {}
-
-    inline BaseType* convert() const {
+    PacketValue(Type* src): src(src) {}
+    void* get_pointer() override {
         return src;
     }
-
-    void load(BaseType* new_data) {
-        *src = *new_data;
+    size_t get_size() override {
+        return sizeof(Type);
     }
-
-    inline constexpr size_t size() const {
-        return sizeof(BaseType);
+    void parse(void* data) override {
+        *src = *((Type*)data);
     }
-};
-
-template<class BaseType> requires Container<BaseType>
-class PacketValue<BaseType> {
-public:
-    using value_type = BaseType;
-    BaseType* src;
-
-    PacketValue() = default;
-    PacketValue(BaseType* src) : src(src) {
-        if constexpr (is_same<string, BaseType>::value) {
-            is_string = true;
-        }
+    void copy_to(void* data) override {
+        *((Type*)data) = *src;
     }
-
-    auto* convert() {
-        return src->data();
-    }
-
-    void load(BaseType* new_data) {
-        memcpy(src->data(), new_data, size());
-    }
-
-    size_t size() const{
-        return src->size() * sizeof(typename remove_reference<decltype(*src)>::type::value_type) + is_string;
-    }
-private:
-    bool is_string = false;
 };
 
 #if __cpp_deduction_guides >= 201606
-template<Container BaseType>
-PacketValue(BaseType* src)->PacketValue<BaseType>;
-template<CustomButNotContainer BaseType>
-PacketValue(BaseType* src)->PacketValue<BaseType>;
+template<class Type> requires NotContainer<Type>
+PacketValue(Type)->PacketValue<Type>;
+#endif
+
+template<class Type> requires Container<Type>
+class PacketValue<Type>: public PacketValue<> {
+public:
+    using value_type = Type;
+    Type* src = nullptr;
+    PacketValue() = default;
+    PacketValue(Type* src): src(src) {}
+    void* get_pointer() override {
+        return src->data();
+    }
+    size_t get_size() override {
+        return src->size()*sizeof(typename Type::value_type);
+    }
+    void parse(void* data) override {
+        memcpy(src->data(), data, get_size());
+    }
+    void copy_to(void* data) override {
+        memcpy(data, src->data(), get_size());
+    }
+};
+
+template<>
+class PacketValue<string> : public PacketValue<>{
+public:
+    using value_type = string;
+    string* src = nullptr;
+    PacketValue() = default;
+    PacketValue(string* src): src(src) {}
+    void* get_pointer() override {
+        return src->data();
+    }
+    size_t get_size() override {
+        return strlen(src->c_str()) + 1;
+    }
+    void parse(void* data) override {
+        memcpy(src->data(), data, get_size());
+    }
+    void copy_to(void* data) override {
+        memcpy(data, src->data(), get_size());
+    }
+};
+
+#if __cpp_deduction_guides >= 201606
+template<class Type> requires Container<Type>
+PacketValue(Type)->PacketValue<Type>;
 #endif

--- a/Inc/HALAL/Services/Communication/Ethernet/TCP/Socket.hpp
+++ b/Inc/HALAL/Services/Communication/Ethernet/TCP/Socket.hpp
@@ -40,8 +40,7 @@ public:
 
 	void reconnect();
 
-	template<class Type, class... Types>
-	bool send_order(Order<Type,Types...>& order);
+	bool send_order(Order& order);
 
 	void send();
 
@@ -55,8 +54,7 @@ public:
 
 };
 
-template<class Type, class... Types>
-bool Socket::send_order(Order<Type,Types...>& order){
+bool Socket::send_order(Order& order){
 	if(state != CONNECTED){
 		reconnect();
 		return false;
@@ -71,13 +69,13 @@ bool Socket::send_order(Order<Type,Types...>& order){
 		return false;
 	}
 
-	order.build();
-	if(order.buffer_size > tcp_sndbuf(socket_control_block)){
+	uint8_t* order_buffer = order.build();
+	if(order.size > tcp_sndbuf(socket_control_block)){
 		return false;
 	}
 
-	tx_packet_buffer = pbuf_alloc(PBUF_TRANSPORT, order.buffer_size, PBUF_POOL);
-	pbuf_take(tx_packet_buffer, order.buffer, order.buffer_size);
+	tx_packet_buffer = pbuf_alloc(PBUF_TRANSPORT, order.size, PBUF_POOL);
+	pbuf_take(tx_packet_buffer, order_buffer, order.size);
 	send();
 	return true;
 }

--- a/Inc/HALAL/Services/Communication/Ethernet/UDP/DatagramSocket.hpp
+++ b/Inc/HALAL/Services/Communication/Ethernet/UDP/DatagramSocket.hpp
@@ -16,12 +16,10 @@ public:
 
 	DatagramSocket();
 	DatagramSocket(IPV4 local_ip, uint32_t local_port, IPV4 remote_ip, uint32_t remote_port);
-	DatagramSocket(string local_ip, uint32_t local_port, string remote_ip, uint32_t remote_port);
 	DatagramSocket(EthernetNode local_node, EthernetNode remote_node);
 	~DatagramSocket();
 
-	template<class Type, class... Types>
-	bool send(Packet<Type,Types...>& packet);
+	bool send(Packet& packet);
 
 	void close();
 
@@ -30,12 +28,11 @@ private:
 	
 };
 
-template<class Type, class... Types>
-bool DatagramSocket::send(Packet<Type, Types...> & packet){
-	packet.build();
+bool DatagramSocket::send(Packet& packet){
+	uint8_t* packet_buffer = packet.build();
 
-	struct pbuf* tx_buffer = pbuf_alloc(PBUF_TRANSPORT, packet.buffer_size, PBUF_RAM);
-	pbuf_take(tx_buffer, packet.buffer, packet.buffer_size);
+	struct pbuf* tx_buffer = pbuf_alloc(PBUF_TRANSPORT, packet.size, PBUF_RAM);
+	pbuf_take(tx_buffer, packet_buffer, packet.size);
 	udp_send(udp_control_block, tx_buffer);
 	pbuf_free(tx_buffer);
 

--- a/Inc/HALAL/Services/Communication/Ethernet/UDP/DatagramSocket.hpp
+++ b/Inc/HALAL/Services/Communication/Ethernet/UDP/DatagramSocket.hpp
@@ -19,7 +19,16 @@ public:
 	DatagramSocket(EthernetNode local_node, EthernetNode remote_node);
 	~DatagramSocket();
 
-	bool send(Packet& packet);
+	bool send(Packet& packet){
+		uint8_t* packet_buffer = packet.build();
+
+		struct pbuf* tx_buffer = pbuf_alloc(PBUF_TRANSPORT, packet.size, PBUF_RAM);
+		pbuf_take(tx_buffer, packet_buffer, packet.size);
+		udp_send(udp_control_block, tx_buffer);
+		pbuf_free(tx_buffer);
+
+		return true;
+	}
 
 	void close();
 
@@ -27,17 +36,6 @@ private:
 	static void receive_callback(void *args, struct udp_pcb *udp_control_block, struct pbuf *packet_buffer, const ip_addr_t *remote_address, u16_t port);
 	
 };
-
-bool DatagramSocket::send(Packet& packet){
-	uint8_t* packet_buffer = packet.build();
-
-	struct pbuf* tx_buffer = pbuf_alloc(PBUF_TRANSPORT, packet.size, PBUF_RAM);
-	pbuf_take(tx_buffer, packet_buffer, packet.size);
-	udp_send(udp_control_block, tx_buffer);
-	pbuf_free(tx_buffer);
-
-	return true;
-}
 
 
 #endif

--- a/Inc/ST-LIB_LOW/DigitalOutput/DigitalOutput.hpp
+++ b/Inc/ST-LIB_LOW/DigitalOutput/DigitalOutput.hpp
@@ -19,8 +19,8 @@ public:
 	void toggle();
 	void set_pin_state(PinState state);
 private:
-	uint8_t id;
 	Pin pin;
+	uint8_t id;
 };
 
 

--- a/Src/HALAL/Models/IPV4/IPV4.cpp
+++ b/Src/HALAL/Models/IPV4/IPV4.cpp
@@ -12,6 +12,38 @@ IPV4::IPV4(string address) : string_address(address){
 	IP_ADDR4(&(this->address), ip_bytes[0], ip_bytes[1], ip_bytes[2], ip_bytes[3]);
 }
 
+IPV4::IPV4(const char* address) {
+    char* temp_ip = (char*)malloc(strlen(address));
+    strcpy(temp_ip,address);
+    string_address = temp_ip;
+    const char* token = strtok(temp_ip,".");
+    int i = 0;
+    uint8_t ip_bytes[4];
+    while(token!=nullptr){
+        ip_bytes[i++] = atoi(token);
+        token = strtok(nullptr,".");
+    }
+    free(temp_ip);
+	IP_ADDR4(&(this->address), ip_bytes[0], ip_bytes[1], ip_bytes[2], ip_bytes[3]);
+}
+
 IPV4::IPV4() = default;
+
+void IPV4::operator =(const char* address){
+    char* temp_ip = (char*)malloc(strlen(address));
+    strcpy(temp_ip,address);
+    string_address = temp_ip;
+    const char* token = strtok(temp_ip,".");
+    int i = 0;
+    uint8_t ip_bytes[4];
+    while(token!=nullptr){
+        ip_bytes[i++] = atoi(token);
+        token = strtok(nullptr,".");
+    }
+    free(temp_ip);
+	IP_ADDR4(&(this->address), ip_bytes[0], ip_bytes[1], ip_bytes[2], ip_bytes[3]);
+}
+
+
 
 #endif

--- a/Src/HALAL/Models/Packets/Packet.cpp
+++ b/Src/HALAL/Models/Packets/Packet.cpp
@@ -1,4 +1,5 @@
-    #include "Packets/Packet.hpp"
+#include "Packets/Packet.hpp"
+#include "Packets/Order.hpp"
 
-map<decltype(Packet<>::id), function<void(uint8_t*)>> Packet<>::save_by_id = {};
-map<decltype(Packet<>::id), void(*)()> Packet<>::on_received = {};
+map<uint16_t,Order*> Order::orders = {};
+map<uint16_t,Packet*> Packet::packets = {};

--- a/Src/HALAL/Services/Communication/Ethernet/TCP/ServerSocket.cpp
+++ b/Src/HALAL/Services/Communication/Ethernet/TCP/ServerSocket.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "Communication/Ethernet/TCP/ServerSocket.hpp"
+#include "lwip/priv/tcp_priv.h"
 #ifdef HAL_ETH_MODULE_ENABLED
 
 uint8_t ServerSocket::priority = 0;
@@ -112,13 +113,16 @@ err_t ServerSocket::receive_callback(void* arg, struct tcp_pcb* client_control_b
 	ServerSocket* server_socket = (ServerSocket*) arg;
 	server_socket->client_control_block = client_control_block;
 
-	if(packet_buffer == nullptr){									//If RECEIVING buffer is empty, is a signal to close connection
+	if(packet_buffer == nullptr){      //FIN has been received
 		server_socket->state = CLOSING;
 		pbuf_free(server_socket->tx_packet_buffer);
-		server_socket->close();
+//		tcp_ack_now(client_control_block);
+//		tcp_output(client_control_block);
+//		server_socket->close();
 		return ERR_OK;
 	}
-	else if(error != ERR_OK){										//Check if packet is valid
+
+	if(error != ERR_OK){										//Check if packet is valid
 		if(packet_buffer != nullptr){
 			pbuf_free(packet_buffer);
 		}
@@ -133,7 +137,7 @@ err_t ServerSocket::receive_callback(void* arg, struct tcp_pcb* client_control_b
 		}
 		return ERR_OK;
 	}
-	else if(server_socket->state == CLOSING){
+	else if(server_socket->state == CLOSING){ 		//Socket is already closed
 		pbuf_free(server_socket->rx_packet_buffer);
 		server_socket->rx_packet_buffer = nullptr;
 		pbuf_free(packet_buffer);
@@ -144,9 +148,7 @@ err_t ServerSocket::receive_callback(void* arg, struct tcp_pcb* client_control_b
 
 void ServerSocket::error_callback(void *arg, err_t error){
 	ServerSocket* server_socket = (ServerSocket*) arg;
-	if(error == ERR_RST || error == ERR_ABRT){
-		server_socket->close();
-	}
+	server_socket->close();
 	//TODO: Error Handler
 }
 
@@ -154,21 +156,24 @@ err_t ServerSocket::poll_callback(void *arg, struct tcp_pcb *client_control_bloc
 	ServerSocket* server_socket = (ServerSocket*)arg;
 	server_socket->client_control_block = client_control_block;
 
-	if(server_socket != nullptr){
-		if(server_socket->tx_packet_buffer != nullptr){
-			server_socket->send();
-		}else{
-			if(server_socket->state == CLOSING){
-				server_socket->close();
-			}
-		}
-		return ERR_OK;
-	}
-	else{
+	if(server_socket == nullptr){    //Polling non existing pcb, fatal error
 		tcp_abort(client_control_block);
 		return ERR_ABRT;
 	}
 
+	if(server_socket->tx_packet_buffer != nullptr){		//TX FIFO is not empty
+		server_socket->send();
+	}
+
+	if(server_socket->rx_packet_buffer != nullptr){		//RX FIFO is not empty
+		server_socket->process_data();
+	}
+
+	if(server_socket->state == CLOSING){ //pcb has been polled to close
+		server_socket->close();
+	}
+
+	return ERR_OK;
 }
 
 err_t ServerSocket::send_callback(void *arg, struct tcp_pcb *client_control_block, u16_t len){

--- a/Src/HALAL/Services/Communication/Ethernet/TCP/ServerSocket.cpp
+++ b/Src/HALAL/Services/Communication/Ethernet/TCP/ServerSocket.cpp
@@ -34,10 +34,6 @@ ServerSocket::ServerSocket(string local_ip, uint32_t local_port) : ServerSocket(
 
 ServerSocket::ServerSocket(EthernetNode local_node) : ServerSocket(local_node.ip,local_node.port){};
 
-ServerSocket::~ServerSocket(){
-	close();
-}
-
 void ServerSocket::close(){
 	// Clean all callbacks
 	tcp_arg(client_control_block, nullptr);
@@ -60,14 +56,7 @@ void ServerSocket::close(){
 
 void ServerSocket::process_data(){
 	uint8_t* new_data = (uint8_t*)rx_packet_buffer->payload;
-	uint16_t id = Packet<>::get_id(new_data);
-	if(Packet<>::save_by_id.contains(id)){
-		Packet<>::save_by_id[id](new_data);
-	}
-
-	if(Packet<>::on_received.contains(id)){
-		Packet<>::on_received[id]();
-	}
+	Order::process_data(new_data);
 	tcp_recved(client_control_block, rx_packet_buffer->tot_len);
 	pbuf_free(rx_packet_buffer);
 	rx_packet_buffer = rx_packet_buffer->next;
@@ -102,7 +91,7 @@ err_t ServerSocket::accept_callback(void* arg, struct tcp_pcb* incomming_control
 		server_socket->state = ACCEPTED;
 		server_socket->client_control_block = incomming_control_block;
 		server_socket->tx_packet_buffer = nullptr;
-	
+
 		tcp_setprio(incomming_control_block, priority);
 		tcp_nagle_disable(incomming_control_block);
 		tcp_arg(incomming_control_block, server_socket);

--- a/Src/HALAL/Services/Communication/Ethernet/TCP/Socket.cpp
+++ b/Src/HALAL/Services/Communication/Ethernet/TCP/Socket.cpp
@@ -77,14 +77,7 @@ void Socket::send(){
 
 void Socket::process_data(){
 	uint8_t* new_data = (uint8_t*)rx_packet_buffer->payload;
-	uint16_t id = Packet<>::get_id(new_data);
-	if(Packet<>::save_by_id.contains(id)){
-		Packet<>::save_by_id[id](new_data);
-	}
-	
-	if(Packet<>::on_received.contains(id)){
-		Packet<>::on_received[id]();
-	}
+	Order::process_data(new_data);
 }
 
 err_t Socket::connect_callback(void* arg, struct tcp_pcb* client_control_block, err_t error){

--- a/Src/HALAL/Services/Communication/Ethernet/UDP/DatagramSocket.cpp
+++ b/Src/HALAL/Services/Communication/Ethernet/UDP/DatagramSocket.cpp
@@ -26,8 +26,6 @@ DatagramSocket::DatagramSocket(IPV4 local_ip, uint32_t local_port, IPV4 remote_i
 		}
 	}
 
-DatagramSocket::DatagramSocket(string local_ip, uint32_t local_port, string remote_ip, uint32_t remote_port): DatagramSocket(IPV4(local_ip), local_port, IPV4(remote_ip), remote_port){}
-
 DatagramSocket::DatagramSocket(EthernetNode local_node, EthernetNode remote_node): DatagramSocket(local_node.ip, local_node.port, remote_node.ip, remote_node.port){}
 
 DatagramSocket::~DatagramSocket(){
@@ -41,11 +39,7 @@ void DatagramSocket::close(){
 
 void DatagramSocket::receive_callback(void *args, struct udp_pcb *udp_control_block, struct pbuf *packet_buffer, const ip_addr_t *remote_address, u16_t port){
 	uint8_t* received_data = (uint8_t*)packet_buffer->payload;
-	uint16_t id = Packet<>::get_id(received_data);
-
-	if(Packet<>::save_by_id.contains(id)){
-		Packet<>::save_by_id[id](received_data);
-	}
+	Packet::parse_data(received_data);
 
 	pbuf_free(packet_buffer);
 }

--- a/Src/ST-LIB_LOW/StateMachine/StateMachine.cpp
+++ b/Src/ST-LIB_LOW/StateMachine/StateMachine.cpp
@@ -35,7 +35,7 @@ void StateMachine::add_state(uint8_t state) {
 		initial_state = state;
 		current_state = state;
 	}
-	states[state] = State();
+	states[state];
 }
 
 void StateMachine::add_enter_action(function<void()> action) {


### PR DESCRIPTION
This PR adds a rework to the Packet Models. Mainly it changes its focus such that it takes much more advantage of cache locality and optimizes overall number of instructions as well as compile time recursive calls, achieving an overall speed improvement of nearly 3000% in some cases and reducing compiled code size in up to 300%.

Now all Packets and Orders implement a common interface that can be used to store any type of Packet or order in a container of interface pointers.

The rework now adds two posible instantiation of Packets and Orders:
   · Stack variants: They don't use almost any heap allocations at the cost of using templates, thus making it harder to store and manipulate if not done through interface pointers. Best for raw perfomance however compiled code is much heavier with this variant, still much better than before as only PacketValues are recursively template stored.
   · Heap variants: They don't use any templates at the cost of heap allocations and worse overall performance. Can be easly manipulated and stored as they do not work with templates and have all the same time. They are almost always twice as slow.
   
Tests have been pased that try to cover several edge cases, they also serve as example code:

```cpp
int main() {
// Test empty StackPacket
{
    StackPacket packet;
    assert(packet.get_id() == 0);
    assert(packet.get_size() == 2);
    uint8_t* data = packet.build();
    assert(data[0] == 0);
    assert(data[1] == 0);
}

// Test StackPacket with one integer value
{
    int value = 42;
    StackPacket packet(1, &value);
    assert(packet.get_id() == 1);
    assert(packet.get_size() == 6);
    uint8_t* data = packet.build();
    assert(data[0] == 1);
    assert(data[1] == 0);
    assert(data[2] == 42);
    assert(data[3] == 0);
    assert(data[4] == 0);
    assert(data[5] == 0);
}

// Test StackPacket with two values (integer and string)
{
    int value = 42;
    string str = "Hello World";
    StackPacket packet(2, &value, &str);
    assert(packet.get_id() == 2);
    assert(packet.get_size() == 18);
    uint8_t* data = packet.build();
    assert(data[0] == 2);
    assert(data[1] == 0);
    assert(data[2] == 42);
    assert(data[3] == 0);
    assert(data[4] == 0);
    assert(data[5] == 0);
    assert(data[6] == 'H');
    assert(data[7] == 'e');
    assert(data[8] == 'l');
    assert(data[9] == 'l');
    assert(data[10] == 'o');
    assert(data[11] == ' ');
    assert(data[12] == 'W');
    assert(data[13] == 'o');
    assert(data[14] == 'r');
    assert(data[15] == 'l');
    assert(data[16] == 'd');
    assert(data[17] == 0);
}

// Test StackPacket with a container value (vector of integers)
{
    vector<int> values = {1, 2, 3, 4, 5};
    StackPacket packet(3, &values);
    assert(packet.get_id() == 3);
    assert(packet.get_size() == 22);
    uint8_t* data = packet.build();
    assert(data[0] == 3);
    assert(data[1] == 0);
    assert(data[2] == 1);
    assert(data[3] == 0);
    assert(data[4] == 0);
    assert(data[5] == 0);
    assert(data[6] == 2);
    assert(data[7] == 0);
    assert(data[8] == 0);
    assert(data[9] == 0);
    assert(data[10] == 3);
    assert(data[11] == 0);
    assert(data[12] == 0);
    assert(data[13] == 0);
    assert(data[14] == 4);
    assert(data[15] == 0);
    assert(data[16] == 0);
    assert(data[17] == 0);
    assert(data[18] == 5);
    assert(data[19] == 0);
    assert(data[20] == 0);
    assert(data[21] == 0);
}

//Test HeapPacket with one integer value
{
    int value = 42;
    HeapPacket packet(1, &value);
    assert(packet.get_id() == 1);
    assert(packet.get_size() == 6);
    uint8_t* data = packet.build();
    assert(data[0] == 1);
    assert(data[1] == 0);
    assert(data[2] == 42);
    assert(data[3] == 0);
    assert(data[4] == 0);
    assert(data[5] == 0);
}
//Time how much it takes to build a packet a million times
{
    int value = 42;
    StackPacket packet(1, &value);
    auto start = chrono::high_resolution_clock::now();
    for (int i = 0; i < 1000000; i++) {
        packet.build();
    }
    auto end = chrono::high_resolution_clock::now();
    auto duration = chrono::duration_cast<chrono::microseconds>(end - start);
    cout << "Time taken by function 1: " << duration.count() << " microseconds" << endl;
}

//Time how much it takes to parse a packet with lots of variables a million times
{
    int int_value = 42;
    string string_value = "hello";
    float float_value = 3.14;
    double double_value = 2.718;
    char char_value = 'a';
    bool bool_value = true;
    int8_t int8_value = 8;
    int16_t int16_value = 16;
    int32_t int32_value = 32;
    int64_t int64_value = 64;
    uint8_t uint8_value = 8;
    uint16_t uint16_value = 16;
    uint32_t uint32_value = 32;
    uint64_t uint64_value = 64;
    StackPacket packet(2, &int_value, &string_value, &float_value, &double_value, &char_value, &bool_value, &int8_value, &int16_value, &int32_value, &int64_value, &uint8_value, &uint16_value, &uint32_value, &uint64_value);
    auto start = chrono::high_resolution_clock::now();
    for (int i = 0; i < 1000000; i++) {
        packet.build();
    }
    auto end = chrono::high_resolution_clock::now();
    auto duration = chrono::duration_cast<chrono::microseconds>(end - start);
    cout << "Time taken by function 2: " << duration.count() << " microseconds" << endl;
}

//Compare timings of StackPacket and HeapPacket
{
    int value = 42;
    StackPacket stack_packet(1, &value);
    HeapPacket heap_packet(1, &value);
    auto start = chrono::high_resolution_clock::now();
    for (int i = 0; i < 1000000; i++) {
        stack_packet.build();
    }
    auto end = chrono::high_resolution_clock::now();
    auto duration = chrono::duration_cast<chrono::microseconds>(end - start);
    cout << "Time taken by StackPacket: " << duration.count() << " microseconds" << endl;
    start = chrono::high_resolution_clock::now();
    for (int i = 0; i < 1000000; i++) {
        heap_packet.build();
    }
    end = chrono::high_resolution_clock::now();
    duration = chrono::duration_cast<chrono::microseconds>(end - start);
    cout << "Time taken by HeapPacket: " << duration.count() << " microseconds" << endl;
}

//Compare timings of StackPacket and HeapPacket with lots of variables
{
    int int_value = 42;
    string string_value = "hello";
    float float_value = 3.14;
    double double_value = 2.718;
    char char_value = 'a';
    bool bool_value = true;
    int8_t int8_value = 8;
    int16_t int16_value = 16;
    int32_t int32_value = 32;
    int64_t int64_value = 64;
    uint8_t uint8_value = 8;
    uint16_t uint16_value = 16;
    uint32_t uint32_value = 32;
    uint64_t uint64_value = 64;
    StackPacket stack_packet(2, &int_value, &string_value, &float_value, &double_value, &char_value, &bool_value, &int8_value, &int16_value, &int32_value, &int64_value, &uint8_value, &uint16_value, &uint32_value, &uint64_value);
    HeapPacket heap_packet(2, &int_value, &string_value, &float_value, &double_value, &char_value, &bool_value, &int8_value, &int16_value, &int32_value, &int64_value, &uint8_value, &uint16_value, &uint32_value, &uint64_value);
    auto start = chrono::high_resolution_clock::now();
    for (int i = 0; i < 1000000; i++) {
        stack_packet.build();
    }
    auto end = chrono::high_resolution_clock::now();
    auto duration = chrono::duration_cast<chrono::microseconds>(end - start);
    cout << "Time taken by StackPacket: " << duration.count() << " microseconds" << endl;
    start = chrono::high_resolution_clock::now();
    for (int i = 0; i < 1000000; i++) {
        heap_packet.build();
    }
    end = chrono::high_resolution_clock::now();
    duration = chrono::duration_cast<chrono::microseconds>(end - start);
    cout << "Time taken by HeapPacket: " << duration.count() << " microseconds" << endl;
}

//Test StackOrder
{
    int int_value = 42;
    string string_value = "hello";
    float float_value = 3.14;
    double double_value = 2.718;
    char char_value = 'a';
    bool bool_value = true;
    int8_t int8_value = 8;
    int16_t int16_value = 16;
    int32_t int32_value = 32;
    int64_t int64_value = 64;
    uint8_t uint8_value = 8;
    uint16_t uint16_value = 16;
    uint32_t uint32_value = 32;
    uint64_t uint64_value = 64;
    StackOrder order(2, &int_value, &string_value, &float_value, &double_value, &char_value, &bool_value, &int8_value, &int16_value, &int32_value, &int64_value, &uint8_value, &uint16_value, &uint32_value, &uint64_value);
    order.build();
    order.set_callback(test_callback);
    order.process();
}

//Test HeapOrder
{
    int int_value = 42;
    string string_value = "hello";
    float float_value = 3.14;
    double double_value = 2.718;
    char char_value = 'a';
    bool bool_value = true;
    int8_t int8_value = 8;
    int16_t int16_value = 16;
    int32_t int32_value = 32;
    int64_t int64_value = 64;
    uint8_t uint8_value = 8;
    uint16_t uint16_value = 16;
    uint32_t uint32_value = 32;
    uint64_t uint64_value = 64;
    HeapOrder order(2, &int_value, &string_value, &float_value, &double_value, &char_value, &bool_value, &int8_value, &int16_value, &int32_value, &int64_value, &uint8_value, &uint16_value, &uint32_value, &uint64_value);
    order.build();
    order.set_callback(test_callback);
    order.process();
}
    cout << "All Tests run successfully!" << endl;
    return 0;
}

```

Here is the obtained output:
```
Time taken by function 1: 10486 microseconds
Time taken by function 2: 116943 microseconds
Time taken by StackPacket: 6611 microseconds
Time taken by HeapPacket: 55293 microseconds
Time taken by StackPacket: 103948 microseconds
Time taken by HeapPacket: 200876 microseconds
All Tests run successfully!
```


