### PR TITLE
Detect Ethernet cable disconnection

### DIFF
--- a/Inc/HALAL/Services/Communication/Ethernet/Ethernet.hpp
+++ b/Inc/HALAL/Services/Communication/Ethernet/Ethernet.hpp
@@ -12,6 +12,7 @@
 #include "EthernetNode.hpp"
 #include "lwip.h"
 #include "ethernetif.h"
+#include "EthernetHelper.hpp"
 #ifdef HAL_ETH_MODULE_ENABLED
 
 #define ETHERNET_POOLS_BASE_ADDRESS 0x30000000

--- a/Inc/HALAL/Services/Communication/Ethernet/EthernetHelper.hpp
+++ b/Inc/HALAL/Services/Communication/Ethernet/EthernetHelper.hpp
@@ -1,0 +1,10 @@
+/**
+ * this file is used to be included inside LWIP, so it cannot have any C++ dependencies
+ * also declared global and extern to indicate external linkage, then lwip.c includes 
+ * this file and has the symbol.
+ * 
+ *
+*/
+#pragma once
+#include <stdbool.h>
+extern bool ETH_is_cable_connected;

--- a/Src/HALAL/Services/Communication/Ethernet/Ethernet.cpp
+++ b/Src/HALAL/Services/Communication/Ethernet/Ethernet.cpp
@@ -16,7 +16,6 @@ extern struct netif gnetif;
 extern ip4_addr_t ipaddr, netmask, gw;
 extern uint8_t IP_ADDRESS[4], NETMASK_ADDRESS[4], GATEWAY_ADDRESS[4];
 
-bool ETH_is_cable_connected = false;
 bool Ethernet::is_ready = false;
 bool Ethernet::is_running = false;
 

--- a/Src/HALAL/Services/Communication/Ethernet/Ethernet.cpp
+++ b/Src/HALAL/Services/Communication/Ethernet/Ethernet.cpp
@@ -132,7 +132,7 @@ void Ethernet::update(){
 	//important to call it here, as ethernetif_input is where it 
 	//actually checks the link status, if we didnt check before we would HardFault
 		if(not ETH_is_cable_connected){
-			ErrorHandler("Cable has been disconnected");
+			ErrorHandler("Ethernet cable has been disconnected");
 		return;
 	}
 	sys_check_timeouts();


### PR DESCRIPTION
Basic changes that need the template-project updates otherwise it doesn't compile.
This detection is way faster than waiting for keepalives, which I'm not sure if detected this kind of failure