### PR TITLE
Fix/tcp queue

### DIFF
--- a/Inc/HALAL/Services/Communication/Ethernet/TCP/ServerSocket.hpp
+++ b/Inc/HALAL/Services/Communication/Ethernet/TCP/ServerSocket.hpp
@@ -15,6 +15,9 @@
 
 #define PBUF_POOL_MEMORY_DESC_POSITION 8
 
+/**
+* @brief ServerSocket class
+*/
 class ServerSocket : public OrderProtocol{
 public:
 
@@ -45,18 +48,32 @@ public:
 
 	void operator=(ServerSocket&& other);
 
+	/**
+	* @brief ends the connection between the server and the client. 
+	*/
 	void close();
 
+	/**
+	* @brief process the data received by the client orders. It is meant to be called only by Lwip on the receive_callback
+	*
+	* reads all the data received by the server in the ethernet buffer, packet by packet.
+	* Then, for each packet, it processes it depending on the order id (default behavior is not process) and removes it from the buffer. 
+	* This makes so the receive_callback (and thus the Socket) can only process declared orders, and ignores all other packets. 
+	*/
 	void process_data();
 
-	/*
-	 * @brief puts the order data into the tx_packet_buffer so it can be sent when a connection is accepted
+	/**
+	 * @brief saves the order data into the tx_packet_buffer so it can be sent when a connection is accepted
+	 *
+	 * @param order the order to send, which contains the data and id of the message
 	 * @return true if the data could be allocated in the buffer, false otherwise
 	 */
 	bool queue_order(Order& order);
 
-	/*
-	 * @brief puts the order data into the tx_packet_buffer and sends it
+	/**
+	 * @brief puts the order data into the tx_packet_buffer and sends all the data in the buffer to the client
+	 *
+	 * @param order the order to send, which contains the data and id of the message
 	 * @return true if the data was sent successfully, false otherwise
 	 */
 	bool send_order(Order& order) override{
@@ -85,8 +102,14 @@ public:
 		return true;
 	}
 
+	/**
+	* @brief sends all the binary data saved in the tx_packet_buffer to the connected client. 
+	*/
 	void send();
 
+	/**
+	* @return true if a connection with the client was established, false otherwise
+	*/
 	bool is_connected();
 
 private:

--- a/Inc/HALAL/Services/Communication/Ethernet/TCP/ServerSocket.hpp
+++ b/Inc/HALAL/Services/Communication/Ethernet/TCP/ServerSocket.hpp
@@ -68,7 +68,7 @@ public:
 	 * @param order the order to send, which contains the data and id of the message
 	 * @return true if the data could be allocated in the buffer, false otherwise
 	 */
-	bool queue_order(Order& order);
+	bool add_order_to_queue(Order& order);
 
 	/**
 	 * @brief puts the order data into the tx_packet_buffer and sends all the data in the buffer to the client

--- a/Inc/HALAL/Services/Communication/Ethernet/TCP/ServerSocket.hpp
+++ b/Inc/HALAL/Services/Communication/Ethernet/TCP/ServerSocket.hpp
@@ -49,6 +49,15 @@ public:
 
 	void process_data();
 
+	/*
+	 * @brief puts the order data into the tx_packet_buffer so it can be sent when a connection is accepted
+	 */
+	void queue_order(Order& order);
+
+	/*
+	 * @brief puts the order data into the tx_packet_buffer and sends it
+	 * @return true if the data was sent successfully, false otherwise
+	 */
 	bool send_order(Order& order) override{
 		if(state != ACCEPTED){
 			return false;

--- a/Inc/HALAL/Services/Communication/Ethernet/TCP/ServerSocket.hpp
+++ b/Inc/HALAL/Services/Communication/Ethernet/TCP/ServerSocket.hpp
@@ -26,7 +26,6 @@ public:
 	};
 
 	static unordered_map<uint32_t,ServerSocket*> listening_sockets;
-	static queue<ServerSocket*> sockets_to_flush;
 	struct tcp_pcb* server_control_block = nullptr;
 	queue<struct pbuf*> tx_packet_buffer;
 	queue<struct pbuf*> rx_packet_buffer;

--- a/Inc/HALAL/Services/Communication/Ethernet/TCP/ServerSocket.hpp
+++ b/Inc/HALAL/Services/Communication/Ethernet/TCP/ServerSocket.hpp
@@ -51,8 +51,9 @@ public:
 
 	/*
 	 * @brief puts the order data into the tx_packet_buffer so it can be sent when a connection is accepted
+	 * @return true if the data could be allocated in the buffer, false otherwise
 	 */
-	void queue_order(Order& order);
+	bool queue_order(Order& order);
 
 	/*
 	 * @brief puts the order data into the tx_packet_buffer and sends it

--- a/Inc/HALAL/Services/Communication/Ethernet/TCP/ServerSocket.hpp
+++ b/Inc/HALAL/Services/Communication/Ethernet/TCP/ServerSocket.hpp
@@ -26,6 +26,7 @@ public:
 	};
 
 	static unordered_map<uint32_t,ServerSocket*> listening_sockets;
+	static queue<ServerSocket*> sockets_to_flush;
 	struct tcp_pcb* server_control_block = nullptr;
 	queue<struct pbuf*> tx_packet_buffer;
 	queue<struct pbuf*> rx_packet_buffer;

--- a/Inc/HALAL/Services/Communication/Ethernet/TCP/Socket.hpp
+++ b/Inc/HALAL/Services/Communication/Ethernet/TCP/Socket.hpp
@@ -52,7 +52,7 @@ public:
 	 * @brief puts the order data into the tx_packet_buffer so it can be sent when a connection is accepted
 	 * @return true if the data could be allocated in the buffer, false otherwise
 	 */
-	bool queue_order(Order& order);
+	bool add_order_to_queue(Order& order);
 
 	/*
 	 * @brief puts the order data into the tx_packet_buffer and sends it

--- a/Inc/HALAL/Services/Communication/Ethernet/TCP/Socket.hpp
+++ b/Inc/HALAL/Services/Communication/Ethernet/TCP/Socket.hpp
@@ -23,6 +23,8 @@ public:
 		CLOSING
 	};
 
+	IPV4 local_ip;
+	uint32_t local_port;
 	IPV4 remote_ip;
 	uint32_t remote_port;
 	tcp_pcb* connection_control_block;
@@ -31,6 +33,7 @@ public:
 	queue<struct pbuf*> tx_packet_buffer;
 	queue<struct pbuf*> rx_packet_buffer;
 	static unordered_map<EthernetNode,Socket*> connecting_sockets;
+	bool pending_connection_reset = false;
 
 	Socket();
 	Socket(Socket&& other);
@@ -43,7 +46,18 @@ public:
 	void close();
 
 	void reconnect();
+	void reset();
 
+	/*
+	 * @brief puts the order data into the tx_packet_buffer so it can be sent when a connection is accepted
+	 * @return true if the data could be allocated in the buffer, false otherwise
+	 */
+	bool queue_order(Order& order);
+
+	/*
+	 * @brief puts the order data into the tx_packet_buffer and sends it
+	 * @return true if the data was sent successfully, false otherwise
+	 */
 	bool send_order(Order& order) override{
 		if(state != CONNECTED){
 			reconnect();
@@ -82,6 +96,9 @@ public:
 	static err_t poll_callback(void* arg, struct tcp_pcb* client_control_block);
 	static err_t send_callback(void* arg, struct tcp_pcb* client_control_block, uint16_t length);
 	static void error_callback(void *arg, err_t error);
+
+	static err_t connection_poll_callback(void* arg, struct tcp_pcb* connection_control_block);
+	static void connection_error_callback(void *arg, err_t error);
 
 };
 #endif

--- a/Src/HALAL/Services/Communication/Ethernet/TCP/ServerSocket.cpp
+++ b/Src/HALAL/Services/Communication/Ethernet/TCP/ServerSocket.cpp
@@ -12,7 +12,6 @@
 
 uint8_t ServerSocket::priority = 1;
 unordered_map<uint32_t,ServerSocket*> ServerSocket::listening_sockets = {};
-queue<ServerSocket*> ServerSocket::sockets_to_flush = {};
 
 ServerSocket::ServerSocket() = default;
 
@@ -165,8 +164,6 @@ err_t ServerSocket::accept_callback(void* arg, struct tcp_pcb* incomming_control
 		tcp_poll(incomming_control_block, poll_callback , 0);
 
 		priority++;
-
-		sockets_to_flush.push(server_socket);
 
 		return ERR_OK;
 	}else

--- a/Src/HALAL/Services/Communication/Ethernet/TCP/ServerSocket.cpp
+++ b/Src/HALAL/Services/Communication/Ethernet/TCP/ServerSocket.cpp
@@ -159,7 +159,7 @@ err_t ServerSocket::accept_callback(void* arg, struct tcp_pcb* incomming_control
 
 		server_socket->state = ACCEPTED;
 		server_socket->client_control_block = incomming_control_block;
-		server_socket->tx_packet_buffer = {};
+
 		server_socket->rx_packet_buffer = {};
 
 		tcp_setprio(incomming_control_block, priority);
@@ -169,6 +169,9 @@ err_t ServerSocket::accept_callback(void* arg, struct tcp_pcb* incomming_control
 		tcp_sent(incomming_control_block, send_callback);
 		tcp_err(incomming_control_block, error_callback);
 		tcp_poll(incomming_control_block, poll_callback , 0);
+
+		server_socket->send(); //send buffered packets before erasing buffer
+		server_socket->tx_packet_buffer = {};
 
 		priority++;
 

--- a/Src/HALAL/Services/Communication/Ethernet/TCP/ServerSocket.cpp
+++ b/Src/HALAL/Services/Communication/Ethernet/TCP/ServerSocket.cpp
@@ -107,24 +107,17 @@ void ServerSocket::process_data(){
 	}
 }
 
-void ServerSocket::queue_order(Order& order){
+bool ServerSocket::queue_order(Order& order){
 	if(state == ACCEPTED){
 		return false; //yet to decide if queue_order should send the order when used after the connection is accepted or just return false
 	}
 	struct memp* next_memory_pointer_in_packet_buffer_pool = (*(memp_pools[PBUF_POOL_MEMORY_DESC_POSITION]->tab))->next;
 	if(next_memory_pointer_in_packet_buffer_pool == nullptr){
-		if(client_control_block->unsent != nullptr){
-			tcp_output(client_control_block);
-		}else{
-			memp_free_pool(memp_pools[PBUF_POOL_MEMORY_DESC_POSITION], next_memory_pointer_in_packet_buffer_pool);
-		}
+		memp_free_pool(memp_pools[PBUF_POOL_MEMORY_DESC_POSITION], next_memory_pointer_in_packet_buffer_pool);
 		return false;
 	}
 
 	uint8_t* order_buffer = order.build();
-	if(order.get_size() > tcp_sndbuf(client_control_block)){
-		return false;
-	}
 
 	struct pbuf* packet = pbuf_alloc(PBUF_TRANSPORT, order.get_size(), PBUF_POOL);
 	pbuf_take(packet, order_buffer, order.get_size());

--- a/Src/HALAL/Services/Communication/Ethernet/TCP/ServerSocket.cpp
+++ b/Src/HALAL/Services/Communication/Ethernet/TCP/ServerSocket.cpp
@@ -12,6 +12,7 @@
 
 uint8_t ServerSocket::priority = 1;
 unordered_map<uint32_t,ServerSocket*> ServerSocket::listening_sockets = {};
+queue<ServerSocket*> ServerSocket::sockets_to_flush = {};
 
 ServerSocket::ServerSocket() = default;
 
@@ -163,10 +164,9 @@ err_t ServerSocket::accept_callback(void* arg, struct tcp_pcb* incomming_control
 		tcp_err(incomming_control_block, error_callback);
 		tcp_poll(incomming_control_block, poll_callback , 0);
 
-		server_socket->send(); //send buffered packets before erasing buffer
-		server_socket->tx_packet_buffer = {};
-
 		priority++;
+
+		sockets_to_flush.push(server_socket);
 
 		return ERR_OK;
 	}else

--- a/Src/HALAL/Services/Communication/Ethernet/TCP/ServerSocket.cpp
+++ b/Src/HALAL/Services/Communication/Ethernet/TCP/ServerSocket.cpp
@@ -107,9 +107,9 @@ void ServerSocket::process_data(){
 	}
 }
 
-bool ServerSocket::queue_order(Order& order){
+bool ServerSocket::add_order_to_queue(Order& order){
 	if(state == ACCEPTED){
-		return false; //yet to decide if queue_order should send the order when used after the connection is accepted or just return false
+		return false; //yet to decide if add_order_to_queue should send the order when used after the connection is accepted or just return false
 	}
 	struct memp* next_memory_pointer_in_packet_buffer_pool = (*(memp_pools[PBUF_POOL_MEMORY_DESC_POSITION]->tab))->next;
 	if(next_memory_pointer_in_packet_buffer_pool == nullptr){

--- a/Src/HALAL/Services/Communication/Ethernet/TCP/Socket.cpp
+++ b/Src/HALAL/Services/Communication/Ethernet/TCP/Socket.cpp
@@ -135,7 +135,7 @@ void Socket::process_data(){
 	}
 }
 
-bool Socket::queue_order(Order& order){
+bool Socket::add_order_to_queue(Order& order){
 	if(state == Socket::SocketState::CONNECTED){
 		return false;
 	}
@@ -245,7 +245,7 @@ void Socket::error_callback(void *arg, err_t error){
 
 void Socket::connection_error_callback(void *arg, err_t error){
 	if(error == ERR_RST){
-		Socket* socket = (Socket*) arg;
+		Socket* socket = arg;
 		socket->pending_connection_reset = true;
 		return;
 	}

--- a/Src/HALAL/Services/Communication/Ethernet/TCP/Socket.cpp
+++ b/Src/HALAL/Services/Communication/Ethernet/TCP/Socket.cpp
@@ -245,7 +245,7 @@ void Socket::error_callback(void *arg, err_t error){
 
 void Socket::connection_error_callback(void *arg, err_t error){
 	if(error == ERR_RST){
-		Socket* socket = arg;
+		Socket* socket = (Socket*) arg;
 		socket->pending_connection_reset = true;
 		return;
 	}

--- a/Src/ST-LIB.cpp
+++ b/Src/ST-LIB.cpp
@@ -21,6 +21,11 @@ void STLIB::start(string ip, string subnet_mask, string gateaway,  UART::Periphe
 }
 
 void STLIB::update() {
+	while(!ServerSocket::sockets_to_flush.empty()){
+		ServerSocket* to_flush = ServerSocket::sockets_to_flush.front();
+		to_flush->send();
+		ServerSocket::sockets_to_flush.pop();
+	}
     Ethernet::update();
 	ErrorHandlerModel::ErrorHandlerUpdate();
 }

--- a/Src/ST-LIB.cpp
+++ b/Src/ST-LIB.cpp
@@ -21,11 +21,6 @@ void STLIB::start(string ip, string subnet_mask, string gateaway,  UART::Periphe
 }
 
 void STLIB::update() {
-	while(!ServerSocket::sockets_to_flush.empty()){
-		ServerSocket* to_flush = ServerSocket::sockets_to_flush.front();
-		to_flush->send();
-		ServerSocket::sockets_to_flush.pop();
-	}
     Ethernet::update();
 	ErrorHandlerModel::ErrorHandlerUpdate();
 }


### PR DESCRIPTION
added a method to queue packets so they get sent when the connection is accepted

added new method to tcp_client "reset", which hards reconnect into the server (destroys pcb and creates a new one)

yet to discuss behaviour when a FIN or RST close connection is received (should it retry reconnecting or throw an error into the Errorhandler)? 