### PR TITLE
[FW-59] DualPWM

### DIFF
--- a/Inc/HALALMock/Models/PinModel/Pin.hpp
+++ b/Inc/HALALMock/Models/PinModel/Pin.hpp
@@ -83,8 +83,8 @@ enum class PinType {
 	DigitalOutput,
 	DigitalInput,
 	PWM,
-	ADC,
-	DualPWM
+	DualPWM,
+	ADC
 	// TODO: Add more types
 };
 
@@ -105,7 +105,7 @@ struct EmulatedPin {
 			std::chrono::nanoseconds dead_time_ns;
 		} PWM;
 		struct {
-			float duty cycle;
+			float duty_cycle;
 			uint32_t frequency;
 			bool is_on = false;
 			std::chrono::nanoseconds dead_time_ns;

--- a/Inc/HALALMock/Models/PinModel/Pin.hpp
+++ b/Inc/HALALMock/Models/PinModel/Pin.hpp
@@ -83,7 +83,8 @@ enum class PinType {
 	DigitalOutput,
 	DigitalInput,
 	PWM,
-	ADC
+	ADC,
+	DualPWM
 	// TODO: Add more types
 };
 
@@ -103,6 +104,12 @@ struct EmulatedPin {
 			bool is_on;
 			std::chrono::nanoseconds dead_time_ns;
 		} PWM;
+		struct {
+			float duty cycle;
+			uint32_t frequency;
+			bool is_on = false;
+			std::chrono::nanoseconds dead_time_ns;
+		}DualPWM;
 		struct {
 			// TODO FW-54
 		} ADC;

--- a/Inc/HALALMock/Services/PWM/DualPWM/DualPWM.hpp
+++ b/Inc/HALALMock/Services/PWM/DualPWM/DualPWM.hpp
@@ -1,27 +1,17 @@
-/*
- * DualPWMInstance.hpp
- *
- *  Created on: Feb 27, 2023
- *      Author: aleja
- */
-
 #pragma once
 
-#include "PWM/PWM/PWM.hpp"
+#include "HALALMock/Services/PWM/PWM/PWM.hpp"
 
 class DualPWM{
 protected:
 	DualPWM() = default;
-	TimerPeripheral* peripheral;
-	uint32_t channel;
-	float duty_cycle;
-	uint32_t frequency;
-	bool is_on = false;
-	static constexpr float CLOCK_FREQ_MHZ_WITHOUT_PRESCALER = 275;
-	static constexpr float clock_period_ns = (1/CLOCK_FREQ_MHZ_WITHOUT_PRESCALER)*1'000;
-	bool is_initialized = false;
+	float* duty_cycle{};
+	uint32_t* frequency{};
+	bool positive_is_on*{};
+	bool negative_is_on*{};
+	std::chrono::nanoseconds *dead_time_ns{};
 public:
-	DualPWM(Pin& pin, Pin& pin_negated);
+	DualPWM(Pin& pin_pos, Pin& pin_neg);
 
 	void turn_on();
 	void turn_on_positive();

--- a/Inc/HALALMock/Services/PWM/DualPWM/DualPWM.hpp
+++ b/Inc/HALALMock/Services/PWM/DualPWM/DualPWM.hpp
@@ -11,7 +11,7 @@ protected:
 	bool negative_is_on*{};
 	std::chrono::nanoseconds *dead_time_ns{};
 public:
-	DualPWM(Pin& pin_pos, Pin& pin_neg);
+	DualPWM(Pin& pin, Pin& pin_negated);
 
 	void turn_on();
 	void turn_on_positive();

--- a/Src/HALALMock/Services/PWM/DualPWM/DualPWM.cpp
+++ b/Src/HALALMock/Services/PWM/DualPWM/DualPWM.cpp
@@ -1,121 +1,92 @@
-/*
- * DualPWM.cpp
- *
- *  Created on: Feb 27, 2023
- *      Author: aleja
- */
+#include "HALALMock/Services/PWM/DualPWM/DualPWM.hpp"
 
-#include "PWM/DualPWM/DualPWM.hpp"
-#include "ErrorHandler/ErrorHandler.hpp"
-#include "stm32h7xx_hal_def.h"
+DualPWM::DualPWM(Pin& pin_pos, Pin& pin_neg) {
+	EmulatedPin &pin_positive = SharedMemory::get_pin(pin_pos);
+	EmulatedPin &pin_negative = SharedMemory::get_pin(pin_neg);
 
-DualPWM::DualPWM(Pin& pin, Pin& pin_negated) {
-	if (not TimerPeripheral::available_dual_pwms.contains({pin, pin_negated})) {
-		ErrorHandler("Pins %s and %s are not registered as an available Dual PWM", pin.to_string(), pin_negated.to_string());
+	if(pin_positive.type==PinType::NOT_USED && pin_negative.type==PinType::NOT_USED){
+		if(pin_positive.type==PinType::NOT_USED)
+		{
+			pin_positive.type=PinType::DualPWM;
+			// for common values between positive and negative pin, class variables
+			// point to the positive pin memory location, then the negative pin 
+			// copies the value
+			this->duty_cycle=&(pin_positive.PinData.DualPWM.duty_cycle);
+			this->frequency=&(pin_positive.PinData.DualPWM.frequency);
+			positive_is_on=&(pin_positive.PinData.DualPWM.is_on);
+			this->dead_time_ns=&(pin_positive.PinData.DualPWM.dead_time_ns);
+		}
+		if(pin_negative.type==PinType::NOT_USED)
+		{
+			pin_negative.type=PinType::DualPWM;
+			negative_is_on=&(pin_negative.PinData.DualPWM.is_on);
+		}
+	}else{
+		ErrorHandler("Pin %s or %s is already in use", pin_pos.to_string(), pin_neg.to_string());
 	}
 
-	TimerPeripheral& timer = TimerPeripheral::available_dual_pwms.at({pin, pin_negated}).first;
-	TimerPeripheral::PWMData& pwm_data = TimerPeripheral::available_dual_pwms.at({pin, pin_negated}).second;
+	//default values
 
-	peripheral = &timer;
-	channel = pwm_data.channel;
-
-	if (pwm_data.mode != TimerPeripheral::PWM_MODE::NORMAL) {
-		ErrorHandler("Pins %s and %s are not registered as a DUAL PWM", pin.to_string(), pin_negated.to_string());
-	}
-
-	Pin::inscribe(pin, TIMER_ALTERNATE_FUNCTION);
-	Pin::inscribe(pin_negated, TIMER_ALTERNATE_FUNCTION);
-	timer.init_data.pwm_channels.push_back(pwm_data);
-
-	duty_cycle = 0;
+	*(this->duty_cycle)=0.0f;
+	pin_negative.PinData.DualPWM.duty_cycle=*(this->duty_cycle);
+	*(this->frequency)=0;
+	pin_negative.PinData.DualPWM.frequency=*(this->frequency);
+	*positive_is_on=false;
+	*negative_is_on=false;
+	*(this->dead_time_ns)=0;
+	pin_negative.PinData.DualPWM.dead_time_ns=*(this->dead_time_ns);
 }
 
-void DualPWM::turn_on() {
-  if (HAL_TIM_PWM_Start(peripheral->handle, channel) != HAL_OK) {
-    ErrorHandler("Dual PWM positive channel did not start correctly", 0);
-  }
 
-  if (HAL_TIMEx_PWMN_Start(peripheral->handle, channel) != HAL_OK) {
-    ErrorHandler("Dual PWM negative channel did not start correctly", 0);
-  }
+void DualPWM::turn_on() {
+	*positive_is_on=true;
+	*negative_is_on=true;
 }
 
 void DualPWM::turn_off() {
-
-  if (HAL_TIM_PWM_Stop(peripheral->handle, channel) != HAL_OK) {
-    ErrorHandler("Dual PWM positive channel did not stop correctly", 0);
-  }
-
-  if (HAL_TIMEx_PWMN_Stop(peripheral->handle, channel) != HAL_OK) {
-    ErrorHandler("Dual PWM negative channel did not stop correctly", 0);
-  }
+	*positive_is_on=false;
+	*negative_is_on=false;
 }
 
 void DualPWM::turn_on_positive() {
-  if (HAL_TIM_PWM_Start(peripheral->handle, channel) != HAL_OK) {
-	ErrorHandler("Dual PWM positive channel did not start correctly", 0);
-  }
+	*positive_is_on=true;
+	*negative_is_on=false;
 }
 
 void DualPWM::turn_on_negated() {
-  if (HAL_TIMEx_PWMN_Start(peripheral->handle, channel) != HAL_OK) {
-	ErrorHandler("Dual PWM negative channel did not start correctly", 0);
-  }
+  	*positive_is_on=false;
+	*negative_is_on=true;
 }
 
 void DualPWM::turn_off_positive() {
-  if (HAL_TIM_PWM_Stop(peripheral->handle, channel) != HAL_OK) {
-	ErrorHandler("Dual PWM positive channel did not stop correctly", 0);
-  }
+  	*positive_is_on=false;
 }
 
 void DualPWM::turn_off_negated() {
-  if (HAL_TIMEx_PWMN_Stop(peripheral->handle, channel) != HAL_OK) {
-	ErrorHandler("Dual PWM negative channel did not stop correctly", 0);
-  }
+	*negative_is_on=false;
 }
 
-void DualPWM::set_duty_cycle(float duty_cycle){
-	uint16_t raw_duty = __HAL_TIM_GET_AUTORELOAD(peripheral->handle) / 100.0 * duty_cycle;
-	__HAL_TIM_SET_COMPARE(peripheral->handle, channel, raw_duty);
-	this->duty_cycle = duty_cycle;
+void DualPWM::set_duty_cycle(float dc){
+	*(this->duty_cycle) = dc;
 }
-void DualPWM::set_frequency(uint32_t freq_in_hz){
-  	this->frequency = freq_in_hz;
-	TIM_TypeDef& timer = *peripheral->handle->Instance;
-	timer.ARR = (HAL_RCC_GetPCLK1Freq()*2 / (timer.PSC+1)) / frequency;
-	set_duty_cycle(duty_cycle);
+void DualPWM::set_frequency(uint32_t freq){
+  	*(this->frequency) = freq;
 }
 uint32_t DualPWM::get_frequency()const{
-  return frequency;
+  return *(this->frequency);
 }
 float DualPWM::get_duty_cycle()const{
-  return duty_cycle;
+  return *(this->duty_cycle);
 }
-void DualPWM::set_dead_time(std::chrono::nanoseconds dead_time_ns)
+void DualPWM::set_dead_time(std::chrono::nanoseconds dead_t_ns)
 {
-	TIM_BreakDeadTimeConfigTypeDef sBreakDeadTimeConfig = {0};
-	
-	// per https://hasanyavuz.ozderya.net/?p=437
-	auto time = dead_time_ns.count();
-
-	if(time <= 127 * clock_period_ns){
-		sBreakDeadTimeConfig.DeadTime = time/clock_period_ns;
-	}else if (time >127 * clock_period_ns && time  <= 2 * clock_period_ns * 127)
-	{
-		sBreakDeadTimeConfig.DeadTime = time /(2 * clock_period_ns) - 64 + 128;
-	}else if(time > 2 * clock_period_ns * 127 && time <= 8 * clock_period_ns * 127){
-		sBreakDeadTimeConfig.DeadTime = time/(8 * clock_period_ns) -32 + 192;
-	}else if(time > 8 * clock_period_ns * 127 && time <=16 * clock_period_ns*127){
-		sBreakDeadTimeConfig.DeadTime = time/(16 * clock_period_ns) -32 + 224;
-	}else{
-		ErrorHandler("Invalid dead time configuration");
+	*(this->dead_time_ns)=dead_t_ns;
+	if(*positive_is_on || *negative_is_on){
+		ErrorHandler("%s","This function can not be called if the PWM is on");
 	}
-	//sBreakDeadTimeConfig.LockLevel = 0;
-	//sBreakDeadTimeConfig.BreakState = 1;
-	HAL_TIMEx_ConfigBreakDeadTime(peripheral->handle,&sBreakDeadTimeConfig);
-	peripheral->handle->Instance->BDTR |= TIM_BDTR_MOE;
+	/*
+		Code that creates a dead time in the mock where duty_cycle is 0
+	*/
 	return;
 
 }


### PR DESCRIPTION
Modified the DualPWM .cpp and .hpp so as to be used with the HALAL mock.  

- Created a bool is_on for each positive and negative channel, at the moment, that is the only variable that should be independent for each channel. Duty, freq and dead_time should be the same in both, so in the constructor, those instance variables point only to the pin_positive address memory, then the pin_negative copies the values.

Also added a DualPWM PinType and defined its struct at Pin.hpp.