### PR TITLE
NTC now uses same approach as other sensors

### DIFF
--- a/Inc/ST-LIB_LOW/Sensors/NTC/NTC.hpp
+++ b/Inc/ST-LIB_LOW/Sensors/NTC/NTC.hpp
@@ -17,8 +17,9 @@ This NTC class is not generic. It is only for 10k Ohm, 1976Beta value NTCs.
 class NTC{
 public:
 	NTC() = default;
-	NTC(Pin &pin);
-	float read();
+	NTC(Pin &pin, float* src);
+  NTC(Pin &pin, float& src);
+	void read();
 	uint8_t get_id();
 
 private:
@@ -497,7 +498,7 @@ private:
   -677, -688, -700, -714, -729, -748, -770, 
   -797, -835, -873
 };
-
+  float* value;
 	uint8_t id;
 };
 

--- a/Src/ST-LIB_LOW/Sensors/NTC/NTC.cpp
+++ b/Src/ST-LIB_LOW/Sensors/NTC/NTC.cpp
@@ -1,6 +1,11 @@
 #include "Sensors/NTC/NTC.hpp"
 
-NTC::NTC(Pin &pin){
+NTC::NTC(Pin &pin,float *src):value(src){
+    id = ADC::inscribe(pin);
+
+    Sensor::adc_id_list.push_back(id);
+}
+NTC::NTC(Pin &pin,float& src):value(&src){
     id = ADC::inscribe(pin);
 
     Sensor::adc_id_list.push_back(id);
@@ -10,10 +15,10 @@ uint8_t NTC::get_id(){
     return id;
 }
 
-float NTC::read() {
+void NTC::read() {
     int val = ADC::get_int_value(id) >> 4;
 
-    return NTC_table[val] * 0.1;
+    *value =  NTC_table[val] * 0.1;
 
     
 }


### PR DESCRIPTION
Minimal changes, so that NTC follows same approach as every other sensor, making it easier and more consistent to use