### PR TITLE
Fix/general

### DIFF
--- a/Inc/HALAL/HALAL.hpp
+++ b/Inc/HALAL/HALAL.hpp
@@ -27,5 +27,5 @@
 #include "CORDIC/CORDIC.hpp"
 
 namespace HALAL {
-	void start(string ip, string subnet_mask, string gateway, UART::Peripheral& printf_peripheral);
+	void start(IPV4 ip, IPV4 subnet_mask, IPV4 gateway, UART::Peripheral& printf_peripheral);
 }

--- a/Inc/ST-LIB.hpp
+++ b/Inc/ST-LIB.hpp
@@ -6,6 +6,8 @@
 
 class STLIB {
 public:
+
+	static void start(IPV4 ip, IPV4 subnet_mask, IPV4 gateaway, UART::Peripheral& printf_peripheral);
 	static void start(
 			string ip = "192.168.1.4",
 			string subnet_mask = "255.255.0.0",

--- a/Inc/ST-LIB_HIGH/Protections/Notification.hpp
+++ b/Inc/ST-LIB_HIGH/Protections/Notification.hpp
@@ -12,7 +12,6 @@ class Notification : public Order{
 private:
 	typedef uint16_t message_size_t;
 	uint16_t id;
-	uint8_t end = 0x00;
     void(*callback)() = nullptr;
     string tx_message;
     message_size_t tx_message_size;
@@ -52,7 +51,6 @@ public:
     	memcpy(buffer,&id,sizeof(id));
     	memcpy(buffer + sizeof(id), &tx_message_size, sizeof(tx_message_size));
      	memcpy(buffer+sizeof(id)+sizeof(tx_message_size),tx_message.c_str(), tx_message.size());
-     	memcpy(buffer+sizeof(id)+sizeof(tx_message_size)+tx_message.size(),&end,sizeof(end));
     	return buffer;
     }
 
@@ -81,7 +79,7 @@ public:
     }
 
     size_t get_size() {
-    	size = sizeof(id) +  sizeof(tx_message_size) +  tx_message_size + sizeof(end);
+    	size = sizeof(id) +  sizeof(tx_message_size) +  tx_message_size;
     	return size;
     }
 

--- a/Inc/ST-LIB_HIGH/Protections/ProtectionManager.hpp
+++ b/Inc/ST-LIB_HIGH/Protections/ProtectionManager.hpp
@@ -36,6 +36,9 @@ class ProtectionManager {
 public:
 	typedef uint8_t state_id;
 
+	static const uint64_t notify_delay_in_nanoseconds = 100000000;
+	static uint64_t last_notify;
+
     static void set_id(Boards::ID id);
 
     static void link_state_machine(StateMachine& general_state_machine, state_id fault_id);
@@ -58,8 +61,8 @@ public:
     static void fault_and_propagate();
 
 private:
-	static constexpr uint16_t warning_id = 1;
-	static constexpr uint16_t fault_id = 2;
+	static constexpr uint16_t warning_id = 2;
+	static constexpr uint16_t fault_id = 3;
 	static char* message;
 	static size_t message_size;
 	static constexpr const char* format = "{\"boardId\": %s, \"timestamp\":{%s}, %s}";

--- a/Src/HALAL/HALAL.cpp
+++ b/Src/HALAL/HALAL.cpp
@@ -63,8 +63,8 @@ void HALAL::start(IPV4 ip, IPV4 subnet_mask, IPV4 gateway, UART::Peripheral& pri
 
 #ifdef HAL_TIM_MODULE_ENABLED
 	Encoder::start();
-	SNTP::sntp_update();
 	Time::start_rtc();
+	SNTP::sntp_update();
 	TimerPeripheral::start();
 	Time::start();
 #endif

--- a/Src/HALAL/HALAL.cpp
+++ b/Src/HALAL/HALAL.cpp
@@ -7,7 +7,7 @@
 
 #include "HALAL/HALAL.hpp"
 
-void HALAL::start(string ip, string subnet_mask, string gateway, UART::Peripheral& printf_peripheral) {
+void HALAL::start(IPV4 ip, IPV4 subnet_mask, IPV4 gateway, UART::Peripheral& printf_peripheral) {
 
 #ifdef HAL_ETH_MODULE_ENABLED
 	Ethernet::inscribe();

--- a/Src/ST-LIB.cpp
+++ b/Src/ST-LIB.cpp
@@ -10,10 +10,14 @@
 
 #include "ST-LIB.hpp"
 
-void STLIB::start(string ip, string subnet_mask, string gateway, UART::Peripheral& printf_peripheral) {
+void STLIB::start(IPV4 ip, IPV4 subnet_mask, IPV4 gateway, UART::Peripheral& printf_peripheral) {
 	HALAL::start(ip, subnet_mask, gateway, printf_peripheral);
 	STLIB_LOW::start();
 	STLIB_HIGH::start();
+}
+
+void STLIB::start(string ip, string subnet_mask, string gateaway,  UART::Peripheral& printf_peripheral){
+	STLIB::start(IPV4(ip),IPV4(subnet_mask),IPV4(gateaway),printf_peripheral);
 }
 
 void STLIB::update() {

--- a/Src/ST-LIB_HIGH/Protections/ProtectionManager.cpp
+++ b/Src/ST-LIB_HIGH/Protections/ProtectionManager.cpp
@@ -6,6 +6,7 @@ StateMachine* ProtectionManager::general_state_machine = nullptr;
 Notification ProtectionManager::fault_notification = {ProtectionManager::fault_id, nullptr};
 Notification ProtectionManager::warning_notification = {ProtectionManager::warning_id, nullptr};
 StackOrder<0> ProtectionManager::fault_order(Protections::FAULT,to_fault);
+uint64_t ProtectionManager::last_notify = 0;
 void *error_handler;
 
 
@@ -53,6 +54,7 @@ void ProtectionManager::check_protections() {
         message = (char*)malloc(get_string_size(protection, current_timestamp));
         serialize(protection, current_timestamp);
 
+        if(Time::get_global_tick() > last_notify + notify_delay_in_nanoseconds){
         switch(protection.fault_type){
         case Protections::FaultType::WARNING:
         	warning_notification.notify(message);
@@ -63,7 +65,8 @@ void ProtectionManager::check_protections() {
         default:
         	ErrorHandler("Protection has not a Fault Type that can be handled correctly by the ProtectionManager");
         }
-
+        last_notify = Time::get_global_tick();
+        }
     	free(message);
     }
 }


### PR DESCRIPTION
Changed HAL start to use IPV4 instead of strings (didn t compile). ST-LIB start still works with strings and just cast them into IPV4 before sending it to HAL start

Solved SNTP parsing issue (needed a time distance lower than 36 years and RTC set too late for that, now changed)

Removed 0x00 at the end of notification, as it is no longer needed by the gui and messes with it

Added a minimun delay between protection notifications so they don t get send at the same speed as the check_protections run (can lead to failure if you try to send it to fast)

Changed Fault and Warning notification ids to properly work with the GUI


-------------------------------------------------------------------------

There is still a bug that forces into Hard Fault on line 300 of time.cpp (Time::high_precision_alarms_by_timer[tim].alarm();) and on line 48 of notification.hpp (if(buffer != nullptr) free(buffer);). The Hard Fault is a BusFault error (instruction prefetch or memory access failures) which are most probably caused by two consecutive free's or a malloc not having enough space

These don t occur on every run of a nucleo, instead occuring around 25% of the time you start the micro. Also, seems that the second one is solved by adding +100 to the get_string_size return value, which is very weird as the get_string_size method isn t even invocated to begin with. This bug will be attended on another pull request to not make this one too big. 

Also, trying to debug the Time::high_precision_alarms_by_timer[tim] results in a debugger crash.

If anyone sees any line of code on this pull request that could be at fault of any of those errors, put it on this pull request and do not accept it. 

https://interrupt.memfault.com/blog/cortex-m-hardfault-debug#bad-address-read-example
https://stackoverflow.com/questions/51057418/stm32-hardfault-at-free
