### PR TITLE
Feature/compiles without warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,9 +68,13 @@ target_compile_options(${LIBRARY} PUBLIC
   -ffunction-sections
   -fdata-sections
   -fno-exceptions
+  ## disable Warnings for C files, this is Driver code from ST
+  $<$<COMPILE_LANGUAGE:C>:-w>
   $<$<COMPILE_LANGUAGE:CXX>:-fno-use-cxa-atexit>
   $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>
-
+  $<$<COMPILE_LANGUAGE:CXX>:-Wall>
+  $<$<COMPILE_LANGUAGE:CXX>:-Wpedantic>
+  $<$<COMPILE_LANGUAGE:CXX>:-Werror>
   -Wno-psabi
   -specs=nosys.specs
 )

--- a/Inc/C++Utilities/RingBuffer.hpp
+++ b/Inc/C++Utilities/RingBuffer.hpp
@@ -15,7 +15,6 @@ public:
 	/**
 	 * @brief introduces a new item on the Ring Buffer unless it is full. Returns false when the Ring Buffer is full.
 	 */
-	[[nodiscard("Push may fail if the Buffer is full")]]
 	bool push(item_type item){
 		if(msize == mcapacity){
 			return false;

--- a/Inc/HALAL/Models/Packets/ForwardOrder.hpp
+++ b/Inc/HALAL/Models/Packets/ForwardOrder.hpp
@@ -13,10 +13,10 @@ public:
         return;
     }
 
-    void parse(void* data) override {
+    void parse(uint8_t* data) override {
         return;
     }
-    void parse(OrderProtocol* socket, void* data) override{
+    void parse(OrderProtocol* socket, uint8_t* data) override{
     	struct pbuf* packet = pbuf_alloc(PBUF_TRANSPORT, get_size(), PBUF_POOL);
         pbuf_take(packet, data, get_size());
         forwarding_socket.tx_packet_buffer.push(packet);

--- a/Inc/HALAL/Models/Packets/Order.hpp
+++ b/Inc/HALAL/Models/Packets/Order.hpp
@@ -13,14 +13,14 @@ class Order : public Packet{
 public:
     virtual void set_callback(void(*callback)(void)) = 0;
     virtual void process() = 0;
-    virtual void parse(OrderProtocol* socket, void* data) = 0;
-    void parse(void* data) override {
+    virtual void parse(OrderProtocol* socket, uint8_t* data) = 0;
+    void parse(uint8_t* data) override {
     	parse(nullptr, data);
     }
     static void process_by_id(uint16_t id) {
         if (orders.find(id) != orders.end()) orders[id]->process();
     }
-    static void process_data(OrderProtocol* socket, void* data) {
+    static void process_data(OrderProtocol* socket, uint8_t* data) {
         uint16_t id = Packet::get_id(data);
         if (orders.contains(id)) {
             orders[id]->parse(socket, data);
@@ -47,10 +47,10 @@ public:
     uint8_t* build() override {
         return StackPacket<BufferLength,Types...>::build();
     }
-    void parse(void* data) override {
+    void parse(uint8_t* data) override {
         StackPacket<BufferLength,Types...>::parse(data);
     }
-    void parse(OrderProtocol* socket, void* data) override{
+    void parse(OrderProtocol* socket, uint8_t* data) override{
     	parse(data);
     }
     size_t get_size() override {
@@ -91,10 +91,10 @@ public:
     uint8_t* build() override {
         return HeapPacket::build();
     }
-    void parse(void* data) override {
+    void parse(uint8_t* data) override {
         HeapPacket::parse(data);
     }
-    void parse(OrderProtocol* socket, void* data){
+    void parse(OrderProtocol* socket, uint8_t* data){
     	parse(data);
     }
     size_t get_size() override {

--- a/Inc/HALAL/Models/Packets/Packet.hpp
+++ b/Inc/HALAL/Models/Packets/Packet.hpp
@@ -7,14 +7,14 @@ class Packet{
 public:
     size_t size;
     virtual uint8_t* build() = 0;
-    virtual void parse(void* data) = 0;
+    virtual void parse(uint8_t* data) = 0;
     virtual size_t get_size() = 0;
     virtual uint16_t get_id() = 0; 
     virtual void set_pointer(size_t index, void* pointer) = 0;
-    static uint16_t get_id(void* data) {
+    static uint16_t get_id(uint8_t* data) {
         return *((uint16_t*)data);
     }
-    static void parse_data(void* data){
+    static void parse_data(uint8_t* data){
         uint16_t id = get_id(data);
         if(packets.contains(id)) packets[id]->parse(data);
     }
@@ -38,7 +38,7 @@ public:
         packets[id] = this;
         size = BufferLength + sizeof(id);
     }
-    void parse(void* data) override {
+    void parse(uint8_t* data) override {
         data+=sizeof(id);
         for (PacketValue<>* value : values) {
             value->parse(data);
@@ -86,7 +86,7 @@ public:
         packets[id] = this;
     }
 
-    void parse(void* data) override {
+    void parse(uint8_t* data) override {
         data+=sizeof(id);
         for (PacketValue<>* value : values) {
             value->parse(data);
@@ -144,7 +144,7 @@ public:
     const size_t size = sizeof(id);
     StackPacket() = default;
     StackPacket(uint16_t id) : id(id){packets[id] = this;}
-    void parse(void* data) override {}
+    void parse(uint8_t* data) override {}
     uint8_t* build() override {
         return (uint8_t*)&id;
     }
@@ -181,7 +181,7 @@ public:
     	packets[id] = this;
     }
 
-    void parse(void* data) override {
+    void parse(uint8_t* data) override {
         data += sizeof(id);
         for (unique_ptr<PacketValue<>>& value : values) {
             value.get()->parse(data);

--- a/Inc/HALAL/Models/Packets/PacketValue.hpp
+++ b/Inc/HALAL/Models/Packets/PacketValue.hpp
@@ -16,8 +16,8 @@ public:
     virtual void* get_pointer() = 0;
     virtual void set_pointer(void* pointer) = 0;
     virtual size_t get_size() = 0;
-    virtual void parse(void* data) = 0;
-    virtual void copy_to(void* data) = 0;
+    virtual void parse(uint8_t* data) = 0;
+    virtual void copy_to(uint8_t* data) = 0;
 };
 
 template<class Type> requires NotContainer<Type> 
@@ -39,10 +39,10 @@ public:
     size_t get_size() override {
         return sizeof(Type);
     }
-    void parse(void* data) override {
+    void parse(uint8_t* data) override {
         *src = *((Type*)data);
     }
-    void copy_to(void* data) override {
+    void copy_to(uint8_t* data) override {
         *((Type*)data) = *src;
     }
 };
@@ -67,10 +67,10 @@ public:
     size_t get_size() override {
         return sizeof(double);
     }
-    void parse(void* data) override {
+    void parse(uint8_t* data) override {
         *src = *((double*)data);
     }
-    void copy_to(void* data) override {
+    void copy_to(uint8_t* data) override {
         memcpy(data,src,get_size());
     }
 };
@@ -98,10 +98,10 @@ public:
     size_t get_size() override {
         return src->size()*sizeof(typename Type::value_type);
     }
-    void parse(void* data) override {
+    void parse(uint8_t* data) override {
         memcpy(src->data(), data, get_size());
     }
-    void copy_to(void* data) override {
+    void copy_to(uint8_t* data) override {
         memcpy(data, src->data(), get_size());
     }
 };
@@ -130,10 +130,10 @@ public:
     size_t get_size() override {
         return strlen(src->c_str()) + 1;
     }
-    void parse(void* data) override {
+    void parse(uint8_t* data) override {
         memcpy(src->data(), data, get_size());
     }
-    void copy_to(void* data) override {
+    void copy_to(uint8_t* data) override {
         memcpy(data, src->data(), get_size());
     }
 };
@@ -157,10 +157,10 @@ public:
     size_t get_size() override {
         return N*sizeof(Type);
     }
-    void parse(void* data) override {
+    void parse(uint8_t* data) override {
         memcpy(src, data, get_size());
     }
-    void copy_to(void* data) override {
+    void copy_to(uint8_t* data) override {
         memcpy(data, src, get_size());
     }
 };
@@ -189,13 +189,13 @@ public:
     size_t get_size() override {
         return N*sizeof(Type);
     }
-    void parse(void* data) override {
+    void parse(uint8_t* data) override {
         for(Type* i : *src) {
             *i = *(Type*)data;
             data += sizeof(Type);
         }
     }
-    void copy_to(void* data) override {
+    void copy_to(uint8_t* data) override {
         for(Type* i : *src) {
             *(Type*)data = *i;
             data += sizeof(Type);

--- a/Inc/HALAL/Models/Packets/SPIOrder.hpp
+++ b/Inc/HALAL/Models/Packets/SPIOrder.hpp
@@ -174,8 +174,9 @@ public:
 	SPIBasePacket& slave_packet;
 
 	SPIStackOrder(uint16_t id, SPIBasePacket& master_packet, SPIBasePacket& slave_packet) :
-	master_packet(master_packet), slave_packet(slave_packet),
-	SPIBaseOrder(id, (uint16_t)master_packet.size, (uint16_t)slave_packet.size){
+	SPIBaseOrder(id, (uint16_t)master_packet.size, (uint16_t)slave_packet.size),
+	master_packet(master_packet), slave_packet(slave_packet)
+	{
 
 	}
 

--- a/Inc/HALAL/Models/Packets/SPIPacket.hpp
+++ b/Inc/HALAL/Models/Packets/SPIPacket.hpp
@@ -23,7 +23,7 @@ public:
 	/**
 	 * @brief function that receives binary data and uses it to update the variables
 	 */
-	virtual void parse(void* data) = 0;
+	virtual void parse(uint8_t* data) = 0;
 
 	/**
 	 * @brief function that transforms the variables into binary data and saves it on the buffer
@@ -50,7 +50,7 @@ public:
         SPIBasePacket::buffer = buffer;
     }
 
-    void parse(void* data) override {
+    void parse(uint8_t* data) override {
         for (PacketValue<>* value : values) {
             value->parse(data);
             data += value->get_size();
@@ -75,7 +75,7 @@ public:
     	size = 0;
     }
 
-    void parse(void* data) override {
+    void parse(uint8_t* data) override {
     }
 
     uint8_t* build() override {

--- a/Inc/HALAL/Models/TimerPeripheral/TimerPeripheral.hpp
+++ b/Inc/HALAL/Models/TimerPeripheral/TimerPeripheral.hpp
@@ -48,12 +48,12 @@ public:
 	private:
 		InitData() = default;
 	public:
+		TIM_TYPE type;
 		uint32_t prescaler;
 		uint32_t period;
 		uint32_t deadtime;
 		uint32_t polarity;
 		uint32_t negated_polarity;
-		TIM_TYPE type;
 		vector<PWMData> pwm_channels = {};
 		vector<pair<uint32_t, uint32_t>> input_capture_channels = {};
 		InitData(TIM_TYPE type, uint32_t prescaler = 5,

--- a/Inc/ST-LIB_HIGH/Protections/Notification.hpp
+++ b/Inc/ST-LIB_HIGH/Protections/Notification.hpp
@@ -70,7 +70,7 @@ public:
     	}
     }
 
-    void parse(OrderProtocol* socket, void* data) {
+    void parse(OrderProtocol* socket, uint8_t* data) {
     	received_socket = socket;
     	char* temp = (char*)malloc(get_string_size(data));
     	memcpy(temp, data+sizeof(id)+sizeof(message_size_t), get_string_size(data));
@@ -98,7 +98,7 @@ public:
 
 private:
 
-    uint16_t get_string_size(void* buffer){
+    uint16_t get_string_size(uint8_t* buffer){
     	return *(uint16_t*)(buffer + sizeof(id));
     }
 };

--- a/Inc/ST-LIB_LOW/StateMachine/HeapStateOrder.hpp
+++ b/Inc/ST-LIB_LOW/StateMachine/HeapStateOrder.hpp
@@ -21,7 +21,7 @@ public:
     	if (callback != nullptr && state_machine.is_on && state_machine.current_state == state) callback();
     }
 
-    void parse(OrderProtocol* socket, void* data)override{
+    void parse(OrderProtocol* socket, uint8_t* data)override{
     	if(state_machine.is_on && state_machine.current_state == state) HeapOrder::parse(data);
     }
 };

--- a/Inc/ST-LIB_LOW/StateMachine/StackStateOrder.hpp
+++ b/Inc/ST-LIB_LOW/StateMachine/StackStateOrder.hpp
@@ -20,7 +20,7 @@ public:
     	if (this->callback != nullptr && state_machine.is_on && state_machine.current_state == state) this->callback();
     }
 
-    void parse(OrderProtocol* socket, void* data)override{
+    void parse(OrderProtocol* socket, uint8_t* data)override{
     	if(state_machine.is_on && state_machine.current_state == state) StackOrder<BufferLength,Types...>::parse(data);
     }
 };

--- a/Src/HALAL/Models/TimerPeripheral/TimerPeripheral.cpp
+++ b/Src/HALAL/Models/TimerPeripheral/TimerPeripheral.cpp
@@ -24,10 +24,10 @@ map<TIM_HandleTypeDef*, TIM_TypeDef*> TimerPeripheral::handle_to_timer= {
 
 TimerPeripheral::InitData::InitData(
 		TIM_TYPE type, uint32_t prescaler, uint32_t period, uint32_t deadtime, uint32_t polarity, uint32_t negated_polarity) :
+		type(type),
 		prescaler(prescaler),
 		period(period),
 		deadtime(deadtime),
-		type(type),
 		polarity(polarity),
 		negated_polarity(negated_polarity)
 		{}

--- a/Src/HALAL/Services/Flash/Flash.cpp
+++ b/Src/HALAL/Services/Flash/Flash.cpp
@@ -40,12 +40,12 @@ bool Flash::write(uint32_t * source, uint32_t dest_addr, uint32_t number_of_word
 	uint32_t end_address = dest_addr + ((number_of_words * 4) - 4);
 	uint32_t end_sector = Flash::get_sector(end_address);
 	uint8_t number_of_sectors = end_sector - start_sector + 1;
-	uint32_t buffer[SECTOR_SIZE_IN_WORDS * number_of_sectors];
+	std::unique_ptr<uint32_t[]> buffer = std::make_unique_for_overwrite<uint32_t[]>(SECTOR_SIZE_IN_WORDS * number_of_sectors);
 	start_relative_position_in_words = (dest_addr - start_sector_addr) / 4 ;
 	end_relative_position_in_words = start_relative_position_in_words + number_of_words - 1;
 	source_pos = 0;
 
-	Flash::read(start_sector_addr, buffer, SECTOR_SIZE_IN_WORDS * number_of_sectors);
+	Flash::read(start_sector_addr, buffer.get(), SECTOR_SIZE_IN_WORDS * number_of_sectors);
 	for (buff_pos = start_relative_position_in_words; buff_pos <= end_relative_position_in_words && source_pos < number_of_words; ++buff_pos ) {
 		buffer[buff_pos] = source[source_pos];
 		source_pos++;

--- a/Src/ST-LIB_LOW/StateMachine/StateMachine.cpp
+++ b/Src/ST-LIB_LOW/StateMachine/StateMachine.cpp
@@ -248,7 +248,7 @@ void StateMachine::add_state_machine(StateMachine& state_machine, uint8_t state)
  * checks for transitions in a nested state machine if applicable.
  */
 void StateMachine::check_transitions() {
-	for (auto const state_transition : transitions[current_state]) {
+	for (auto const& state_transition : transitions[current_state]) {
 		if (state_transition.second()) {
 			force_change_state(state_transition.first);
 		}


### PR DESCRIPTION
Add `-Werror` option to C++ compilation,
additionally added `-Wall` and `-Wpedantic` compiler flags to C++ compilation.

Changed the code to make it compliant with these compiler settings, the changes involve mostly replacing `void*` with `uint8_t*` and fixing `-Wreorder` warnings.

Also removed `[[nodiscard]]` attribute from RingBuffer impl.

Fixed some other warnings.