### PR TITLE
State order fix

### DIFF
--- a/Inc/ST-LIB_LOW/StateMachine/StateOrder.hpp
+++ b/Inc/ST-LIB_LOW/StateMachine/StateOrder.hpp
@@ -9,10 +9,10 @@ public:
 		REMOVE_STATE_ORDERS = 6
 	};
 	static OrderProtocol* informer_socket;
-	static uint8_t state_orders_ids_size;
+	static uint16_t state_orders_ids_size;
 	static vector<uint16_t>* state_orders_ids;
-	static StackOrder<0,uint8_t, vector<uint16_t>> add_state_orders_order;
-	static StackOrder<0,uint8_t, vector<uint16_t>> remove_state_orders_order;
+	static StackOrder<0,uint16_t, vector<uint16_t>> add_state_orders_order;
+	static StackOrder<0,uint16_t, vector<uint16_t>> remove_state_orders_order;
 
 	static void set_socket(OrderProtocol& socket){
 		informer_socket = &socket;

--- a/Src/ST-LIB_LOW/StateMachine/StateOrder.cpp
+++ b/Src/ST-LIB_LOW/StateMachine/StateOrder.cpp
@@ -1,7 +1,7 @@
 #include "StateMachine/StateOrder.hpp"
 
 OrderProtocol* StateOrder::informer_socket = nullptr;
-uint8_t StateOrder::state_orders_ids_size = 0;
+uint16_t StateOrder::state_orders_ids_size = 0;
 vector<uint16_t>* StateOrder::state_orders_ids = nullptr;
-StackOrder<0,uint8_t, vector<uint16_t>> StateOrder::add_state_orders_order(StateOrdersID::ADD_STATE_ORDERS, &StateOrder::state_orders_ids_size, StateOrder::state_orders_ids);
-StackOrder<0,uint8_t, vector<uint16_t>> StateOrder::remove_state_orders_order(StateOrdersID::REMOVE_STATE_ORDERS, &StateOrder::state_orders_ids_size, StateOrder::state_orders_ids);
+StackOrder<0,uint16_t, vector<uint16_t>> StateOrder::add_state_orders_order(StateOrdersID::ADD_STATE_ORDERS, &StateOrder::state_orders_ids_size, StateOrder::state_orders_ids);
+StackOrder<0,uint16_t, vector<uint16_t>> StateOrder::remove_state_orders_order(StateOrdersID::REMOVE_STATE_ORDERS, &StateOrder::state_orders_ids_size, StateOrder::state_orders_ids);


### PR DESCRIPTION
Se han cambiado el tamaño de los vectores de uint8_t a uint16_t para hacerlos compatibles con el backend