### PR TITLE
ForwardOrder

### DIFF
--- a/Inc/HALAL/HALAL.hpp
+++ b/Inc/HALAL/HALAL.hpp
@@ -18,6 +18,7 @@
 #include "Communication/SPI/SPI.hpp"
 #include "Communication/UART/UART.hpp"
 #include "Communication/I2C/I2C.hpp"
+#include "Models/Packets/ForwardOrder.hpp"
 #include "Communication/Ethernet/UDP/DatagramSocket.hpp"
 #include "Communication/Ethernet/TCP/ServerSocket.hpp"
 #include "Communication/Ethernet/TCP/Socket.hpp"

--- a/Inc/HALAL/Models/Packets/ForwardOrder.hpp
+++ b/Inc/HALAL/Models/Packets/ForwardOrder.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+
+
+#include  "HALAL/Services/Communication/Ethernet/TCP/ServerSocket.hpp"
+
+template<size_t BufferLength,class... Types> requires NotCallablePack<Types*...>
+class ForwardOrder : public StackPacket<BufferLength,Types...>, public Order{
+public:
+    ForwardOrder(uint16_t id,ServerSocket& forwarder, Types*... values) : StackPacket<BufferLength,Types...>(id,values...) ,forwarding_socket{forwarder}{orders[id] = this;}
+
+    void process() override {
+        return;
+    }
+
+    void parse(void* data) override {
+        return;
+    }
+    void parse(OrderProtocol* socket, void* data) override{
+    	struct pbuf* packet = pbuf_alloc(PBUF_TRANSPORT, get_size(), PBUF_POOL);
+        pbuf_take(packet, data, get_size());
+        forwarding_socket.tx_packet_buffer.push(packet);
+        forwarding_socket.send();
+    }
+    size_t get_size() override {
+        return StackPacket<BufferLength,Types...>::get_size();
+    }
+    uint16_t get_id() override {
+        return StackPacket<BufferLength,Types...>::get_id();
+    }
+
+
+private:
+    void set_callback(void(*callback)(void))override{
+        return;
+    }
+    uint8_t* build() override {
+        return StackPacket<BufferLength,Types...>::build();
+    }
+    void set_pointer(size_t index, void* pointer) override{
+		StackPacket<BufferLength,Types...>::set_pointer(index, pointer);
+	}
+    // socket in charge of forwarding the order
+    ServerSocket& forwarding_socket;
+};
+
+#if __cpp_deduction_guides >= 201606
+template<class... Types> requires NotCallablePack<Types*...>
+ForwardOrder(uint16_t id,ServerSocket& fwd, Types*... values)->ForwardOrder<(!has_container<Types...>::value)*total_sizeof<Types...>::value, Types...>;
+#endif


### PR DESCRIPTION
ForwardOrder, the callback has been removed.
Visibility of unused methods has been changed to private, compiler optimizes better with this.
 Note that the can't be removed because Order is pure virtual.
The constructor takes in a normal order + the ServerSocket that should forward it, it takes it in as a reference so that it can never be null.

testing code, some more changes are needed to change the MAC addresses

The PWM does change on the oscilloscope.

```cpp
//#define CLIENT

#include "main.h"
#include "lwip.h"
#include "ST-LIB.hpp"
#include "Runes/Runes.hpp"

static_assert(HSE_VALUE==8'000'000);

uint16_t test_phase = 0;
float test_duty = 0;
DigitalOutput* d1;
PWM* test_with_payload;
void change_duty(){
	test_with_payload->set_duty_cycle(test_duty);
}
using namespace std::chrono_literals;
int main(void)
{
	d1 = new DigitalOutput(PB14);
	#ifdef CLIENT
		test_with_payload = new PWM{PB8};
		STLIB::start("192.168.1.8");	
		test_with_payload->turn_on();
		test_with_payload->set_frequency(10'000);
		test_with_payload->set_duty_cycle(0);
		Socket vcu_socket{IPV4{"192.168.1.8"},50500,"192.168.1.6",50400};
		StackOrder tcp_order{uint16_t{601},change_duty,&test_duty,&test_phase};
	#else
		STLIB::start("192.168.1.6");	
		ServerSocket ss{"192.168.1.6",50500};
		ServerSocket pcu_socket{IPV4{"192.168.1.6"},50400};
		ForwardOrder forwarding_order{uint16_t{601},pcu_socket,&test_duty,&test_phase};
	#endif
	d1->turn_on();
	Time::set_timeout(2000,[](){
		d1->turn_off();
	});
	while(1) {
		STLIB::update();		
	}
}
```

