### PR TITLE
Feature/warning notifications

### DIFF
--- a/Inc/C++Utilities/CppUtils.hpp
+++ b/Inc/C++Utilities/CppUtils.hpp
@@ -57,6 +57,7 @@ using std::integral_constant;
 using std::snprintf;
 using std::make_unique;
 using std::unique_ptr;
+using std::shared_ptr;
 using std::hash;
 using std::unordered_map;
 using std::vector;

--- a/Inc/ST-LIB_HIGH/Protections/Boundary.hpp
+++ b/Inc/ST-LIB_HIGH/Protections/Boundary.hpp
@@ -73,6 +73,7 @@ struct Boundary<Type, BELOW> : public BoundaryInterface{
 	Boundary(Type warning_threshold, Type boundary): has_warning_level{true}, boundary(boundary), warning_threshold(warning_threshold){};
 	Boundary(Type boundary):boundary(boundary){}
 	Boundary(Type* src, Boundary<Type, Protector> boundary): 
+		has_warning_level(boundary.has_warning_level),
 		src(src),boundary(boundary.boundary)
 		{
 			// we have to do this because we cannot take address of rvalue (ProtectionType::BELOW)
@@ -80,10 +81,17 @@ struct Boundary<Type, BELOW> : public BoundaryInterface{
 			format_id = BoundaryInterface::format_look_up.at(type_id<Type>);
 			// we have to preallocate space, otherwise the might get moved around, invalidating the pointer, better safe than sorry
 			name.reserve(NAME_MAX_LEN);
+			if(this->has_warning_level){
+				warning_threshold = boundary.warning_threshold;
+				message = new HeapOrder(uint16_t{111},&format_id,&boundary_type_id,&string_len,&name,&this->warning_threshold,&this->boundary,this->src,
+				&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
+				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
+			}else{
 			message = new HeapOrder(uint16_t{111},&format_id,&boundary_type_id,&string_len,&name,&this->boundary,this->src,
 				&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
 			}
+		}
 
 
 	Boundary(Type* src, Type boundary): src(src),boundary(boundary){}

--- a/Inc/ST-LIB_HIGH/Protections/Boundary.hpp
+++ b/Inc/ST-LIB_HIGH/Protections/Boundary.hpp
@@ -83,11 +83,11 @@ struct Boundary<Type, BELOW> : public BoundaryInterface{
 			name.reserve(NAME_MAX_LEN);
 			if(this->has_warning_level){
 				warning_threshold = boundary.warning_threshold;
-				message = new HeapOrder(uint16_t{111},&format_id,&boundary_type_id,&string_len,&name,&this->warning_threshold,&this->boundary,this->src,
+				message = new HeapOrder(uint16_t{111},&format_id,&boundary_type_id,&has_warning_level,&string_len,&name,&this->warning_threshold,&this->boundary,this->src,
 				&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
 			}else{
-			message = new HeapOrder(uint16_t{111},&format_id,&boundary_type_id,&string_len,&name,&this->boundary,this->src,
+			message = new HeapOrder(uint16_t{111},&format_id,&boundary_type_id,&has_warning_level,&string_len,&name,&this->boundary,this->src,
 				&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
 			}
@@ -114,14 +114,23 @@ struct Boundary<Type, ABOVE> : public BoundaryInterface{
 	Boundary(Type boundary): boundary(boundary){};
 	Boundary(Type* src, Boundary<Type, Protector> boundary): 
 		has_warning_level(boundary.has_warning_level),
-		src(src),boundary(boundary.boundary),warning_threshold(boundary.warning_threshold)
+		src(src),boundary(boundary.boundary)
 		{
+			// we have to do this because we cannot take address of rvalue (ProtectionType::BELOW)
 			boundary_type_id = Protector;
 			format_id = BoundaryInterface::format_look_up.at(type_id<Type>);
+			// we have to preallocate space, otherwise the might get moved around, invalidating the pointer, better safe than sorry
 			name.reserve(NAME_MAX_LEN);
-			message = new HeapOrder(uint16_t{111},&format_id,&boundary_type_id,&string_len,&name,&this->boundary,this->src,
+			if(this->has_warning_level){
+				warning_threshold = boundary.warning_threshold;
+				message = new HeapOrder(uint16_t{111},&format_id,&boundary_type_id,&has_warning_level,&string_len,&name,&this->warning_threshold,&this->boundary,this->src,
 				&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
+			}else{
+			message = new HeapOrder(uint16_t{111},&format_id,&boundary_type_id,&has_warning_level,&string_len,&name,&this->boundary,this->src,
+				&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
+				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
+			}
 		}
 	Boundary(Type* src, Type boundary): src(src),boundary(boundary){}
 	Protections::FaultType check_bounds()override{

--- a/Inc/ST-LIB_HIGH/Protections/Boundary.hpp
+++ b/Inc/ST-LIB_HIGH/Protections/Boundary.hpp
@@ -68,9 +68,9 @@ struct Boundary<Type, BELOW> : public BoundaryInterface{
 	bool has_warning_level{false};
 	Type* src = nullptr;
 	Type boundary;
-	Type warning_level;
+	Type warning_threshold;
 
-	Boundary(Type warning_level, Type boundary): has_warning_level{true}, boundary(boundary), warning_level(warning_level){};
+	Boundary(Type warning_threshold, Type boundary): has_warning_level{true}, boundary(boundary), warning_threshold(warning_threshold){};
 	Boundary(Type boundary):boundary(boundary){}
 	Boundary(Type* src, Boundary<Type, Protector> boundary): 
 		src(src),boundary(boundary.boundary)
@@ -83,13 +83,13 @@ struct Boundary<Type, BELOW> : public BoundaryInterface{
 			message = new HeapOrder(uint16_t{111},&format_id,&boundary_type_id,&string_len,&name,&this->boundary,this->src,
 				&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
-		}
+			}
 
 
 	Boundary(Type* src, Type boundary): src(src),boundary(boundary){}
 	Protections::FaultType check_bounds()override{
 		if(*src < boundary) return Protections::FAULT;
-		if(has_warning_level && *src < warning_level) return Protections::WARNING;
+		if(has_warning_level && *src < warning_threshold) return Protections::WARNING;
 		return Protections::OK;
 	}
 };
@@ -100,13 +100,13 @@ struct Boundary<Type, ABOVE> : public BoundaryInterface{
 	bool has_warning_level{false};
 	Type* src = nullptr;
 	Type boundary;
-	Type warning_level;
+	Type warning_threshold;
 
-	Boundary(Type warning_level, Type boundary): has_warning_level{true}, boundary(boundary), warning_level(warning_level){};
+	Boundary(Type warning_threshold, Type boundary): has_warning_level{true}, boundary(boundary), warning_threshold(warning_threshold){};
 	Boundary(Type boundary): boundary(boundary){};
 	Boundary(Type* src, Boundary<Type, Protector> boundary): 
 		has_warning_level(boundary.has_warning_level),
-		src(src),boundary(boundary.boundary),warning_level(boundary.warning_level)
+		src(src),boundary(boundary.boundary),warning_threshold(boundary.warning_threshold)
 		{
 			boundary_type_id = Protector;
 			format_id = BoundaryInterface::format_look_up.at(type_id<Type>);
@@ -118,7 +118,7 @@ struct Boundary<Type, ABOVE> : public BoundaryInterface{
 	Boundary(Type* src, Type boundary): src(src),boundary(boundary){}
 	Protections::FaultType check_bounds()override{
 		if(*src > boundary) return Protections::FAULT;
-		if(has_warning_level && *src > warning_level) return Protections::WARNING;
+		if(has_warning_level && *src > warning_threshold) return Protections::WARNING;
 		return Protections::OK;
 	}
 };

--- a/Inc/ST-LIB_HIGH/Protections/Boundary.hpp
+++ b/Inc/ST-LIB_HIGH/Protections/Boundary.hpp
@@ -30,8 +30,8 @@ enum ProtectionType : uint8_t {
 struct BoundaryInterface{
 public:
     virtual Protections::FaultType check_bounds() = 0;
-	HeapOrder* message;
-
+	HeapOrder* fault_message;
+	HeapOrder* warn_message;
 	void update_name(char* n){
 		name = n;
 		if(strlen(n) > NAME_MAX_LEN){
@@ -89,14 +89,14 @@ struct Boundary<Type, BELOW> : public BoundaryInterface{
 			name.reserve(NAME_MAX_LEN);
 			if(this->has_warning_level){
 				warning_threshold = boundary.warning_threshold;
-				message = new HeapOrder(uint16_t{111},&format_id,&boundary_type_id,&has_warning_level,&string_len,&name,&this->warning_threshold,&this->boundary,this->src,
-				&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
-				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
-			}else{
-			message = new HeapOrder(uint16_t{111},&format_id,&boundary_type_id,&has_warning_level,&string_len,&name,&this->boundary,this->src,
+				warn_message = new HeapOrder(uint16_t{1000},&format_id,&boundary_type_id,&name,&this->warning_threshold,&this->boundary,this->src,
 				&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
 			}
+			fault_message = new HeapOrder(uint16_t{2000},&format_id,&boundary_type_id,&name,&this->boundary,this->src,
+				&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
+				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
+			
 		}
 
 
@@ -133,14 +133,14 @@ struct Boundary<Type, ABOVE> : public BoundaryInterface{
 			name.reserve(NAME_MAX_LEN);
 			if(this->has_warning_level){
 				warning_threshold = boundary.warning_threshold;
-				message = new HeapOrder(uint16_t{111},&format_id,&boundary_type_id,&has_warning_level,&string_len,&name,&this->warning_threshold,&this->boundary,this->src,
-				&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
-				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
-			}else{
-			message = new HeapOrder(uint16_t{111},&format_id,&boundary_type_id,&has_warning_level,&string_len,&name,&this->boundary,this->src,
+				warn_message = new HeapOrder(uint16_t{2111},&format_id,&boundary_type_id,&name,&this->warning_threshold,&this->boundary,this->src,
 				&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
 			}
+			fault_message = new HeapOrder(uint16_t{1111},&format_id,&boundary_type_id,&name,&this->boundary,this->src,
+				&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
+				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
+			
 		}
 	Boundary(Type* src, Type boundary): src(src),boundary(boundary){}
 	Protections::FaultType check_bounds()override{
@@ -163,7 +163,7 @@ struct Boundary<Type, EQUALS> : public BoundaryInterface{
 			boundary_type_id = Protector;	
 			format_id = BoundaryInterface::format_look_up.at(type_id<Type>);
 			name.reserve(NAME_MAX_LEN);
-			message = new HeapOrder(uint16_t{111},&format_id,&boundary_type_id,&string_len,&name,&this->boundary,this->src,
+			fault_message = new HeapOrder(uint16_t{1333},&format_id,&boundary_type_id,&name,&this->boundary,this->src,
 				&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
 		}
@@ -186,7 +186,7 @@ struct Boundary<Type, NOT_EQUALS> : public BoundaryInterface{
 			boundary_type_id = Protector;
 			format_id = BoundaryInterface::format_look_up.at(type_id<Type>);
 			name.reserve(NAME_MAX_LEN);			
-			message = new HeapOrder(uint16_t{111},&format_id,&boundary_type_id,&string_len,&name,&this->boundary,this->src,
+			fault_message = new HeapOrder(uint16_t{1444},&format_id,&boundary_type_id,&name,&this->boundary,this->src,
 				&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
 		}
@@ -217,14 +217,14 @@ struct Boundary<Type, OUT_OF_RANGE> : public BoundaryInterface{
 		format_id = BoundaryInterface::format_look_up.at(type_id<Type>);
 		name.reserve(NAME_MAX_LEN);
 		if(boundary.has_warning_level){
-			message = new HeapOrder(uint16_t{111},&format_id,&boundary_type_id,&has_warning_level,&string_len,&name,&boundary.lower_boundary,&boundary.upper_boundary,this->src,
-			&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
-			&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
-		}else{
-		message = new HeapOrder(uint16_t{111},&format_id,&boundary_type_id,&has_warning_level,&string_len,&name,&this->lower_boundary,&this->upper_boundary,this->src,
+			warn_message = new HeapOrder(uint16_t{2222},&format_id,&boundary_type_id,&name,&boundary.lower_boundary,&boundary.upper_boundary,this->src,
 			&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 			&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
 		}
+		fault_message = new HeapOrder(uint16_t{1222},&format_id,&boundary_type_id,&name,&this->lower_boundary,&this->upper_boundary,this->src,
+			&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
+			&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
+		
 	}
 	Boundary(Type* src, Type lower_boundary, Type upper_boundary): src(src), lower_boundary(lower_boundary), upper_boundary(upper_boundary){}
 	Protections::FaultType check_bounds()override{
@@ -241,7 +241,7 @@ struct Boundary<void, ERROR_HANDLER> : public BoundaryInterface{
 	{
 		boundary_type_id = Protector;
 		error_handler_string.reserve(ERROR_HANDLER_MSG_MAX_LEN);
-		message = new HeapOrder(uint16_t{111},&boundary_type_id,&string_len,&name,&error_handler_string_len,&error_handler_string,
+		fault_message = new HeapOrder(uint16_t{1555},&boundary_type_id,&name,&error_handler_string,
 			&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 			&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
 	}
@@ -287,14 +287,14 @@ struct Boundary<Type, TIME_ACCUMULATION> : public BoundaryInterface {
 		name.reserve(NAME_MAX_LEN);
 		if(boundary.has_warning_level){
 			warning_threshold = boundary.warning_threshold;
-			message = new HeapOrder(uint16_t{111},&format_id,&boundary_type_id,&has_warning_level,&string_len,&name,&this->warning_threshold,&this->bound,this->src,&this->time_limit,&this->frequency,
-			&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
-			&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
-		}else{
-		message = new HeapOrder(uint16_t{111},&format_id,&boundary_type_id,&has_warning_level,&string_len,&name,&this->bound,this->src,&this->time_limit,&this->frequency,
+			warn_message = new HeapOrder(uint16_t{2666},&format_id,&boundary_type_id,&name,&this->warning_threshold,&this->bound,this->src,&this->time_limit,&this->frequency,
 			&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 			&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
 		}
+		fault_message = new HeapOrder(uint16_t{1666},&format_id,&boundary_type_id,&name,&this->bound,this->src,&this->time_limit,&this->frequency,
+			&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
+			&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
+		
 	}
 	Boundary(Type* src, Type bound ,float time_limit, float frequency): src(src),bound(bound) ,time_limit(time_limit), frequency(frequency),moving_order(frequency*time_limit/100), external_pointer(nullptr){}
 	bool has_warning_level{false};

--- a/Inc/ST-LIB_HIGH/Protections/Protection.hpp
+++ b/Inc/ST-LIB_HIGH/Protections/Protection.hpp
@@ -9,15 +9,15 @@
 class Protection{
 private:
     char* name = nullptr;
-    vector<unique_ptr<BoundaryInterface>> boundaries;
+    vector<shared_ptr<BoundaryInterface>> boundaries;
     BoundaryInterface* fault_protection = nullptr;
     static constexpr Protections::FaultType fault_type = Protections::FaultType::FAULT;
     uint8_t triggered_protecions_idx[4]{};
 public:
-    vector<BoundaryInterface*> warnings_triggered;
+    vector<shared_ptr<BoundaryInterface>> warnings_triggered;
     template<class Type, ProtectionType... Protector, template<class,ProtectionType> class Boundaries>
     Protection(Type* src, Boundaries<Type,Protector>... protectors) {
-        (boundaries.push_back(unique_ptr<BoundaryInterface>(new Boundary<Type,Protector>(src,protectors))), ...);
+        (boundaries.push_back(shared_ptr<BoundaryInterface>(new Boundary<Type,Protector>(src,protectors))), ...);
     }
 
     void set_name(char* name) {
@@ -32,8 +32,8 @@ public:
         uint8_t warning_count = 0;
         //to save the index of the triggered warning
         uint8_t idx = 0;
-        for(unique_ptr<BoundaryInterface>& bound: boundaries){
-            auto fault_type = bound.get()->check_bounds();
+        for(shared_ptr<BoundaryInterface>& bound: boundaries){
+            auto fault_type = bound->check_bounds();
             idx++;
             switch(fault_type){
                 // in case a Protection has more than one boundary, give priority to fault messages
@@ -54,7 +54,7 @@ public:
         }
         if(warning_count){
             for(uint8_t i = 0; i < warning_count; i++){
-                warnings_triggered.push_back(boundaries[triggered_protecions_idx[i]].get());
+                warnings_triggered.push_back(boundaries[triggered_protecions_idx[i]]);
             }
             return Protections::WARNING;
         }

--- a/Inc/ST-LIB_HIGH/Protections/Protection.hpp
+++ b/Inc/ST-LIB_HIGH/Protections/Protection.hpp
@@ -4,21 +4,17 @@
 #include "ErrorHandler/ErrorHandler.hpp"
 #include "Boundary.hpp"
 
-namespace Protections{
-enum FaultType : uint8_t{
-	FAULT = 0,
-	WARNING,
-    OK
-};
-}
+
 
 class Protection{
 private:
     char* name = nullptr;
     vector<unique_ptr<BoundaryInterface>> boundaries;
-    BoundaryInterface* jumped_protection = nullptr;
+    BoundaryInterface* fault_protection = nullptr;
     static constexpr Protections::FaultType fault_type = Protections::FaultType::FAULT;
+    uint8_t triggered_protecions_idx[4]{};
 public:
+    vector<BoundaryInterface*> warnings_triggered;
     template<class Type, ProtectionType... Protector, template<class,ProtectionType> class Boundaries>
     Protection(Type* src, Boundaries<Type,Protector>... protectors) {
         (boundaries.push_back(unique_ptr<BoundaryInterface>(new Boundary<Type,Protector>(src,protectors))), ...);
@@ -32,14 +28,37 @@ public:
         return name;
     }
 
-    bool check_state() {
+    Protections::FaultType check_state() {
+        uint8_t warning_count = 0;
+        //to save the index of the triggered warning
+        uint8_t idx = 0;
         for(unique_ptr<BoundaryInterface>& bound: boundaries){
-            if(not bound.get()->check_bounds()){
-                jumped_protection = bound.get();
-                return false;
+            auto fault_type = bound.get()->check_bounds();
+            idx++;
+            switch(fault_type){
+                // in case a Protection has more than one boundary, give priority to fault messages
+                case Protections::FAULT:
+                    fault_protection = bound.get();
+                    // adding the fault_protection to the vector is not desired,
+                    // the fault signal should propagate as fast as possible
+                    return Protections::FAULT;
+                case Protections::WARNING:
+                    //warnings are non fatal, but we cannot waste time, we need to check if any
+                    //faults were triggered
+                    triggered_protecions_idx[warning_count] = idx-1;
+                    warning_count++;
+                    break;
+                default:
+                    break;
             }
         }
-        return true;
+        if(warning_count){
+            for(uint8_t i = 0; i < warning_count; i++){
+                warnings_triggered.push_back(boundaries[triggered_protecions_idx[i]].get());
+            }
+            return Protections::WARNING;
+        }
+        return Protections::OK;
     }
     friend class ProtectionManager;
 };

--- a/Src/ST-LIB_HIGH/Protections/ProtectionManager.cpp
+++ b/Src/ST-LIB_HIGH/Protections/ProtectionManager.cpp
@@ -101,13 +101,13 @@ void ProtectionManager::notify(Protection& protection){
         protection.fault_protection->update_error_handler_message(protection.fault_protection->get_error_handler_string());
     }
     for(OrderProtocol* socket : OrderProtocol::sockets){
-        socket->send_order(*protection.fault_protection->message);
+        if(protection.fault_protection)
+            socket->send_order(*protection.fault_protection->message);
         for(auto& warning : protection.warnings_triggered){
             if(warning->boundary_type_id == ERROR_HANDLER){
                 warning->update_error_handler_message(warning->get_error_handler_string());
             }
             socket->send_order(*warning->message);
-            delete warning;
         }
         protection.warnings_triggered.clear();
     }

--- a/Src/ST-LIB_HIGH/Protections/ProtectionManager.cpp
+++ b/Src/ST-LIB_HIGH/Protections/ProtectionManager.cpp
@@ -102,12 +102,12 @@ void ProtectionManager::notify(Protection& protection){
     }
     for(OrderProtocol* socket : OrderProtocol::sockets){
         if(protection.fault_protection)
-            socket->send_order(*protection.fault_protection->message);
+            socket->send_order(*protection.fault_protection->fault_message);
         for(auto& warning : protection.warnings_triggered){
             if(warning->boundary_type_id == ERROR_HANDLER){
                 warning->update_error_handler_message(warning->get_error_handler_string());
             }
-            socket->send_order(*warning->message);
+            socket->send_order(*warning->warn_message);
         }
         protection.warnings_triggered.clear();
     }

--- a/Src/ST-LIB_HIGH/Protections/ProtectionManager.cpp
+++ b/Src/ST-LIB_HIGH/Protections/ProtectionManager.cpp
@@ -52,14 +52,17 @@ void ProtectionManager::fault_and_propagate(){
 
 void ProtectionManager::check_protections() {
     for (Protection& protection: low_frequency_protections) {
-        if (protection.check_state()) {
+        auto protection_status = protection.check_state();
+        if (protection_status == Protections::OK) {
             continue;
         }
         if(general_state_machine == nullptr){
         	ErrorHandler("Protection Manager does not have General State Machine Linked");
         	return;
         }
-        if(protection.fault_type == Protections::FAULT){
+        //ensure we only go to FAULT if a FAULT was triggered, and not only a WARNING
+        if(protection.fault_type == Protections::FAULT &&
+          protection_status == Protections::FAULT){
             ProtectionManager::to_fault();
         }
         Global_RTC::update_rtc_data();
@@ -94,12 +97,21 @@ void ProtectionManager::warn(string message){
 }
 
 void ProtectionManager::notify(Protection& protection){
-    if(protection.jumped_protection->boundary_type_id == ERROR_HANDLER){
-        protection.jumped_protection->update_error_handler_message(protection.jumped_protection->get_error_handler_string());
+    if(protection.fault_protection->boundary_type_id == ERROR_HANDLER){
+        protection.fault_protection->update_error_handler_message(protection.fault_protection->get_error_handler_string());
     }
     for(OrderProtocol* socket : OrderProtocol::sockets){
-        socket->send_order(*protection.jumped_protection->message);
+        socket->send_order(*protection.fault_protection->message);
+        for(auto& warning : protection.warnings_triggered){
+            if(warning->boundary_type_id == ERROR_HANDLER){
+                warning->update_error_handler_message(warning->get_error_handler_string());
+            }
+            socket->send_order(*warning->message);
+            delete warning;
+        }
+        protection.warnings_triggered.clear();
     }
+
 }
 
 Boards::ID ProtectionManager::board_id = Boards::ID::NOBOARD;


### PR DESCRIPTION
The code below should allow you to test Warnings and FAULTS triggered by ABOVE/BELOW protections, an also a general example for ErrorHandler, note that currently the GUI does not support this, and upon receiving a bad TCP message it will send  a FIN message, making debugging harder, ideally you should check with wireshark.


```cpp
enum MyStates{
	FAULT = 0,
	OPERATIONAL = 1,
};

int main(void)
{
	float read_value = 28.0f;
	IPV4 local_ip("192.168.0.3");
	STLIB::start("192.168.0.3");
	ServerSocket* backend = new ServerSocket(local_ip,50500);
	StateMachine state_machine;
	state_machine.add_state(MyStates::FAULT);
	state_machine.add_state(MyStates::OPERATIONAL);
	add_protection(&read_value,Boundary<float,BELOW>(22.0f,20.0f));
	ProtectionManager::initialize();
	ProtectionManager::link_state_machine(state_machine,MyStates::FAULT);
	ProtectionManager::set_id(Boards::ID::VCU);
	Time::register_low_precision_alarm(1000,[&read_value](){
		read_value -= 1.0;
	});
	Time::register_low_precision_alarm(20,ProtectionManager::check_protections);
	while(1) {
		STLIB::update();
		if(read_value < 0.0f){
			ErrorHandler("Protection worked fine");
		}
	}
}
```