### PR TITLE
moved concepts and data_structures

### DIFF
--- a/Inc/C++Utilities/CppUtils.hpp
+++ b/Inc/C++Utilities/CppUtils.hpp
@@ -36,6 +36,7 @@
 #include <cstdarg>
 #include <stdarg.h>
 
+
 namespace chrono = std::chrono;
 namespace placeholders = std::placeholders;
 
@@ -67,9 +68,4 @@ using std::unordered_map;
 using std::vector;
 using std::queue;
 using std::map;
-
-template<class Type>
-concept Integral = is_integral<Type>::value;
-
-template<class Type>
-concept NotIntegral = !is_integral<Type>::value;
+using std::stringstream;

--- a/Inc/HALAL/Models/Concepts/Concepts.hpp
+++ b/Inc/HALAL/Models/Concepts/Concepts.hpp
@@ -1,0 +1,65 @@
+#pragma once
+#include "C++Utilities/CppUtils.hpp"
+
+template<class Type>
+concept Integral = is_integral<Type>::value;
+
+template<class Type>
+concept NotIntegral = !is_integral<Type>::value;
+
+template <class T>
+concept Callable = requires(T a)
+{
+    { a() };
+};
+
+template <class T>
+concept NotCallable = !Callable<T>;
+
+template <class... Types>
+struct has_callable;
+
+template <class Type, class... Types>
+struct has_callable<Type,Types...>{
+	static constexpr bool value = Callable<Type> || has_callable<Types...>::value;
+};
+
+template <>
+struct has_callable<>{
+	static constexpr bool value = false;
+};
+
+template <class... Types>
+concept CallablePack = has_callable<Types...>::value;
+
+template <class... Types>
+concept NotCallablePack = !CallablePack<Types...>;
+
+template <class T>
+concept Container = requires(T a, const T b)
+{
+    requires std::regular<T>;
+    requires std::swappable<T>;
+    requires std::same_as<typename T::reference, typename T::value_type &>;
+    requires std::same_as<typename T::const_reference, const typename T::value_type &>;
+    requires std::forward_iterator<typename T::iterator>;
+    requires std::forward_iterator<typename T::const_iterator>;
+    requires std::signed_integral<typename T::difference_type>;
+    requires std::same_as<typename T::difference_type, typename std::iterator_traits<typename T::iterator>::difference_type>;
+    requires std::same_as<typename T::difference_type, typename std::iterator_traits<typename T::const_iterator>::difference_type>;
+    { a.begin() } -> std::same_as<typename T::iterator>;
+    { a.end() } -> std::same_as<typename T::iterator>;
+    { b.begin() } -> std::same_as<typename T::const_iterator>;
+    { b.end() } -> std::same_as<typename T::const_iterator>;
+    { a.cbegin() } -> std::same_as<typename T::const_iterator>;
+    { a.cend() } -> std::same_as<typename T::const_iterator>;
+    { a.size() } -> std::same_as<typename T::size_type>;
+    { a.max_size() } -> std::same_as<typename T::size_type>;
+    { a.empty() } -> std::convertible_to<bool>;
+};
+
+template <class T>
+concept NotContainer = !Container<T>;
+
+template <class T, class... U>
+concept PackDerivesFrom = (std::derived_from<T, U> && ...);

--- a/Inc/HALAL/Models/DataStructures/StackTuple.hpp
+++ b/Inc/HALAL/Models/DataStructures/StackTuple.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "C++Utilities/CppUtils.hpp"
+
+template<class... Types> class stack_tuple;
+
+template<>
+class stack_tuple<> {
+public:
+    stack_tuple() = default;
+    template<class FunctionType>
+    void for_each(FunctionType function) {}
+};
+
+template<class Type, class... Types>
+class stack_tuple<Type, Types...>: public stack_tuple<Types...> {
+public:
+    Type value;
+    stack_tuple() = default;
+    stack_tuple(Type value, Types... values): stack_tuple<Types...>(values...), value(value) {}
+    template<class FunctionType>
+    void for_each(FunctionType function) {
+        function(value);
+        stack_tuple<Types...>::for_each(function);
+    }
+};

--- a/Inc/HALAL/Models/DataStructures/TemplatePackFilter.hpp
+++ b/Inc/HALAL/Models/DataStructures/TemplatePackFilter.hpp
@@ -1,0 +1,25 @@
+#pragma once
+#include "C++Utilities/CppUtils.hpp"
+
+template<class... Types>
+struct TemplatePack{
+    using Pack = Types...;
+};
+
+template<class FilterType, class... ToFilter>
+struct TemplatePackFilter;
+
+template<class FilterType, class First, class... ToFilter> requires requires { requires !is_same<FilterType, First>::value; }
+struct TemplatePackFilter<FilterType, First, ToFilter...>{
+    using FilteredPack = typename TemplatePackFilter<FilterType, ToFilter...>::FilteredPack;
+};
+
+template<class FilterType, class... ToFilter>
+struct TemplatePackFilter<FilterType, FilterType, ToFilter...>{
+    using FilteredPack = TemplatePack<FilterType, typename TemplatePackFilter<FilterType, ToFilter...>::FilteredPack>::Pack;
+};
+
+template<class FilterType>
+struct TemplatePackFilter<FilterType>{
+    using FilteredPack = TemplatePack<>::Pack;
+};

--- a/Inc/HALAL/Models/Packets/Packet.hpp
+++ b/Inc/HALAL/Models/Packets/Packet.hpp
@@ -1,29 +1,7 @@
 #pragma once
 
 #include "PacketValue.hpp"
-
-template<class... Types> class stack_tuple;
-
-template<> 
-class stack_tuple<> {
-public:
-    stack_tuple() = default;
-    template<class FunctionType>
-    void for_each(FunctionType function) {}
-};
-
-template<class Type, class... Types>
-class stack_tuple<Type, Types...>: public stack_tuple<Types...> {
-public:
-    Type value;
-    stack_tuple() = default;
-    stack_tuple(Type value, Types... values): stack_tuple<Types...>(values...), value(value) {}
-    template<class FunctionType>
-    void for_each(FunctionType function) {
-        function(value);
-        stack_tuple<Types...>::for_each(function);
-    }
-};
+#include "DataStructures/StackTuple.hpp"
 
 class Packet{
 public:

--- a/Inc/HALAL/Models/Packets/PacketValue.hpp
+++ b/Inc/HALAL/Models/Packets/PacketValue.hpp
@@ -1,32 +1,7 @@
 #pragma once
 
 #include "C++Utilities/CppUtils.hpp"
-
-template <class T>
-concept Container = requires(T a, const T b)
-{
-    requires std::regular<T>;
-    requires std::swappable<T>;
-    requires std::same_as<typename T::reference, typename T::value_type &>;
-    requires std::same_as<typename T::const_reference, const typename T::value_type &>;
-    requires std::forward_iterator<typename T::iterator>;
-    requires std::forward_iterator<typename T::const_iterator>;
-    requires std::signed_integral<typename T::difference_type>;
-    requires std::same_as<typename T::difference_type, typename std::iterator_traits<typename T::iterator>::difference_type>;
-    requires std::same_as<typename T::difference_type, typename std::iterator_traits<typename T::const_iterator>::difference_type>;
-    { a.begin() } -> std::same_as<typename T::iterator>;
-    { a.end() } -> std::same_as<typename T::iterator>;
-    { b.begin() } -> std::same_as<typename T::const_iterator>;
-    { b.end() } -> std::same_as<typename T::const_iterator>;
-    { a.cbegin() } -> std::same_as<typename T::const_iterator>;
-    { a.cend() } -> std::same_as<typename T::const_iterator>;
-    { a.size() } -> std::same_as<typename T::size_type>;
-    { a.max_size() } -> std::same_as<typename T::size_type>;
-    { a.empty() } -> std::convertible_to<bool>;
-};
-
-template <class T>
-concept NotContainer = !Container<T>;
+#include "Concepts/Concepts.hpp"
 
 struct empty_type {};
 


### PR DESCRIPTION
Created Separate Model for Concepts and Data Structures
Added Several new Data Structures and concepts:
·TemplatePackFilter : receives a Template Argument Pack and filters types that are equal to argument type, can be used to count how many types are of one type or as template to filter a template argument pack given a certain concept
·PackDerivesFrom concept: returns true if all types in a given template parameter pack inherit from a given type
·Callable: returns true if type is invokable
·Has Callable: returns true if a given template parameter pack has any invokable type in it