### PR TITLE
removed str constructor as IPV4 can resolve

### DIFF
--- a/Inc/HALAL/Services/Communication/Ethernet/TCP/ServerSocket.hpp
+++ b/Inc/HALAL/Services/Communication/Ethernet/TCP/ServerSocket.hpp
@@ -44,7 +44,6 @@ public:
 	ServerSocket();
 	ServerSocket(ServerSocket&& other);
 	ServerSocket(IPV4 local_ip, uint32_t local_port);
-	ServerSocket(string local_ip, uint32_t local_port);
 	ServerSocket(EthernetNode local_node);
 	~ServerSocket();
 

--- a/Src/HALAL/Services/Communication/Ethernet/TCP/ServerSocket.cpp
+++ b/Src/HALAL/Services/Communication/Ethernet/TCP/ServerSocket.cpp
@@ -77,8 +77,6 @@ ServerSocket::~ServerSocket(){
 
 }
 
-ServerSocket::ServerSocket(string local_ip, uint32_t local_port) : ServerSocket(IPV4(local_ip),local_port){}
-
 ServerSocket::ServerSocket(EthernetNode local_node) : ServerSocket(local_node.ip,local_node.port){};
 
 void ServerSocket::close(){


### PR DESCRIPTION
When trying to make a ServerSocket using a string C++ couldn t resolve as both IPV4 and string constructors can accept an string. 

Just removed the string constructor, which just called the IPV4 one. Tested with the wiki ServerSocket code (changed ip to 192.168.0.3)