### PR TITLE
[FW-82] Better IP and ports declaration in SPI mock

### DIFF
--- a/Inc/HALALMock/Services/Communication/SPI/SPI.hpp
+++ b/Inc/HALALMock/Services/Communication/SPI/SPI.hpp
@@ -120,6 +120,8 @@ public:
 	static SPI::Instance instance5;
 	static SPI::Instance instance6;
 
+    static std::string ip;
+
     /*=========================================
      * User functions for configuration of the SPI
      ==========================================*/
@@ -344,5 +346,3 @@ private:
     static void TxRxCpltCallback(uint8_t id);
 
 };
-
-external std::string vmcu_ip; // IP address of this VMCU, it should be defined on a .hpp file configuration

--- a/Inc/HALALMock/Services/Communication/SPI/SPI.hpp
+++ b/Inc/HALALMock/Services/Communication/SPI/SPI.hpp
@@ -80,6 +80,7 @@ public:
         std::mutex transmission_reception_mx;
         std::condition_variable cv_transmission_reception;
 
+        uint16_t port;
     };
 
     /**
@@ -119,7 +120,7 @@ public:
 	static SPI::Instance instance5;
 	static SPI::Instance instance6;
 
-
+    static std::string ip; // IP address of this VMCU, it should be defined on a .hpp file configuration
 
     /*=========================================
      * User functions for configuration of the SPI
@@ -345,6 +346,3 @@ private:
     static void TxRxCpltCallback(uint8_t id);
 
 };
-
-extern std::array<int, 6> peripheral_ports; // Array of SPI peripheral ports, it should be defined on a .hpp file configuration
-extern std::string ip; // IP address of this VMCU, it should be defined on a .hpp file configuration

--- a/Inc/HALALMock/Services/Communication/SPI/SPI.hpp
+++ b/Inc/HALALMock/Services/Communication/SPI/SPI.hpp
@@ -120,8 +120,6 @@ public:
 	static SPI::Instance instance5;
 	static SPI::Instance instance6;
 
-    static std::string ip; // IP address of this VMCU, it should be defined on a .hpp file configuration
-
     /*=========================================
      * User functions for configuration of the SPI
      ==========================================*/
@@ -346,3 +344,5 @@ private:
     static void TxRxCpltCallback(uint8_t id);
 
 };
+
+external std::string vmcu_ip; // IP address of this VMCU, it should be defined on a .hpp file configuration


### PR DESCRIPTION
I just change ip and ports declaration so now port is an attribute of Instance, and VMCU IP has a better name.