### PR TITLE
Change public to private In Communication

### DIFF
--- a/Inc/HALAL/Services/Communication/Ethernet/TCP/ServerSocket.hpp
+++ b/Inc/HALAL/Services/Communication/Ethernet/TCP/ServerSocket.hpp
@@ -42,15 +42,13 @@ public:
 	};
 
 	static unordered_map<uint32_t,ServerSocket*> listening_sockets;
-	struct tcp_pcb* server_control_block = nullptr;
-	queue<struct pbuf*> tx_packet_buffer;
-	queue<struct pbuf*> rx_packet_buffer;
+	
 	IPV4 local_ip;
 	uint32_t local_port;
 	IPV4 remote_ip;
 	ServerState state;
 	static uint8_t priority;
-	struct tcp_pcb* client_control_block;
+	
 
 	struct KeepaliveConfig{
 		uint32_t inactivity_time_until_keepalive_ms = TCP_INACTIVITY_TIME_UNTIL_KEEPALIVE_MS;
@@ -88,14 +86,7 @@ public:
 	*/
 	void close();
 
-	/**
-	* @brief process the data received by the client orders. It is meant to be called only by Lwip on the receive_callback
-	*
-	* reads all the data received by the server in the ethernet buffer, packet by packet.
-	* Then, for each packet, it processes it depending on the order id (default behavior is not process) and removes it from the buffer. 
-	* This makes so the receive_callback (and thus the Socket) can only process declared orders, and ignores all other packets. 
-	*/
-	void process_data();
+
 
 	/**
 	 * @brief saves the order data into the tx_packet_buffer so it can be sent when a connection is accepted
@@ -156,7 +147,18 @@ public:
 	bool is_connected();
 
 private:
-
+	struct tcp_pcb* server_control_block = nullptr;
+	queue<struct pbuf*> tx_packet_buffer;
+	queue<struct pbuf*> rx_packet_buffer;
+	struct tcp_pcb* client_control_block;
+		/**
+	* @brief process the data received by the client orders. It is meant to be called only by Lwip on the receive_callback
+	*
+	* reads all the data received by the server in the ethernet buffer, packet by packet.
+	* Then, for each packet, it processes it depending on the order id (default behavior is not process) and removes it from the buffer. 
+	* This makes so the receive_callback (and thus the Socket) can only process declared orders, and ignores all other packets. 
+	*/
+	void process_data();
 	/**
 	 * @brief the callback for the listener socket receiving a request for connection into the ServerSocket.
 	 *

--- a/Inc/HALAL/Services/Communication/Ethernet/TCP/Socket.hpp
+++ b/Inc/HALAL/Services/Communication/Ethernet/TCP/Socket.hpp
@@ -16,6 +16,21 @@
 #define PBUF_POOL_MEMORY_DESC_POSITION 8
 
 class Socket : public OrderProtocol{
+private:
+	tcp_pcb* connection_control_block;
+	tcp_pcb* socket_control_block;
+	queue<struct pbuf*> tx_packet_buffer;
+	queue<struct pbuf*> rx_packet_buffer;
+	void process_data();
+	static err_t connect_callback(void* arg, struct tcp_pcb* client_control_block, err_t error);
+	static err_t receive_callback(void* arg, struct tcp_pcb* client_control_block, struct pbuf* packet_buffer, err_t error);
+	static err_t poll_callback(void* arg, struct tcp_pcb* client_control_block);
+	static err_t send_callback(void* arg, struct tcp_pcb* client_control_block, uint16_t length);
+	static void error_callback(void *arg, err_t error);
+
+	static err_t connection_poll_callback(void* arg, struct tcp_pcb* connection_control_block);
+	static void connection_error_callback(void *arg, err_t error);
+	static void config_keepalive(tcp_pcb* control_block, Socket* socket);
 public:
 	enum SocketState{
 		INACTIVE,
@@ -27,11 +42,9 @@ public:
 	uint32_t local_port;
 	IPV4 remote_ip;
 	uint32_t remote_port;
-	tcp_pcb* connection_control_block;
-	tcp_pcb* socket_control_block;
+	
 	SocketState state;
-	queue<struct pbuf*> tx_packet_buffer;
-	queue<struct pbuf*> rx_packet_buffer;
+	
 	static unordered_map<EthernetNode,Socket*> connecting_sockets;
 	bool pending_connection_reset = false;
 	bool use_keep_alives{true};
@@ -92,21 +105,6 @@ public:
 	}
 
 	void send();
-
-	void process_data();
-
 	bool is_connected();
-
-	static err_t connect_callback(void* arg, struct tcp_pcb* client_control_block, err_t error);
-	static err_t receive_callback(void* arg, struct tcp_pcb* client_control_block, struct pbuf* packet_buffer, err_t error);
-	static err_t poll_callback(void* arg, struct tcp_pcb* client_control_block);
-	static err_t send_callback(void* arg, struct tcp_pcb* client_control_block, uint16_t length);
-	static void error_callback(void *arg, err_t error);
-
-	static err_t connection_poll_callback(void* arg, struct tcp_pcb* connection_control_block);
-	static void connection_error_callback(void *arg, err_t error);
-
-	static void config_keepalive(tcp_pcb* control_block, Socket* socket);
-
 };
 #endif

--- a/Inc/HALAL/Services/Communication/Ethernet/UDP/DatagramSocket.hpp
+++ b/Inc/HALAL/Services/Communication/Ethernet/UDP/DatagramSocket.hpp
@@ -8,8 +8,6 @@
 
 class DatagramSocket{
 public:
-
-	struct udp_pcb* udp_control_block;
 	IPV4 local_ip;
 	uint32_t local_port;
 	IPV4 remote_ip;
@@ -41,7 +39,7 @@ public:
 
 private:
 	static void receive_callback(void *args, struct udp_pcb *udp_control_block, struct pbuf *packet_buffer, const ip_addr_t *remote_address, u16_t port);
-	
+	struct udp_pcb* udp_control_block;
 };
 
 


### PR DESCRIPTION
I've moved functions and variables that must be only use by the class to private so there is no lack of compatibility between halal and halmock