### PR TITLE
time config now working on runes

### DIFF
--- a/Inc/HALAL/Services/Time/Time.hpp
+++ b/Inc/HALAL/Services/Time/Time.hpp
@@ -17,7 +17,6 @@
 #include "HALAL/Services/Time/RTC.hpp"
 // HIGH RESOLUTION TIMERS
 extern TIM_HandleTypeDef htim2;		// Used for the global timer (3,36nS step)
-
 extern TIM_HandleTypeDef htim5;		// Used for the high precision alarms (1uS)
 extern TIM_HandleTypeDef htim24;	// Used for the high precision alarms (1uS)
 
@@ -41,6 +40,8 @@ private :
 		bool is_on = false;
 	};
 
+
+
 	static constexpr uint32_t HIGH_PRECISION_MAX_ARR = 4294967295;
 	static constexpr uint32_t MID_PRECISION_MAX_ARR = 4294967295;
 	static constexpr uint32_t mid_precision_step_in_us = 50;
@@ -48,6 +49,9 @@ private :
 	static uint64_t low_precision_tick;
 	static uint64_t mid_precision_tick;
 	static bool mid_precision_registered;
+
+	static unordered_map<TIM_HandleTypeDef*, TIM_TypeDef*> timer32_by_timer32handler_map;
+	static unordered_map<TIM_HandleTypeDef*, IRQn_Type> timer32interrupt_by_timer32handler_map;
 
 	static unordered_map<uint8_t, Alarm> high_precision_alarms_by_id;
 	static unordered_map<TIM_HandleTypeDef*, Alarm> high_precision_alarms_by_timer;
@@ -62,6 +66,7 @@ private :
 	static void init_timer(TIM_TypeDef* tim, TIM_HandleTypeDef* htim,uint32_t prescaler, uint32_t period, IRQn_Type interrupt_channel);
 	static void ConfigTimer(TIM_HandleTypeDef* tim, uint32_t period_in_us);
 	static bool is_valid_timer(TIM_HandleTypeDef* tim);
+	static void hal_enable_timer(TIM_HandleTypeDef* tim);
 
 public :
 	static TIM_HandleTypeDef* global_timer;

--- a/Src/HALAL/Services/Time/Time.cpp
+++ b/Src/HALAL/Services/Time/Time.cpp
@@ -108,10 +108,6 @@ void Time::hal_enable_timer(TIM_HandleTypeDef* tim){
 // PUBLIC SERVICE METHODS
 
 uint64_t Time::get_global_tick(){
-	if(global_timer == nullptr){
-		ErrorHandler("tried to use global tick without global timer configured");
-		return 0;
-	}
 	uint64_t current_tick = Time::global_tick + global_timer->Instance->CNT;
 	uint32_t apb1_tim_freq = HAL_RCC_GetPCLK1Freq()*2;
 	double to_nanoseconds = 1.0 / apb1_tim_freq * 1000000000.0;


### PR DESCRIPTION
Lets you configure on runes what timer should be high, mid or global, or even disable them by putting nullptr on the respective pointer (or leaving the set empty for the high timers)

For any project that copied the template before this patch, it is needed to add on runes the next lines, on line 144:`
```
TIM_HandleTypeDef* Time::global_timer = &htim2;
set<TIM_HandleTypeDef*> Time::high_precision_timers = {&htim5, &htim24};
TIM_HandleTypeDef* Time::mid_precision_timer = &htim23;
```

This is the standard configuration used before this patch. 