### PR TITLE
[FW-88] Added stuff to allow developing inside a container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,1 @@
+FROM mcr.microsoft.com/devcontainers/cpp:1-ubuntu-24.04

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+	"name": "C++",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	"remoteUser": "vscode",
+	"runArgs": [
+		"--userns=keep-id"
+	],
+	"containerEnv": {
+		"HOME": "/home/vscode"
+	}
+}


### PR DESCRIPTION
This Dockerfile and  config file allow to use the "Dev Containers" extension in Visual Studio Code to develop ST-LIB inside a container, in which compiler, cmake and all required tools for compiling and developing are already installed and configured.

This only works for compiling and developing ST-LIB in simulator mode. Compiling for STM32 will be investigated in the future