### PR TITLE
protection manager changes

### DIFF
--- a/Inc/ST-LIB_HIGH/Protections/Notification.hpp
+++ b/Inc/ST-LIB_HIGH/Protections/Notification.hpp
@@ -12,6 +12,7 @@ class Notification : public Order{
 private:
 	typedef uint16_t message_size_t;
 	uint16_t id;
+	uint8_t end = 0x00;
     void(*callback)() = nullptr;
     string tx_message;
     message_size_t tx_message_size;
@@ -51,6 +52,7 @@ public:
     	memcpy(buffer,&id,sizeof(id));
     	memcpy(buffer + sizeof(id), &tx_message_size, sizeof(tx_message_size));
      	memcpy(buffer+sizeof(id)+sizeof(tx_message_size),tx_message.c_str(), tx_message.size());
+     	memcpy(buffer+sizeof(id)+sizeof(tx_message_size)+tx_message.size(),&end,sizeof(end));
     	return buffer;
     }
 
@@ -79,7 +81,7 @@ public:
     }
 
     size_t get_size() {
-    	size = sizeof(id) +  sizeof(tx_message_size) +  tx_message_size;
+    	size = sizeof(id) +  sizeof(tx_message_size) +  tx_message_size + sizeof(end);
     	return size;
     }
 

--- a/Inc/ST-LIB_HIGH/Protections/Protection.hpp
+++ b/Inc/ST-LIB_HIGH/Protections/Protection.hpp
@@ -4,9 +4,9 @@
 #include "ErrorHandler/ErrorHandler.hpp"
 #include "Boundary.hpp"
 
-namespace protections{
+namespace Protections{
 enum FaultType{
-	FAULT,
+	FAULT = 0,
 	WARNING
 };
 }
@@ -17,7 +17,7 @@ private:
     char* name = nullptr;
     vector<unique_ptr<BoundaryInterface>> boundaries;
     BoundaryInterface* jumped_protection = nullptr;
-    static constexpr protections::FaultType fault_type = protections::FaultType::FAULT;
+    static constexpr Protections::FaultType fault_type = Protections::FaultType::FAULT;
 public:
     template<class Type, ProtectionType... Protector, template<class,ProtectionType> class Boundaries>
     Protection(Type* src, Boundaries<Type,Protector>... protectors) {

--- a/Inc/ST-LIB_HIGH/Protections/Protection.hpp
+++ b/Inc/ST-LIB_HIGH/Protections/Protection.hpp
@@ -4,10 +4,12 @@
 #include "ErrorHandler/ErrorHandler.hpp"
 #include "Boundary.hpp"
 
+namespace protections{
 enum FaultType{
 	FAULT,
 	WARNING
 };
+}
 
 class Protection{
 private:
@@ -15,7 +17,7 @@ private:
     char* name = nullptr;
     vector<unique_ptr<BoundaryInterface>> boundaries;
     BoundaryInterface* jumped_protection = nullptr;
-    static constexpr FaultType fault_type = FaultType::FAULT;
+    static constexpr protections::FaultType fault_type = protections::FaultType::FAULT;
 public:
     template<class Type, ProtectionType... Protector, template<class,ProtectionType> class Boundaries>
     Protection(Type* src, Boundaries<Type,Protector>... protectors) {

--- a/Inc/ST-LIB_HIGH/Protections/ProtectionManager.hpp
+++ b/Inc/ST-LIB_HIGH/Protections/ProtectionManager.hpp
@@ -60,6 +60,7 @@ private:
 
     static Notification fault_notification;
     static Notification warning_notification;
+    static StackOrder<0> fault_order;
 
     static int get_string_size(Protection& prot ,const Time::RTCData& timestamp){
     	return snprintf(nullptr,0,format,"","","") + prot.get_string_size() + Time::RTCData::get_string_size(timestamp);

--- a/Inc/ST-LIB_HIGH/Protections/ProtectionManager.hpp
+++ b/Inc/ST-LIB_HIGH/Protections/ProtectionManager.hpp
@@ -11,15 +11,25 @@
 #define add_protection(src,...)  \
 		{\
             Protection& ref = ProtectionManager::_add_protection(src,__VA_ARGS__); \
-            ref.set_name((char*)malloc(sizeof(getname(src))-1)); \
-            sprintf(ref.get_name(),"%s",getname(src)+1); \
+            if (getname(src)[0] == '&'){ \
+            	ref.set_name((char*)malloc(sizeof(getname(src))-1));\
+            	sprintf(ref.get_name(),"%s",getname(src)+1); \
+            }else{\
+            	ref.set_name((char*)malloc(sizeof(getname(src))));\
+            	sprintf(ref.get_name(),"%s",getname(src)); \
+            }\
 		}\
 
 #define add_high_frequency_protection(src,...)  \
 		{\
             Protection& ref = ProtectionManager::_add_high_frequency_protection(src,__VA_ARGS__); \
-            ref.set_name((char*)malloc(sizeof(getname(src))-1)); \
-            sprintf(ref.get_name(),"%s",getname(src)+1); \
+            if (getname(src)[0] == '&'){ \
+            	ref.set_name((char*)malloc(sizeof(getname(src))-1)); \
+            	sprintf(ref.get_name(),"%s",getname(src)+1); \
+            }else{\
+            	ref.set_name((char*)malloc(sizeof(getname(src))));\
+            	sprintf(ref.get_name(),"%s",getname(src)); \
+            }\
 		}\
 
 class ProtectionManager {
@@ -42,9 +52,10 @@ public:
         return high_frequency_protections.back();
     }
 
+    static void add_standard_protections();
     static void check_protections();
     static void check_high_frequency_protections();
-    static void propagate_fault();
+    static void fault_and_propagate();
 
 private:
 	static constexpr uint16_t warning_id = 1;

--- a/Inc/ST-LIB_HIGH/Protections/ProtectionManager.hpp
+++ b/Inc/ST-LIB_HIGH/Protections/ProtectionManager.hpp
@@ -44,6 +44,7 @@ public:
 
     static void check_protections();
     static void check_high_frequency_protections();
+    static void propagate_fault();
 
 private:
 	static constexpr uint16_t warning_id = 1;

--- a/Inc/ST-LIB_HIGH/Protections/ProtectionManager.hpp
+++ b/Inc/ST-LIB_HIGH/Protections/ProtectionManager.hpp
@@ -62,7 +62,7 @@ private:
 	static constexpr uint16_t fault_id = 2;
 	static char* message;
 	static size_t message_size;
-	static constexpr const char* format = "{\"boardId\": %s, \"timestamp\":{%s}, %s}\0";
+	static constexpr const char* format = "{\"boardId\": %s, \"timestamp\":{%s}, %s}";
 
     static Boards::ID board_id;
     static vector<Protection> low_frequency_protections;

--- a/Inc/ST-LIB_HIGH/ST-LIB_HIGH.hpp
+++ b/Inc/ST-LIB_HIGH/ST-LIB_HIGH.hpp
@@ -23,3 +23,7 @@
 #include "Control/Blocks/MeanCalculator.hpp"
 #include "Control/ControlSystem.hpp"
 #include "FlashStorer/FlashStorer.hpp"
+
+namespace STLIB_HIGH {
+	void start();
+}

--- a/Src/HALAL/Services/Communication/SNTP/SNTP.cpp
+++ b/Src/HALAL/Services/Communication/SNTP/SNTP.cpp
@@ -9,7 +9,7 @@
 
 #define SUBSECONDS_PER_SECOND 32767
 #define TRANSFORMATION_FACTOR (SUBSECONDS_PER_SECOND/999999.0)
-#define TARGET_IP "192.168.1.3"
+#define TARGET_IP "192.168.0.9"
 
 void SNTP::sntp_update(uint8_t address_head, uint8_t address_second, uint8_t address_third, uint8_t address_last){
 	sntp_setoperatingmode(SNTP_OPMODE_POLL);

--- a/Src/ST-LIB.cpp
+++ b/Src/ST-LIB.cpp
@@ -13,6 +13,7 @@
 void STLIB::start(string ip, string subnet_mask, string gateway, UART::Peripheral& printf_peripheral) {
 	HALAL::start(ip, subnet_mask, gateway, printf_peripheral);
 	STLIB_LOW::start();
+	STLIB_HIGH::start();
 }
 
 void STLIB::update() {

--- a/Src/ST-LIB_HIGH/Protections/ProtectionManager.cpp
+++ b/Src/ST-LIB_HIGH/Protections/ProtectionManager.cpp
@@ -3,7 +3,7 @@
 #include "Protections/Notification.hpp"
 
 StateMachine* ProtectionManager::general_state_machine = nullptr;
-Notification ProtectionManager::fault_notification = {ProtectionManager::fault_id, ProtectionManager::to_fault};
+Notification ProtectionManager::fault_notification = {ProtectionManager::fault_id, nullptr};
 Notification ProtectionManager::warning_notification = {ProtectionManager::warning_id, nullptr};
 StackOrder<0> ProtectionManager::fault_order(Protections::FAULT,to_fault);
 void *error_handler;

--- a/Src/ST-LIB_HIGH/Protections/ProtectionManager.cpp
+++ b/Src/ST-LIB_HIGH/Protections/ProtectionManager.cpp
@@ -19,11 +19,15 @@ void ProtectionManager::link_state_machine(StateMachine& general_state_machine, 
 void ProtectionManager::to_fault(){
     if(general_state_machine->current_state != fault_state_id){
 	    ProtectionManager::general_state_machine->force_change_state(fault_state_id);
-		for(OrderProtocol* socket : OrderProtocol::sockets){
-			socket->send_order(fault_order);
-		}
+	    propagate_fault();
 	}
 
+}
+
+void ProtectionManager::propagate_fault(){
+	for(OrderProtocol* socket : OrderProtocol::sockets){
+		socket->send_order(fault_order);
+	}
 }
 
 void ProtectionManager::check_protections() {

--- a/Src/ST-LIB_HIGH/Protections/ProtectionManager.cpp
+++ b/Src/ST-LIB_HIGH/Protections/ProtectionManager.cpp
@@ -21,7 +21,6 @@ void ProtectionManager::to_fault(){
 	    ProtectionManager::general_state_machine->force_change_state(fault_state_id);
 		for(OrderProtocol* socket : OrderProtocol::sockets){
 			socket->send_order(fault_order);
-			socket->send_order(fault_order);
 		}
 	}
 

--- a/Src/ST-LIB_HIGH/ST-LIB_HIGH.cpp
+++ b/Src/ST-LIB_HIGH/ST-LIB_HIGH.cpp
@@ -1,0 +1,12 @@
+/*
+ * ST-LIB_LOW.cpp
+ *
+ *  Created on: 19 jun. 2023
+ *      Author: ricardo
+ */
+
+#include "ST-LIB_HIGH.hpp"
+
+void STLIB_HIGH::start() {
+	ProtectionManager::add_standard_protections();
+}


### PR DESCRIPTION
Changes added:

Changed IP of SNTP to the actual server IP (tested)

Put enum of faultType into a namespace so the global space isn t polluted with enums that are not meant to be used there (like FAULT)

Made that when the protection handler goes to fault it first sends a packet with ID 0 to all sockets to get all boards into fault faster. (tested)

add Error as a part of protection handler (tested)

changed build of notification to add a 0x00 byte at the end as the last version of chango-gui needs it to differenciate a packet end. (chango works with it and doesn t without in v12)

For now the ProtectionManager sends this fast packet once when it forces the GeneralStateMachine into fault. There is also a method called propagate_fault for anyone that needs it, but if any other behaviour is prefered for all boards let me know here.

![image](https://github.com/HyperloopUPV-H8/ST-LIB/assets/116189892/5f4a7132-304d-4c51-9809-6a1202d12f61)

