### PR TITLE
tcp server multiconnection

### DIFF
--- a/Inc/C++Utilities/CppUtils.hpp
+++ b/Inc/C++Utilities/CppUtils.hpp
@@ -39,8 +39,8 @@
 namespace chrono = std::chrono;
 namespace placeholders = std::placeholders;
 
-using std::map;
 using std::array;
+using std::map;
 using std::span;
 using std::pair;
 using std::function;
@@ -57,13 +57,9 @@ using std::integral_constant;
 using std::snprintf;
 using std::make_unique;
 using std::unique_ptr;
-using std::unordered_map;
-using std::vector;
-using std::queue;
 using std::hash;
 using std::unordered_map;
 using std::vector;
 using std::queue;
-using std::map;
 using std::stringstream;
 using std::move;

--- a/Inc/HALAL/Models/IPV4/IPV4.hpp
+++ b/Inc/HALAL/Models/IPV4/IPV4.hpp
@@ -26,6 +26,7 @@ public:
 	IPV4();
 	IPV4(const char* address);
 	IPV4(string address);
+	IPV4(ip_addr_t address);
 
 	void operator=(const char* address);
 };

--- a/Inc/HALAL/Services/Communication/Ethernet/TCP/ServerSocket.hpp
+++ b/Inc/HALAL/Services/Communication/Ethernet/TCP/ServerSocket.hpp
@@ -25,7 +25,8 @@ public:
 		INACTIVE,
 		LISTENING,
 		ACCEPTED,
-		CLOSING
+		CLOSING,
+		CLOSED
 	};
 
 	static unordered_map<uint32_t,ServerSocket*> listening_sockets;

--- a/Inc/HALAL/Services/Communication/Ethernet/TCP/ServerSocket.hpp
+++ b/Inc/HALAL/Services/Communication/Ethernet/TCP/ServerSocket.hpp
@@ -34,6 +34,7 @@ public:
 	queue<struct pbuf*> rx_packet_buffer;
 	IPV4 local_ip;
 	uint32_t local_port;
+	IPV4 remote_ip;
 	ServerState state;
 	static uint8_t priority;
 	struct tcp_pcb* client_control_block;

--- a/Inc/HALAL/Services/Communication/Ethernet/TCP/ServerSocket.hpp
+++ b/Inc/HALAL/Services/Communication/Ethernet/TCP/ServerSocket.hpp
@@ -34,7 +34,6 @@ public:
 	queue<struct pbuf*> rx_packet_buffer;
 	IPV4 local_ip;
 	uint32_t local_port;
-	IPV4 remote_ip;
 	ServerState state;
 	static uint8_t priority;
 	struct tcp_pcb* client_control_block;

--- a/Inc/ST-LIB_LOW/Communication/Server/Server.hpp
+++ b/Inc/ST-LIB_LOW/Communication/Server/Server.hpp
@@ -1,0 +1,27 @@
+/*
+ * Server.hpp
+ *
+ * Created on: Oct 12, 2023
+ * 		Author: Ricardo
+ */
+
+#pragma once
+#include "Communication/Ethernet/TCP/ServerSocket.hpp"
+#include "ErrorHandler/ErrorHandler.hpp"
+
+class Server{
+public:
+	ServerSocket *open_connection;
+	vector<ServerSocket*> running_connections;
+	IPV4 local_ip;
+	uint32_t local_port;
+
+	static vector<Server*> running_servers;
+
+	Server(IPV4 local_ip, uint32_t local_port);
+	~Server();
+	void update();
+	uint32_t connections_count();
+
+	static void update_servers();
+};

--- a/Inc/ST-LIB_LOW/Communication/Server/Server.hpp
+++ b/Inc/ST-LIB_LOW/Communication/Server/Server.hpp
@@ -23,7 +23,7 @@ public:
 	};
 
 	ServerSocket *open_connection;
-	array<ServerSocket*,10> running_connections;
+	array<ServerSocket*,MAX_CONNECTIONS_TCP_SERVER> running_connections;
 	uint16_t running_connections_count;
 	IPV4 local_ip;
 	uint32_t local_port;

--- a/Inc/ST-LIB_LOW/Communication/Server/Server.hpp
+++ b/Inc/ST-LIB_LOW/Communication/Server/Server.hpp
@@ -11,16 +11,26 @@
 
 class Server{
 public:
+
+	enum ServerState{
+		RUNNING,
+		CLOSING,
+		CLOSED
+	};
+
 	ServerSocket *open_connection;
 	vector<ServerSocket*> running_connections;
 	IPV4 local_ip;
 	uint32_t local_port;
+	ServerState status;
 
 	static vector<Server*> running_servers;
 
 	Server(IPV4 local_ip, uint32_t local_port);
 	~Server();
 	void update();
+	void broadcast_order(Order& order);
+	void close_all();
 	uint32_t connections_count();
 
 	static void update_servers();

--- a/Inc/ST-LIB_LOW/Communication/Server/Server.hpp
+++ b/Inc/ST-LIB_LOW/Communication/Server/Server.hpp
@@ -9,6 +9,10 @@
 #include "Communication/Ethernet/TCP/ServerSocket.hpp"
 #include "ErrorHandler/ErrorHandler.hpp"
 
+#ifndef MAX_CONNECTIONS_TCP_SERVER
+	#define MAX_CONNECTIONS_TCP_SERVER 10
+#endif
+
 class Server{
 public:
 
@@ -19,7 +23,8 @@ public:
 	};
 
 	ServerSocket *open_connection;
-	vector<ServerSocket*> running_connections;
+	array<ServerSocket*,10> running_connections;
+	uint16_t running_connections_count;
 	IPV4 local_ip;
 	uint32_t local_port;
 	ServerState status;

--- a/Inc/ST-LIB_LOW/ST-LIB_LOW.hpp
+++ b/Inc/ST-LIB_LOW/ST-LIB_LOW.hpp
@@ -19,6 +19,7 @@
 #include "Sensors/EncoderSensor/EncoderSensor.hpp"
 #include "Sensors/PWMSensor/PWMSensor.hpp"
 #include "Sensors/NTC/NTC.hpp"
+#include "Communication/Server/Server.hpp"
 
 class STLIB_LOW {
 public:

--- a/LWIP/Target/lwipopts.h
+++ b/LWIP/Target/lwipopts.h
@@ -49,6 +49,10 @@
 /* Parameters set in STM32CubeMX LwIP Configuration GUI -*/
 /*----- Default value in ETH configuration GUI in CubeMx: 1524 -----*/
 #define ETH_RX_BUFFER_SIZE 1536
+ /*----- Value in opt.h for LWIP_TCP_KEEPALIVE: 0 -----*/
+ #define LWIP_TCP_KEEPALIVE 1
+
+ #define MEMP_NUM_NETCONN 4
 /*----- Value in opt.h for NO_SYS: 0 -----*/
 #define NO_SYS 1
 /*----- Value in opt.h for SO_REUSE: 0 -----*/

--- a/LWIP/Target/lwipopts.h
+++ b/LWIP/Target/lwipopts.h
@@ -51,6 +51,8 @@
 #define ETH_RX_BUFFER_SIZE 1536
 /*----- Value in opt.h for NO_SYS: 0 -----*/
 #define NO_SYS 1
+/*----- Value in opt.h for SO_REUSE: 0 -----*/
+#define SO_REUSE 1
 /*----- Value in opt.h for SYS_LIGHTWEIGHT_PROT: 1 -----*/
 #define SYS_LIGHTWEIGHT_PROT 0
 /*----- Value in opt.h for MEM_ALIGNMENT: 1 -----*/

--- a/Src/HALAL/Models/IPV4/IPV4.cpp
+++ b/Src/HALAL/Models/IPV4/IPV4.cpp
@@ -27,6 +27,11 @@ IPV4::IPV4(const char* address) {
 	IP_ADDR4(&(this->address), ip_bytes[0], ip_bytes[1], ip_bytes[2], ip_bytes[3]);
 }
 
+IPV4::IPV4(ip_addr_t address) : address(address){
+	string_address = std::to_string((u8_t) address.addr) + "." + std::to_string((u8_t) (address.addr >> 8))+ "."
+			+ std::to_string((uint8_t) (address.addr >> 16)) + "." + std::to_string((uint8_t) (address.addr >> 24));
+}
+
 IPV4::IPV4() = default;
 
 void IPV4::operator =(const char* address){

--- a/Src/HALAL/Services/Communication/Ethernet/TCP/ServerSocket.cpp
+++ b/Src/HALAL/Services/Communication/Ethernet/TCP/ServerSocket.cpp
@@ -221,7 +221,7 @@ err_t ServerSocket::receive_callback(void* arg, struct tcp_pcb* client_control_b
 void ServerSocket::error_callback(void *arg, err_t error){
 	ServerSocket* server_socket = (ServerSocket*) arg;
 	server_socket->close();
-	//ErrorHandler("Socket error: %d. Socket closed", error);
+	ErrorHandler("Socket error: %d. Socket closed", error);
 }
 
 err_t ServerSocket::poll_callback(void *arg, struct tcp_pcb *client_control_block){

--- a/Src/HALAL/Services/Communication/Ethernet/TCP/ServerSocket.cpp
+++ b/Src/HALAL/Services/Communication/Ethernet/TCP/ServerSocket.cpp
@@ -34,7 +34,7 @@ ServerSocket::ServerSocket(IPV4 local_ip, uint32_t local_port) : local_ip(local_
 		tcp_accept(server_control_block, accept_callback);
 	}else{
 		memp_free(MEMP_TCP_PCB, server_control_block);
-		ErrorHandler("Cannnot bind server socket, memory low");
+		ErrorHandler("Cannot bind server socket, memory low");
 	}
 	OrderProtocol::sockets.push_back(this);
 }
@@ -148,7 +148,6 @@ bool ServerSocket::is_connected(){
 err_t ServerSocket::accept_callback(void* arg, struct tcp_pcb* incomming_control_block, err_t error){
 	if(listening_sockets.contains(incomming_control_block->local_port)){
 		ServerSocket* server_socket = listening_sockets[incomming_control_block->local_port];
-		listening_sockets.erase(incomming_control_block->local_port);
 
 		server_socket->state = ACCEPTED;
 		server_socket->client_control_block = incomming_control_block;
@@ -212,6 +211,7 @@ void ServerSocket::error_callback(void *arg, err_t error){
 err_t ServerSocket::poll_callback(void *arg, struct tcp_pcb *client_control_block){
 	ServerSocket* server_socket = (ServerSocket*)arg;
 	server_socket->client_control_block = client_control_block;
+
 
 	if(server_socket == nullptr){    //Polling non existing pcb, fatal error
 		tcp_abort(client_control_block);

--- a/Src/HALAL/Services/Communication/Ethernet/TCP/ServerSocket.cpp
+++ b/Src/HALAL/Services/Communication/Ethernet/TCP/ServerSocket.cpp
@@ -102,9 +102,8 @@ void ServerSocket::close(){
     tcp_pcb_remove(&tcp_active_pcbs, client_control_block);
     tcp_free(client_control_block);
 
-    tcp_accept(server_control_block, accept_callback);
 	listening_sockets[local_port] = this;
-	state = LISTENING;
+	state = CLOSED;
 
 	priority--;
 

--- a/Src/HALAL/Services/Communication/Ethernet/TCP/ServerSocket.cpp
+++ b/Src/HALAL/Services/Communication/Ethernet/TCP/ServerSocket.cpp
@@ -165,7 +165,7 @@ err_t ServerSocket::accept_callback(void* arg, struct tcp_pcb* incomming_control
 
 		server_socket->state = ACCEPTED;
 		server_socket->client_control_block = incomming_control_block;
-
+		server_socket->remote_ip = IPV4(incomming_control_block->remote_ip);
 		server_socket->rx_packet_buffer = {};
 
 		tcp_setprio(incomming_control_block, priority);

--- a/Src/HALAL/Services/Communication/Ethernet/TCP/Socket.cpp
+++ b/Src/HALAL/Services/Communication/Ethernet/TCP/Socket.cpp
@@ -10,6 +10,7 @@
 
 unordered_map<EthernetNode,Socket*> Socket::connecting_sockets = {};
 
+
 Socket::Socket() = default;
 
 Socket::Socket(Socket&& other):remote_port(move(remote_port)), connection_control_block(move(other.connection_control_block)),
@@ -40,6 +41,8 @@ Socket::Socket(IPV4 local_ip, uint32_t local_port, IPV4 remote_ip, uint32_t remo
 		return;
 	}
 	state = INACTIVE;
+	tx_packet_buffer = {};
+	rx_packet_buffer = {};
 	EthernetNode remote_node(remote_ip, remote_port);
 
 	connection_control_block = tcp_new();
@@ -118,7 +121,12 @@ void Socket::send(){
 			tcp_output(socket_control_block);
 			memp_free_pool(memp_pools[PBUF_POOL_MEMORY_DESC_POSITION],temporal_packet_buffer);
 		}else{
-			ErrorHandler("Cannot write to client socket. Error code: %d",error);
+			if(error == ERR_MEM){
+				close();
+				ErrorHandler("Too many unacked messages on client socket, disconnecting...");
+			}else{
+				ErrorHandler("Cannot write to client socket. Error code: %d",error);
+			}
 		}
 	}
 }
@@ -174,6 +182,7 @@ err_t Socket::connect_callback(void* arg, struct tcp_pcb* client_control_block, 
 		tcp_poll(client_control_block, poll_callback,0);
 		tcp_sent(client_control_block, send_callback);
 		tcp_err(client_control_block, error_callback);
+
 		return ERR_OK;
 	}else return ERROR;
 }
@@ -248,6 +257,8 @@ void Socket::connection_error_callback(void *arg, err_t error){
 	if(error == ERR_RST){
 		Socket* socket = (Socket*)arg;
 		socket->pending_connection_reset = true;
+		return;
+	}else if(error == ERR_ABRT){
 		return;
 	}
 	ErrorHandler("Connection socket error: %d. Couldn t start client socket ", error);

--- a/Src/HALAL/Services/Communication/Ethernet/TCP/Socket.cpp
+++ b/Src/HALAL/Services/Communication/Ethernet/TCP/Socket.cpp
@@ -245,7 +245,7 @@ void Socket::error_callback(void *arg, err_t error){
 
 void Socket::connection_error_callback(void *arg, err_t error){
 	if(error == ERR_RST){
-		Socket* socket = arg;
+		Socket* socket = (Socket*)arg;
 		socket->pending_connection_reset = true;
 		return;
 	}

--- a/Src/HALAL/Services/Communication/Ethernet/TCP/Socket.cpp
+++ b/Src/HALAL/Services/Communication/Ethernet/TCP/Socket.cpp
@@ -76,6 +76,7 @@ void Socket::close(){
 	}
 
   tcp_close(socket_control_block);
+  state = INACTIVE;
 }
 
 void Socket::reconnect(){
@@ -239,8 +240,9 @@ void Socket::error_callback(void *arg, err_t error){
 	Socket* socket = (Socket*) arg;
 	if(error == ERR_RST || error == ERR_ABRT){
 		socket->close();
-	}
+	}else{
 	ErrorHandler("Client socket error: %d. Socket closed",error);
+	}
 }
 
 void Socket::connection_error_callback(void *arg, err_t error){

--- a/Src/ST-LIB.cpp
+++ b/Src/ST-LIB.cpp
@@ -23,4 +23,5 @@ void STLIB::start(string ip, string subnet_mask, string gateaway,  UART::Periphe
 void STLIB::update() {
     Ethernet::update();
 	ErrorHandlerModel::ErrorHandlerUpdate();
+	Server::update_servers();
 }

--- a/Src/ST-LIB_LOW/Communication/Server/Server.cpp
+++ b/Src/ST-LIB_LOW/Communication/Server/Server.cpp
@@ -1,0 +1,52 @@
+/*
+ * Server.cpp
+ *
+ * Created on: Oct 12, 2023
+ * 		Author: Ricardo
+ */
+
+#include "Communication/Server/Server.hpp"
+
+vector<Server*> Server::running_servers = {};
+
+Server::Server(IPV4 local_ip, uint32_t local_port): local_ip(local_ip), local_port(local_port){
+	open_connection = new ServerSocket(local_ip, local_port);
+	running_servers.push_back(this);
+}
+
+Server::~Server(){
+	open_connection->~ServerSocket();
+
+	for(ServerSocket *s : running_connections){
+		s->~ServerSocket();
+	}
+
+	running_servers.erase(find(running_servers.begin(), running_servers.end(), this));
+}
+
+void Server::update(){
+	if(open_connection->is_connected()){
+		running_connections.push_back(open_connection);
+		open_connection = new ServerSocket(local_ip, local_port);
+	}
+
+	for(auto& ss : running_connections){
+		if(!ss->is_connected()){
+			ErrorHandler("ip %s disconnected, going to FAULT",ss->remote_ip.string_address);
+			running_connections.erase(find(running_connections.begin(), running_connections.end(), ss));
+			auto is_empty = running_connections.empty();
+			ss->~ServerSocket();
+			(*running_connections.begin())->send();
+		}
+	}
+}
+
+uint32_t Server::connections_count(){
+	return running_connections.size();
+}
+
+void Server::update_servers(){
+	for(Server *s : running_servers){
+		s->update();
+	}
+}

--- a/Src/ST-LIB_LOW/Communication/Server/Server.cpp
+++ b/Src/ST-LIB_LOW/Communication/Server/Server.cpp
@@ -32,7 +32,7 @@ void Server::update(){
 
 	for(auto& ss : running_connections){
 		if(!ss->is_connected()){
-			ErrorHandler("ip disconnected, going to FAULT");
+			ErrorHandler("ip %s disconnected, going to FAULT",ss->remote_ip.string_address.c_str());
 		}
 	}
 }

--- a/Src/ST-LIB_LOW/Communication/Server/Server.cpp
+++ b/Src/ST-LIB_LOW/Communication/Server/Server.cpp
@@ -32,11 +32,7 @@ void Server::update(){
 
 	for(auto& ss : running_connections){
 		if(!ss->is_connected()){
-			ErrorHandler("ip %s disconnected, going to FAULT",ss->remote_ip.string_address);
-			running_connections.erase(find(running_connections.begin(), running_connections.end(), ss));
-			auto is_empty = running_connections.empty();
-			ss->~ServerSocket();
-			(*running_connections.begin())->send();
+			ErrorHandler("ip disconnected, going to FAULT");
 		}
 	}
 }

--- a/Src/ST-LIB_LOW/Communication/Server/Server.cpp
+++ b/Src/ST-LIB_LOW/Communication/Server/Server.cpp
@@ -12,6 +12,8 @@ vector<Server*> Server::running_servers = {};
 Server::Server(IPV4 local_ip, uint32_t local_port): local_ip(local_ip), local_port(local_port), status(RUNNING){
 	open_connection = new ServerSocket(local_ip, local_port);
 	running_servers.push_back(this);
+	running_connections = {};
+	running_connections_count = 0;
 }
 
 Server::~Server(){
@@ -26,13 +28,14 @@ Server::~Server(){
 
 void Server::update(){
 	if(open_connection->is_connected()){
-		running_connections.push_back(open_connection);
+		running_connections[running_connections_count] = open_connection;
+		running_connections_count++;
 		open_connection = new ServerSocket(local_ip, local_port);
 	}
 
-	for(auto& ss : running_connections){
-		if(status == RUNNING && !ss->is_connected()){
-			ErrorHandler("ip %s disconnected, going to FAULT",ss->remote_ip.string_address.c_str());
+	for(uint16_t s = 0; s < running_connections_count; s++){
+		if(status == RUNNING && !running_connections[s]->is_connected()){
+			ErrorHandler("ip %s disconnected, going to FAULT",running_connections[s]->remote_ip.string_address.c_str());
 			status = CLOSING;
 			break;
 		}
@@ -44,23 +47,24 @@ void Server::update(){
 }
 
 void Server::broadcast_order(Order& order){
-	for(auto& ss : running_connections){
-		if(!ss->send_order(order)){
-			ErrorHandler("Couldn t put Order %d into buffer of ip's %s ServerSocket, buffer may be full or the ServerSocket may be ill formed",order.get_id(),ss->remote_ip.string_address.c_str());
+	for(uint16_t s = 0; s < running_connections_count; s++){
+		if(running_connections[s]->send_order(order)){
+			ErrorHandler("Couldn t put Order %d into buffer of ip's %s ServerSocket, buffer may be full or the ServerSocket may be ill formed",order.get_id(),running_connections[s]->remote_ip.string_address.c_str());
 		}
 	}
 }
 
 void Server::close_all(){
-	for(auto& ss : running_connections){
-		ss->close();
-		running_connections.erase(find(running_connections.begin(),running_connections.end(),ss));
+	for(uint16_t s = 0; s < running_connections_count; s++){
+		running_connections[s]->close();
+		running_connections[s] = nullptr;
 	}
+	running_connections_count = 0;
 	status = CLOSED;
 }
 
 uint32_t Server::connections_count(){
-	return running_connections.size();
+	return running_connections_count;
 }
 
 void Server::update_servers(){


### PR DESCRIPTION
added a new class called Server which acts as a multi client server on same port. 
It includes broadcast and simple logic for disconnects.

Also fixes a few ServerSocket and Socket bugs, and adds a new constructor for IPV4. 

the keepalive is yet to be implemented, and will be in another pull request. This one is already bloated enough.


multi connection server code (blinks when he receives a hello order, and sends one each second to all connections)
```
uint32_t data = 0;
DigitalOutput* connection_led;
DigitalOutput* message_led;

void tog() {
	message_led->toggle();
}


int main(void)
{

connection_led = new DigitalOutput(PE1);
	message_led = new DigitalOutput(PB14);


	STLIB::start();

	StackOrder<0> hello_order(100,tog);
	Server computer_socket(IPV4("192.168.0.3"),30000);

	Time::register_low_precision_alarm(1000, [&](){
			computer_socket.broadcast_order(hello_order);
		});

	while(1){
		STLIB::update();
		if(computer_socket.connections_count() > 0){
			connection_led->turn_on();
		}else{
			connection_led->turn_off();
		}
	}
}
```

client code (change ip for each new board)
```
connection_led = new DigitalOutput(PE1);
	DigitalOutput client_led(PB14);
	STLIB::start();
	StackOrder<0> hello_order(100);
	StackOrder<4,uint32_t> data_order(200,&data);
	Socket computer_server(IPV4("192.168.0.4"),30000,IPV4("192.168.0.3"),30000);
	Time::register_low_precision_alarm(1000, [&](){
		if(computer_server.is_connected()){
			computer_server.send_order(hello_order);
		}else{
			computer_server.add_order_to_queue(hello_order);
		}
	});

	client_led.turn_on();

	while(1) {
		STLIB::update();
		if(computer_server.is_connected()){
			connection_led->turn_on();
		}else{
			connection_led->turn_off();
		}
	}
```