### PR TITLE
[FW-110] Encoder and EncoderSensor refactor

### DIFF
--- a/Inc/HALAL/Services/Encoder/Encoder.hpp
+++ b/Inc/HALAL/Services/Encoder/Encoder.hpp
@@ -77,5 +77,7 @@ public:
 	static void init(TimerPeripheral* encoder);
 
 	static uint32_t get_initial_counter_value(uint8_t id);
+
+	static int64_t get_delta_clock(uint64_t clock_time, uint64_t last_clock_time);
 };
 #endif

--- a/Inc/HALALMock/Services/Encoder/Encoder.hpp
+++ b/Inc/HALALMock/Services/Encoder/Encoder.hpp
@@ -72,4 +72,6 @@ class Encoder {
     static void init(void* encoder);
 
     static uint32_t get_initial_counter_value(uint8_t id);
+
+    static int64_t get_delta_clock(uint64_t clock_time, uint64_t last_clock_time);
 };

--- a/Src/HALAL/Services/Encoder/Encoder.cpp
+++ b/Src/HALAL/Services/Encoder/Encoder.cpp
@@ -146,4 +146,12 @@ void Encoder::init(TimerPeripheral* encoder) {
     }
 }
 
+int64_t Encoder::get_delta_clock(uint64_t clock_time, uint64_t last_clock_time){
+		int64_t delta_clock = clock_time - last_clock_time;
+		if(clock_time < last_clock_time){ //overflow handle
+			delta_clock = clock_time + CLOCK_MAX_VALUE * NANO_SECOND / HAL_RCC_GetPCLK1Freq()*2 - last_clock_time;
+		}
+		return delta_clock;
+	}
+
 #endif

--- a/Src/HALALMock/Services/Encoder/Encoder.cpp
+++ b/Src/HALALMock/Services/Encoder/Encoder.cpp
@@ -99,3 +99,8 @@ uint32_t Encoder::get_initial_counter_value(uint8_t id) {
 }
 
 void Encoder::init(void *encoder) {}
+
+int64_t Encoder::get_delta_clock(uint64_t clock_time, uint64_t last_clock_time){
+		int64_t delta_clock = clock_time - last_clock_time;
+		return delta_clock;
+	}

--- a/Src/ST-LIB_LOW/Sensors/EncoderSensor/EncoderSensor.cpp
+++ b/Src/ST-LIB_LOW/Sensors/EncoderSensor/EncoderSensor.cpp
@@ -1,7 +1,5 @@
 #include "Sensors/EncoderSensor/EncoderSensor.hpp"
-#ifdef SIM_ON
-uint32_t HAL_RCC_GetPCLK1Freq(void){return 0;}
-#endif
+
 EncoderSensor::EncoderSensor(Pin pin1, Pin pin2, double *position, double* direction, double *speed, double *acceleration)
 : position(position), direction(direction), speed(speed), acceleration(acceleration){
 	id = Encoder::inscribe(pin1,pin2);
@@ -27,10 +25,8 @@ void EncoderSensor::read(){
 	uint64_t clock_time = Time::get_global_tick();
 	*direction = (double)Encoder::get_direction(id);
 
-	int64_t delta_clock = clock_time - last_clock_time;
-	if(clock_time < last_clock_time){ //overflow handle
-		delta_clock = clock_time + CLOCK_MAX_VALUE * NANO_SECOND / HAL_RCC_GetPCLK1Freq()*2 - last_clock_time;
-	}
+	int64_t delta_clock = Encoder::get_delta_clock(clock_time, last_clock_time);
+	
 	time = time + delta_clock / NANO_SECOND;
 	last_clock_time = clock_time;
 


### PR DESCRIPTION
Implemented a get_delta_clock() function inside Encoder class and adapted EncoderSensor to get the value from there, now:

1. Implemented get_delta_clock(clock_time, last_clock_time) function

- On the HALAL version,makes the same operations as before

- On the HALALMock version, skips the overflow handle as it is not necessary for a simulated  timer

2. Adapted EncoderSensor::read() to get the delta_clock value from Encoder::get_delta_clock()
