### PR TITLE
Changed send function name on DatagramSocket

### DIFF
--- a/Inc/HALAL/Services/Communication/Ethernet/UDP/DatagramSocket.hpp
+++ b/Inc/HALAL/Services/Communication/Ethernet/UDP/DatagramSocket.hpp
@@ -24,7 +24,7 @@ public:
 
 	void operator=(DatagramSocket&&);
 
-	bool send(Packet& packet){
+	bool send_packet(Packet& packet){
 		uint8_t* packet_buffer = packet.build();
 
 		struct pbuf* tx_buffer = pbuf_alloc(PBUF_TRANSPORT, packet.size, PBUF_RAM);


### PR DESCRIPTION
send is used in ServerSocket as a way to send raw data, while send_order is used to abstract that into sending the data of a full order.

On DatagramSocket send is not used to send raw data, but instead is the abstraction of that for the full send of a packet. This makes nomenclature inconsistent between two similar classes, so i changed it into send_packet. 

