### PR TITLE
Feature/improve forward order

### DIFF
--- a/Inc/HALAL/Models/Packets/ForwardOrder.hpp
+++ b/Inc/HALAL/Models/Packets/ForwardOrder.hpp
@@ -53,7 +53,7 @@ private:
     void set_pointer(size_t index, void* pointer) override{
 		StackPacket<BufferLength,Types...>::set_pointer(index, pointer);
 	}
-    // socket in charge of forwarding the order
+    // socket(s) in charge of forwarding the order
     vector<ServerSocket*>* forwarding_sockets{};
 };
 


### PR DESCRIPTION
Allow for callback, this way the forwarding socket can notify the board that an order was received,also it now allows to forward it to multiple sockets, using a vector is probably not desired.

This functionality is specially useful in demonstration environments.