### PR TITLE
Protections refactor

### DIFF
--- a/Inc/HALAL/Services/Time/RTC.hpp
+++ b/Inc/HALAL/Services/Time/RTC.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "stm32h7xx_hal.h"
+#include "ErrorHandler/ErrorHandler.hpp"
+
+
+#define RTC_MAX_COUNTER 32767
+
+#ifdef HAL_RTC_MODULE_ENABLED
+
+	struct RTCData{
+		uint16_t counter;
+		uint8_t second;
+		uint8_t minute;
+		uint8_t hour;
+		uint8_t day;
+		uint8_t month;
+		uint16_t year;
+	};
+    
+    class Global_RTC{
+    public:
+    
+        static RTCData global_RTC;
+        static void start_rtc();
+        static void update_rtc_data();
+        static RTCData get_rtc_timestamp();
+        static void set_rtc_data(uint16_t counter, uint8_t second, uint8_t minute, uint8_t hour, uint8_t day, uint8_t month, uint16_t year);
+        };
+
+
+
+#endif

--- a/Inc/HALAL/Services/Time/Time.hpp
+++ b/Inc/HALAL/Services/Time/Time.hpp
@@ -14,7 +14,7 @@
 #ifdef HAL_TIM_MODULE_ENABLED
 
 #include "C++Utilities/CppUtils.hpp"
-
+#include "HALAL/Services/Time/RTC.hpp"
 // HIGH RESOLUTION TIMERS
 extern TIM_HandleTypeDef htim2;		// Used for the global timer (3,36nS step)
 
@@ -138,31 +138,6 @@ public :
 	 * @param id The id of the timeout to cancel
 	 */
 	static void cancel_timeout(uint8_t id);
-#ifdef HAL_RTC_MODULE_ENABLED
-	struct RTCData{
-		uint16_t counter;
-		uint8_t second;
-		uint8_t minute;
-		uint8_t hour;
-		uint8_t day;
-		uint8_t month;
-		uint16_t year;
-
-		string serialize() const {
-			return "\"counter\": " + to_string(counter) + ",\"second\": " + to_string(second) + ",\"minute\": " + to_string(minute) + ",\"hour\": " + to_string(hour) + ",\"day\": " + to_string(day) + ",\"month\": " + to_string(month) + ",\"year\": " + to_string(year);
-		}
-
-		static size_t get_string_size(const RTCData& to_serialize){
-			return to_serialize.serialize().size();
-		}
-	};
-
-	static void start_rtc();
-	static RTCData get_rtc_data();
-	static void set_rtc_data(uint16_t counter, uint8_t second, uint8_t minute, uint8_t hour, uint8_t day, uint8_t month, uint16_t year);
-
-	static RTC_HandleTypeDef hrtc;
-#endif
 };
 
 #endif

--- a/Inc/ST-LIB_HIGH/Protections/Boundary.hpp
+++ b/Inc/ST-LIB_HIGH/Protections/Boundary.hpp
@@ -189,7 +189,7 @@ struct Boundary<void, ERROR_HANDLER> : public BoundaryInterface{
 
 
 template<typename Type>
-//requires(std::is_floating_point_v<Type>)
+requires(std::is_floating_point_v<Type>)
 struct Boundary<Type, TIME_ACCUMULATION> : public BoundaryInterface {
 	static constexpr ProtectionType Protector = TIME_ACCUMULATION;	
 	Boundary(Type bound, float time_limit, float frequency, Boundary<Type, Protector>*& external_pointer): bound(bound),time_limit(time_limit) ,frequency(frequency), moving_order(frequency*time_limit/100),

--- a/Inc/ST-LIB_HIGH/Protections/Boundary.hpp
+++ b/Inc/ST-LIB_HIGH/Protections/Boundary.hpp
@@ -26,7 +26,9 @@ public:
 
 	void update_name(char* n){
 		name = n;
+		string_len = name.size();
 	}
+
 protected:
 	static const map<type_id_t,uint8_t> format_look_up;
 	static int get_error_handler_string_size(){
@@ -38,6 +40,8 @@ protected:
 	//this will store the name of the variable
 	string name;
 	static constexpr size_t NAME_MAX_LEN = 30;
+	uint8_t format_id;
+	size_t string_len;
 };
 
 template<class Type, ProtectionType Protector> struct Boundary;
@@ -49,18 +53,18 @@ struct Boundary<Type, BELOW> : public BoundaryInterface{
 	Type boundary;
 	// we have to do this because we cannot take address of rvalue (ProtectionType::BELOW)
 	uint8_t boundary_type_id = Protector;
-	uint8_t format_id;
+	
 	Boundary(Type boundary):boundary(boundary)
 	{
 		
 	}
 	Boundary(Type* src, Boundary<Type, Protector> boundary): 
-		src(src),boundary(boundary.boundary),format_id{BoundaryInterface::format_look_up.at(type_id<Type>)}
-
+		src(src),boundary(boundary.boundary)
 		{
+			format_id = BoundaryInterface::format_look_up.at(type_id<Type>);
 			// we have to preallocate space, otherwise the might get moved around, invalidating the pointer, better safe than sorry
 			name.reserve(NAME_MAX_LEN);
-			message = new HeapOrder(uint16_t{111},&format_id,&boundary_type_id,&name,&this->boundary,this->src,
+			message = new HeapOrder(uint16_t{111},&format_id,&boundary_type_id,&string_len,&name,&this->boundary,this->src,
 				&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
 		}
@@ -79,14 +83,14 @@ struct Boundary<Type, ABOVE> : public BoundaryInterface{
 	Type* src = nullptr;
 	Type boundary;
 	uint8_t boundary_type_id = Protector;
-	uint8_t format_id;
+	
 	Boundary(Type boundary): boundary(boundary){};
 	Boundary(Type* src, Boundary<Type, Protector> boundary): 
-		src(src),boundary(boundary.boundary),format_id{BoundaryInterface::format_look_up.at(type_id<Type>)}
-
+		src(src),boundary(boundary.boundary)
 		{
+			format_id = BoundaryInterface::format_look_up.at(type_id<Type>);
 			name.reserve(NAME_MAX_LEN);
-			message = new HeapOrder(uint16_t{111},&format_id,&boundary_type_id,&name,&this->boundary,this->src,
+			message = new HeapOrder(uint16_t{111},&format_id,&boundary_type_id,&string_len,&name,&this->boundary,this->src,
 				&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
 		}
@@ -103,13 +107,14 @@ struct Boundary<Type, EQUALS> : public BoundaryInterface{
 	Type* src = nullptr;
 	Type boundary;
 	uint8_t boundary_type_id = Protector;
-	uint8_t format_id;
+	
 	Boundary(Type boundary): boundary(boundary){};
 	Boundary(Type* src, Boundary<Type, Protector> boundary): 
-		src(src),boundary(boundary.boundary),format_id{BoundaryInterface::format_look_up.at(type_id<Type>)}
+		src(src),boundary(boundary.boundary)
 		{			
+			format_id = BoundaryInterface::format_look_up.at(type_id<Type>);
 			name.reserve(NAME_MAX_LEN);
-			message = new HeapOrder(uint16_t{111},&format_id,&boundary_type_id,&name,&this->boundary,this->src,
+			message = new HeapOrder(uint16_t{111},&format_id,&boundary_type_id,&string_len,&name,&this->boundary,this->src,
 				&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
 		}
@@ -126,14 +131,14 @@ struct Boundary<Type, NOT_EQUALS> : public BoundaryInterface{
 	Type* src = nullptr;
 	Type boundary;
 	uint8_t boundary_type_id = Protector;
-	uint8_t format_id;
+	
 	Boundary(Type boundary): boundary(boundary){};
 	Boundary(Type* src, Boundary<Type, Protector> boundary): 
-		src(src),boundary(boundary.boundary),format_id{BoundaryInterface::format_look_up.at(type_id<Type>)}
-
+		src(src),boundary(boundary.boundary)
 		{
+			format_id = BoundaryInterface::format_look_up.at(type_id<Type>);
 			name.reserve(NAME_MAX_LEN);			
-			message = new HeapOrder(uint16_t{111},&format_id,&boundary_type_id,&name,&this->boundary,this->src,
+			message = new HeapOrder(uint16_t{111},&format_id,&boundary_type_id,&string_len,&name,&this->boundary,this->src,
 				&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
 		}
@@ -150,13 +155,14 @@ struct Boundary<Type, OUT_OF_RANGE> : public BoundaryInterface{
 	Type* src = nullptr;
 	Type lower_boundary, upper_boundary;
 	uint8_t boundary_type_id = Protector;
-	uint8_t format_id;
+	
 	Boundary(Type lower_boundary, Type upper_boundary): lower_boundary(lower_boundary), upper_boundary(upper_boundary){};
 	Boundary(Type* src, Boundary<Type, Protector> boundary): 
-	src(src),lower_boundary(boundary.lower_boundary),upper_boundary(boundary.upper_boundary),format_id{BoundaryInterface::format_look_up.at(type_id<Type>)}
+	src(src),lower_boundary(boundary.lower_boundary),upper_boundary(boundary.upper_boundary)
 	{
+		format_id = BoundaryInterface::format_look_up.at(type_id<Type>);
 		name.reserve(NAME_MAX_LEN);
-		message = new HeapOrder(uint16_t{111},&format_id,&boundary_type_id,&name,&this->lower_boundary,&this->upper_boundary,this->src,
+		message = new HeapOrder(uint16_t{111},&format_id,&boundary_type_id,&string_len,&name,&this->lower_boundary,&this->upper_boundary,this->src,
 			&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 			&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
 	}
@@ -200,7 +206,7 @@ struct Boundary<Type, TIME_ACCUMULATION> : public BoundaryInterface {
 		*external_pointer = this;
 		format_id = BoundaryInterface::format_look_up.at(type_id<Type>);
 		name.reserve(NAME_MAX_LEN);
-		message = new HeapOrder(uint16_t{111},&format_id,&boundary_type_id,&name,&this->bound,this->src,&this->time_limit,&this->frequency,
+		message = new HeapOrder(uint16_t{111},&format_id,&boundary_type_id,&string_len,&name,&this->bound,this->src,&this->time_limit,&this->frequency,
 			&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 			&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
 	}

--- a/Inc/ST-LIB_HIGH/Protections/Boundary.hpp
+++ b/Inc/ST-LIB_HIGH/Protections/Boundary.hpp
@@ -36,7 +36,7 @@ protected:
 		return ErrorHandlerModel::description;
 	}
 	//this will store the name of the variable
-	char* name;
+	string name;
 	static constexpr size_t NAME_MAX_LEN = 30;
 };
 
@@ -58,8 +58,9 @@ struct Boundary<Type, BELOW> : public BoundaryInterface{
 		src(src),boundary(boundary.boundary),format_id{BoundaryInterface::format_look_up.at(type_id<Type>)}
 
 		{
-			name = (char*)malloc(NAME_MAX_LEN);
-			message = new HeapOrder(uint16_t{111},&format_id,&boundary_type_id,name,&this->boundary,this->src,
+			// we have to preallocate space, otherwise the might get moved around, invalidating the pointer, better safe than sorry
+			name.reserve(NAME_MAX_LEN);
+			message = new HeapOrder(uint16_t{111},&format_id,&boundary_type_id,&name,&this->boundary,this->src,
 				&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
 		}
@@ -84,7 +85,8 @@ struct Boundary<Type, ABOVE> : public BoundaryInterface{
 		src(src),boundary(boundary.boundary),format_id{BoundaryInterface::format_look_up.at(type_id<Type>)}
 
 		{
-			message = new HeapOrder(uint16_t{111},&boundary_type_id,&format_id,&this->boundary,this->src,
+			name.reserve(NAME_MAX_LEN);
+			message = new HeapOrder(uint16_t{111},&format_id,&boundary_type_id,&name,&this->boundary,this->src,
 				&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
 		}
@@ -105,9 +107,9 @@ struct Boundary<Type, EQUALS> : public BoundaryInterface{
 	Boundary(Type boundary): boundary(boundary){};
 	Boundary(Type* src, Boundary<Type, Protector> boundary): 
 		src(src),boundary(boundary.boundary),format_id{BoundaryInterface::format_look_up.at(type_id<Type>)}
-
-		{
-			message = new HeapOrder(uint16_t{111},&boundary_type_id,&format_id,&this->boundary,this->src,
+		{			
+			name.reserve(NAME_MAX_LEN);
+			message = new HeapOrder(uint16_t{111},&format_id,&boundary_type_id,&name,&this->boundary,this->src,
 				&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
 		}
@@ -130,7 +132,8 @@ struct Boundary<Type, NOT_EQUALS> : public BoundaryInterface{
 		src(src),boundary(boundary.boundary),format_id{BoundaryInterface::format_look_up.at(type_id<Type>)}
 
 		{
-			message = new HeapOrder(uint16_t{111},&boundary_type_id,&format_id,&this->boundary,this->src,
+			name.reserve(NAME_MAX_LEN);			
+			message = new HeapOrder(uint16_t{111},&format_id,&boundary_type_id,&name,&this->boundary,this->src,
 				&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
 		}
@@ -152,7 +155,8 @@ struct Boundary<Type, OUT_OF_RANGE> : public BoundaryInterface{
 	Boundary(Type* src, Boundary<Type, Protector> boundary): 
 	src(src),lower_boundary(boundary.lower_boundary),upper_boundary(boundary.upper_boundary),format_id{BoundaryInterface::format_look_up.at(type_id<Type>)}
 	{
-		message = new HeapOrder(uint16_t{111},&boundary_type_id,&format_id,&this->lower_boundary,&this->upper_boundary,this->src,
+		name.reserve(NAME_MAX_LEN);
+		message = new HeapOrder(uint16_t{111},&format_id,&boundary_type_id,&name,&this->lower_boundary,&this->upper_boundary,this->src,
 			&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 			&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
 	}
@@ -195,7 +199,8 @@ struct Boundary<Type, TIME_ACCUMULATION> : public BoundaryInterface {
 	Boundary(Type* src, Boundary<Type, Protector> boundary): src(src),bound(boundary.bound),time_limit(boundary.time_limit),frequency(boundary.frequency),moving_order(frequency*time_limit/100), external_pointer(boundary.external_pointer){
 		*external_pointer = this;
 		format_id = BoundaryInterface::format_look_up.at(type_id<Type>);
-		message = new HeapOrder(uint16_t{111},&boundary_type_id,&format_id,&this->bound,this->src,&this->time_limit,&this->frequency,
+		name.reserve(NAME_MAX_LEN);
+		message = new HeapOrder(uint16_t{111},&format_id,&boundary_type_id,&name,&this->bound,this->src,&this->time_limit,&this->frequency,
 			&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 			&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
 	}

--- a/Inc/ST-LIB_HIGH/Protections/Protection.hpp
+++ b/Inc/ST-LIB_HIGH/Protections/Protection.hpp
@@ -41,15 +41,5 @@ public:
         }
         return true;
     }
-
-    char* serialize(char* dst) {
-    	sprintf(dst,format,name,string(jumped_protection->serialize(dst)).c_str());
-    	return dst;
-    }
-
-    int get_string_size(){
-    	return jumped_protection->get_string_size() + snprintf(nullptr,0,format, name, "");
-    }
-
     friend class ProtectionManager;
 };

--- a/Inc/ST-LIB_HIGH/Protections/Protection.hpp
+++ b/Inc/ST-LIB_HIGH/Protections/Protection.hpp
@@ -5,15 +5,15 @@
 #include "Boundary.hpp"
 
 namespace Protections{
-enum FaultType{
+enum FaultType : uint8_t{
 	FAULT = 0,
-	WARNING
+	WARNING,
+    OK
 };
 }
 
 class Protection{
 private:
-	static constexpr const char* format = "\"protection\" : {\"name\":\"%s\", %s}";
     char* name = nullptr;
     vector<unique_ptr<BoundaryInterface>> boundaries;
     BoundaryInterface* jumped_protection = nullptr;

--- a/Inc/ST-LIB_HIGH/Protections/ProtectionManager.hpp
+++ b/Inc/ST-LIB_HIGH/Protections/ProtectionManager.hpp
@@ -54,7 +54,10 @@ public:
     	high_frequency_protections.push_back(Protection(src,protectors...));
         return high_frequency_protections.back();
     }
-
+    /**
+     * @brief call on startup to initialize the names of the protections
+    */
+    static void initialize();
     static void add_standard_protections();
     static void check_protections();
     static void check_high_frequency_protections();

--- a/Inc/ST-LIB_HIGH/Protections/ProtectionManager.hpp
+++ b/Inc/ST-LIB_HIGH/Protections/ProtectionManager.hpp
@@ -78,15 +78,6 @@ private:
     static Notification warning_notification;
     static StackOrder<0> fault_order;
 
-    static int get_string_size(Protection& prot ,const Time::RTCData& timestamp){
-    	return snprintf(nullptr,0,format,"","","") + prot.get_string_size() + Time::RTCData::get_string_size(timestamp);
-    }
-
-    static char* serialize(Protection& prot, const Time::RTCData& timestamp){
-    	sprintf(message,format,to_string(board_id).c_str(),timestamp.serialize().c_str(),string(prot.serialize(message)).c_str());
-    	return message;
-    }
-
     static void to_fault();
 };
 

--- a/Inc/ST-LIB_HIGH/Protections/ProtectionManager.hpp
+++ b/Inc/ST-LIB_HIGH/Protections/ProtectionManager.hpp
@@ -60,7 +60,7 @@ public:
     static void check_high_frequency_protections();
     static void warn(string message);
     static void fault_and_propagate();
-
+    static void notify(Protection& protection);
 private:
 	static constexpr uint16_t warning_id = 2;
 	static constexpr uint16_t fault_id = 3;

--- a/Src/HALAL/HALAL.cpp
+++ b/Src/HALAL/HALAL.cpp
@@ -65,7 +65,7 @@ void HALAL::start(IPV4 ip, IPV4 subnet_mask, IPV4 gateway, UART::Peripheral& pri
 
 #ifdef HAL_TIM_MODULE_ENABLED
 	Encoder::start();
-	Time::start_rtc();
+	Global_RTC::start_rtc();
 	SNTP::sntp_update();
 	TimerPeripheral::start();
 	Time::start();

--- a/Src/HALAL/Services/Time/RTC.cpp
+++ b/Src/HALAL/Services/Time/RTC.cpp
@@ -1,0 +1,84 @@
+#include "HALAL/Services/Time/RTC.hpp"
+
+RTC_HandleTypeDef hrtc;
+RTCData global_RTC;
+
+void Global_RTC::start_rtc(){
+	RTC_TimeTypeDef sTime = { 0 };
+	RTC_DateTypeDef sDate = { 0 };
+
+	hrtc.Instance = RTC;
+	hrtc.Init.HourFormat = RTC_HOURFORMAT_24;
+	hrtc.Init.AsynchPrediv = 0;
+	hrtc.Init.SynchPrediv = 32767;
+	hrtc.Init.OutPut = RTC_OUTPUT_DISABLE;
+	hrtc.Init.OutPutPolarity = RTC_OUTPUT_POLARITY_HIGH;
+	hrtc.Init.OutPutType = RTC_OUTPUT_TYPE_OPENDRAIN;
+	hrtc.Init.OutPutRemap = RTC_OUTPUT_REMAP_NONE;
+
+	if (HAL_RTC_Init(&hrtc) != HAL_OK) {
+		ErrorHandler("Error on RTC Init");
+	}
+	sTime.Hours = 0x0;
+	sTime.Minutes = 0x0;
+	sTime.Seconds = 0x0;
+	sTime.DayLightSaving = RTC_DAYLIGHTSAVING_NONE;
+	sTime.StoreOperation = RTC_STOREOPERATION_RESET;
+
+	if (HAL_RTC_SetTime(&hrtc, &sTime, RTC_FORMAT_BIN) != HAL_OK) {
+		ErrorHandler("Error while setting time at RTC start");
+	}
+
+	sDate.WeekDay = RTC_WEEKDAY_MONDAY;
+	sDate.Month = RTC_MONTH_JANUARY;
+	sDate.Date = 0x1;
+	sDate.Year = 23;
+
+	if (HAL_RTC_SetDate(&hrtc, &sDate, RTC_FORMAT_BIN) != HAL_OK) {
+		ErrorHandler("Error while setting date at RTC start");
+	}
+}
+
+
+RTCData Global_RTC::get_rtc_timestamp(){
+	RTCData ret;
+	RTC_TimeTypeDef gTime;
+	RTC_DateTypeDef gDate;
+	HAL_RTC_GetTime(&hrtc, &gTime, RTC_FORMAT_BIN);
+	HAL_RTC_GetDate(&hrtc, &gDate, RTC_FORMAT_BIN);
+	ret.counter = gTime.SecondFraction - gTime.SubSeconds;
+	ret.second = gTime.Seconds;
+	ret.minute = gTime.Minutes;
+	ret.hour = gTime.Hours;
+	ret.day = gDate.Date;
+	ret.month = gDate.Month;
+	ret.year = 2000 + gDate.Year;
+	return ret;
+}
+
+void Global_RTC::set_rtc_data(uint16_t counter, uint8_t second, uint8_t minute, uint8_t hour, uint8_t day, uint8_t month, uint16_t year){
+	RTC_TimeTypeDef gTime;
+	RTC_DateTypeDef gDate;
+	gTime.SubSeconds = counter;
+	gTime.Seconds = second;
+	gTime.Minutes = minute;
+	gTime.Hours = hour;
+	gTime.DayLightSaving = RTC_DAYLIGHTSAVING_NONE;
+	gTime.StoreOperation = RTC_STOREOPERATION_RESET;
+	gDate.WeekDay = 0;
+	gDate.Date = day;
+	gDate.Month = month;
+	gDate.Year = year - 2000;
+	if (HAL_RTC_SetTime(&hrtc, &gTime, RTC_FORMAT_BIN) != HAL_OK)
+	{
+		ErrorHandler("Error on writing Time on the RTC");
+	}
+	if (HAL_RTC_SetDate(&hrtc, &gDate, RTC_FORMAT_BIN) != HAL_OK)
+	{
+		ErrorHandler("Error on writing Date on the RTC");
+	}
+
+}
+void Global_RTC::update_rtc_data(){
+    global_RTC = get_rtc_timestamp();
+}

--- a/Src/HALAL/Services/Time/RTC.cpp
+++ b/Src/HALAL/Services/Time/RTC.cpp
@@ -1,7 +1,7 @@
 #include "HALAL/Services/Time/RTC.hpp"
 
 RTC_HandleTypeDef hrtc;
-RTCData global_RTC;
+RTCData Global_RTC::global_RTC;
 
 void Global_RTC::start_rtc(){
 	RTC_TimeTypeDef sTime = { 0 };

--- a/Src/HALAL/Services/Time/Time.cpp
+++ b/Src/HALAL/Services/Time/Time.cpp
@@ -10,7 +10,7 @@
 #include "TimerPeripheral/TimerPeripheral.hpp"
 
 
-RTC_HandleTypeDef Time::hrtc;
+
 
 TIM_HandleTypeDef* Time::global_timer = &htim2;
 TIM_HandleTypeDef* Time::low_precision_timer = &htim7;
@@ -370,78 +370,3 @@ void Time::ConfigTimer(TIM_HandleTypeDef* tim, uint32_t period_in_us){
 
 }
 
-void Time::start_rtc(){
-	RTC_TimeTypeDef sTime = { 0 };
-	RTC_DateTypeDef sDate = { 0 };
-
-	hrtc.Instance = RTC;
-	hrtc.Init.HourFormat = RTC_HOURFORMAT_24;
-	hrtc.Init.AsynchPrediv = 0;
-	hrtc.Init.SynchPrediv = 32767;
-	hrtc.Init.OutPut = RTC_OUTPUT_DISABLE;
-	hrtc.Init.OutPutPolarity = RTC_OUTPUT_POLARITY_HIGH;
-	hrtc.Init.OutPutType = RTC_OUTPUT_TYPE_OPENDRAIN;
-	hrtc.Init.OutPutRemap = RTC_OUTPUT_REMAP_NONE;
-
-	if (HAL_RTC_Init(&hrtc) != HAL_OK) {
-		ErrorHandler("Error on RTC Init");
-	}
-	sTime.Hours = 0x0;
-	sTime.Minutes = 0x0;
-	sTime.Seconds = 0x0;
-	sTime.DayLightSaving = RTC_DAYLIGHTSAVING_NONE;
-	sTime.StoreOperation = RTC_STOREOPERATION_RESET;
-
-	if (HAL_RTC_SetTime(&hrtc, &sTime, RTC_FORMAT_BIN) != HAL_OK) {
-		ErrorHandler("Error while setting time at RTC start");
-	}
-
-	sDate.WeekDay = RTC_WEEKDAY_MONDAY;
-	sDate.Month = RTC_MONTH_JANUARY;
-	sDate.Date = 0x1;
-	sDate.Year = 23;
-
-	if (HAL_RTC_SetDate(&hrtc, &sDate, RTC_FORMAT_BIN) != HAL_OK) {
-		ErrorHandler("Error while setting date at RTC start");
-	}
-}
-
-
-Time::RTCData Time::get_rtc_data(){
-	RTCData ret;
-	RTC_TimeTypeDef gTime;
-	RTC_DateTypeDef gDate;
-	HAL_RTC_GetTime(&hrtc, &gTime, RTC_FORMAT_BIN);
-	HAL_RTC_GetDate(&hrtc, &gDate, RTC_FORMAT_BIN);
-	ret.counter = gTime.SecondFraction - gTime.SubSeconds;
-	ret.second = gTime.Seconds;
-	ret.minute = gTime.Minutes;
-	ret.hour = gTime.Hours;
-	ret.day = gDate.Date;
-	ret.month = gDate.Month;
-	ret.year = 2000 + gDate.Year;
-	return ret;
-}
-
-void Time::set_rtc_data(uint16_t counter, uint8_t second, uint8_t minute, uint8_t hour, uint8_t day, uint8_t month, uint16_t year){
-	RTC_TimeTypeDef gTime;
-	RTC_DateTypeDef gDate;
-	gTime.SubSeconds = counter;
-	gTime.Seconds = second;
-	gTime.Minutes = minute;
-	gTime.Hours = hour;
-	gTime.DayLightSaving = RTC_DAYLIGHTSAVING_NONE;
-	gTime.StoreOperation = RTC_STOREOPERATION_RESET;
-	gDate.WeekDay = 0;
-	gDate.Date = day;
-	gDate.Month = month;
-	gDate.Year = year - 2000;
-	if (HAL_RTC_SetTime(&hrtc, &gTime, RTC_FORMAT_BIN) != HAL_OK)
-	{
-		ErrorHandler("Error on writing Time on the RTC");
-	}
-	if (HAL_RTC_SetDate(&hrtc, &gDate, RTC_FORMAT_BIN) != HAL_OK)
-	{
-		ErrorHandler("Error on writing Date on the RTC");
-	}
-}

--- a/Src/ST-LIB_HIGH/Protections/Boundary.cpp
+++ b/Src/ST-LIB_HIGH/Protections/Boundary.cpp
@@ -1,0 +1,16 @@
+#include "ST-LIB_HIGH/Protections/Boundary.hpp"
+
+ const map<type_id_t,uint8_t> BoundaryInterface::format_look_up{
+    {type_id<int>,0},
+    {type_id<float>,1},
+    {type_id<double>,2},
+    {type_id<char>,3},
+    {type_id<bool>,4},
+    {type_id<short>,5},
+    {type_id<long>,6},
+    {type_id<uint8_t>,7},
+    {type_id<uint16_t>,8},
+    {type_id<uint32_t>,9},
+    {type_id<uint64_t>,10},
+    {type_id<int8_t>,11},
+};

--- a/Src/ST-LIB_HIGH/Protections/ProtectionManager.cpp
+++ b/Src/ST-LIB_HIGH/Protections/ProtectionManager.cpp
@@ -10,6 +10,19 @@ uint64_t ProtectionManager::last_notify = 0;
 void *error_handler;
 
 
+void ProtectionManager::initialize(){
+    for (Protection& protection: low_frequency_protections) {
+        for(auto& boundary : protection.boundaries){
+            boundary->update_name(protection.get_name());
+        }
+    }
+    for (Protection& protection: high_frequency_protections) {
+        for(auto& boundary : protection.boundaries){
+            boundary->update_name(protection.get_name());
+        }
+    }
+}
+
 void ProtectionManager::add_standard_protections(){
 	add_protection(error_handler, Boundary<void,ERROR_HANDLER>(error_handler));
 }
@@ -50,7 +63,6 @@ void ProtectionManager::check_protections() {
             ProtectionManager::to_fault();
         }
         Global_RTC::update_rtc_data();
-
         
         if(Time::get_global_tick() > last_notify + notify_delay_in_nanoseconds){
             ProtectionManager::notify(protection);
@@ -96,8 +108,6 @@ void ProtectionManager::warn(string message){
 }
 
 void ProtectionManager::notify(Protection& protection){
-
-    protection.jumped_protection->update_name(protection.get_name());
     for(OrderProtocol* socket : OrderProtocol::sockets){
         socket->send_order(*protection.jumped_protection->message);
     }

--- a/Src/ST-LIB_HIGH/Protections/ProtectionManager.cpp
+++ b/Src/ST-LIB_HIGH/Protections/ProtectionManager.cpp
@@ -108,6 +108,9 @@ void ProtectionManager::warn(string message){
 }
 
 void ProtectionManager::notify(Protection& protection){
+    if(protection.jumped_protection->Protector == ERROR_HANDLER){
+        protection.jumped_protection->update_error_handler_message(protection.jumped_protection->get_error_handler_string());
+    }
     for(OrderProtocol* socket : OrderProtocol::sockets){
         socket->send_order(*protection.jumped_protection->message);
     }

--- a/Src/ST-LIB_HIGH/Protections/ProtectionManager.cpp
+++ b/Src/ST-LIB_HIGH/Protections/ProtectionManager.cpp
@@ -68,7 +68,6 @@ void ProtectionManager::check_protections() {
             ProtectionManager::notify(protection);
         last_notify = Time::get_global_tick();
         }
-    	free(message);
     }
 }
 
@@ -82,24 +81,11 @@ void ProtectionManager::check_high_frequency_protections(){
         	return;
         }
 
-        ProtectionManager::to_fault();
-
+        if(protection.fault_type == Protections::FAULT){
+            ProtectionManager::to_fault();
+        }
         Global_RTC::update_rtc_data();
-        for(OrderProtocol* socket : OrderProtocol::sockets){
-        	socket->send_order(*protection.jumped_protection->message);
-        }
-        switch(protection.fault_type){
-        case Protections::FaultType::WARNING:
-        	warning_notification.notify(message);
-            break;
-        case Protections::FaultType::FAULT:
-        	fault_notification.notify(message);
-            break;
-        default:
-        	ErrorHandler("Protection has not a Fault Type that can be handled correctly by the ProtectionManager");
-        }
-
-    	free(message);
+        ProtectionManager::notify(protection);
     }
 }
 


### PR DESCRIPTION
Bunch of changes review carefully:

RTC:
-   Created a global static entity  to allow direct access and usage as a variable within a Packet
-   Moved to a separate file (minor stuff)

Boundary:
 - Sending now uses standard packets, containing _(roughly)_: 
```
    id(TBD) | format_id | boundary_type_id | name_len | name |
    < Boundary metrics> |     < Boundary metrics> |     < Boundary metrics> |
   RTC data |    RTC data |    RTC data |    RTC data |    RTC data |
   RTC data |    RTC data |    RTC data |    RTC data |    RTC data |
```
Protection Manager:
- Added an `initialize()` method that sets the name of all the boundaries registered, since it does not make any sense to have to do it every time you want to send it

Discarded the notification class, still have to revisit the functionality,
Unified the TIME_ACCUMULATION specialization instead of having the same one for doubles and floats
