### PR TITLE
Time::cancel_timeout feature

### DIFF
--- a/Inc/HALAL/Services/Time/Time.hpp
+++ b/Inc/HALAL/Services/Time/Time.hpp
@@ -122,8 +122,22 @@ public :
 	static uint8_t register_mid_precision_alarm(uint32_t period_in_us, function<void()> func);
 	static bool unregister_mid_precision_alarm(uint8_t id);
 
-	static void set_timeout(int milliseconds, function<void()> callback);
 
+	/**
+	 * @brief Creates a timeout that will execute a function after a specified time
+	 * 
+	 * @param milliseconds the time to wait before executing
+	 * @param callback the function to be executed
+	 * @return uint8_t the id of the order, if it didnot succeed it will return 255
+	 */
+	[[nodiscard]]static uint8_t set_timeout(int milliseconds, function<void()> callback);
+
+	/**
+	 * @brief Cancels a timeout by derigstering the alarm bound to it
+	 * 
+	 * @param id The id of the timeout to cancel
+	 */
+	static void cancel_timeout(uint8_t id);
 #ifdef HAL_RTC_MODULE_ENABLED
 	struct RTCData{
 		uint16_t counter;

--- a/Src/HALAL/Services/Time/Time.cpp
+++ b/Src/HALAL/Services/Time/Time.cpp
@@ -274,10 +274,10 @@ bool Time::unregister_low_precision_alarm(uint8_t id){
 	return true;
 }
 
-void Time::set_timeout(int milliseconds, function<void()> callback){
+uint8_t Time::set_timeout(int milliseconds, function<void()> callback){
 	if(low_precision_alarms_by_id.size() == std::numeric_limits<uint8_t>::max()){
 		ErrorHandler("Cannot register timeout as all low precision alarms id's are already occupied");
-		return;
+		return 255;
 	}
 	while(low_precision_alarms_by_id.contains(low_precision_ids))
 		low_precision_ids++;
@@ -290,6 +290,14 @@ void Time::set_timeout(int milliseconds, function<void()> callback){
 		callback();
 		Time::unregister_low_precision_alarm(id);
 	});
+	return id;
+}
+
+void Time::cancel_timeout(uint8_t id){
+	//we can take advantage of the fact that if we try to 
+	//unregister an alarm that is not registered, it will return false
+	//instead of going HardFault or ErrorHandler
+	Time::unregister_low_precision_alarm(id);
 }
 
 void Time::global_timer_callback(){


### PR DESCRIPTION
We already had a timeout function that was very useful, but we might want to cancel that timeout for whatever reasons,
we can do it now,
Watch out:
`set_timeout `now returns an uint8_t which is the id of the alarm registered, if the map of cyclic actions was full it will return 255, 


The function calls the ErrorHandler, so it should be fine, but in order for it to compile it needs to return something, so beware if no StateMachine has been implemented and you have registered a lot of actions.

In order to enforce checking for the return value the attribute `[[nodiscard]]` has been used