### PR TITLE
[FW-116] overload start in shared_memory_gpio and create close functions, improve the class with slight changes

### DIFF
--- a/Inc/HALALMock/Services/SharedMemory/SharedMemory.hpp
+++ b/Inc/HALALMock/Services/SharedMemory/SharedMemory.hpp
@@ -16,12 +16,13 @@ class SharedMemory {
 	static char* gpio_memory_name;
   	static constexpr  uint8_t total_pins= 114;
 	static constexpr int gpio_memory_size = total_pins * sizeof(EmulatedPin);
-  
 	constexpr static size_t state_machine_memory_size=16;
 	static uint8_t* state_machine_count;
-
+	//descriptors
+	static int shm_gpio_fd;
+	
 	static void start();
-	static void start(char* name);
+	static void start(char* gpio_memory_name);
 	static void close();
 	static void close_gpio_shared_memory();
 	

--- a/Inc/HALALMock/Services/SharedMemory/SharedMemory.hpp
+++ b/Inc/HALALMock/Services/SharedMemory/SharedMemory.hpp
@@ -24,7 +24,7 @@ class SharedMemory {
 	static void start();
 	static void start(char* gpio_memory_name);
 	static void close();
-	static void close_gpio_shared_memory();
+
 	
 	static EmulatedPin &get_pin(Pin pin);
 
@@ -35,4 +35,5 @@ class SharedMemory {
 		//Private to avoid bad use of this functions from the user
 		static void start_gpio_shared_memory();
 		static void start_state_machine_memory();
+		static void close_gpio_shared_memory();
 };

--- a/Inc/HALALMock/Services/SharedMemory/SharedMemory.hpp
+++ b/Inc/HALALMock/Services/SharedMemory/SharedMemory.hpp
@@ -13,7 +13,7 @@ class SharedMemory {
 	
   	static EmulatedPin *gpio_memory;
 	static uint8_t* state_machine_memory;
-  
+	char* gpio_memory_name;
   	constexpr static uint8_t total_pins= 114;
 	static constexpr int gpio_memory_size = total_pins * sizeof(EmulatedPin);
   
@@ -21,6 +21,8 @@ class SharedMemory {
 	static uint8_t* state_machine_count;
 
 	static void start();
+	static void start(char* name);
+	static void start_gpio_shared_memory();
 	static void start_state_machine_memory();
 
 	static EmulatedPin &get_pin(Pin pin);

--- a/Inc/HALALMock/Services/SharedMemory/SharedMemory.hpp
+++ b/Inc/HALALMock/Services/SharedMemory/SharedMemory.hpp
@@ -13,8 +13,8 @@ class SharedMemory {
 	
   	static EmulatedPin *gpio_memory;
 	static uint8_t* state_machine_memory;
-	char* gpio_memory_name;
-  	constexpr static uint8_t total_pins= 114;
+	static char* gpio_memory_name;
+  	static constexpr  uint8_t total_pins= 114;
 	static constexpr int gpio_memory_size = total_pins * sizeof(EmulatedPin);
   
 	constexpr static size_t state_machine_memory_size=16;
@@ -22,13 +22,16 @@ class SharedMemory {
 
 	static void start();
 	static void start(char* name);
-	static void start_gpio_shared_memory();
-	static void start_state_machine_memory();
-
+	static void close();
+	static void close_gpio_shared_memory();
+	
 	static EmulatedPin &get_pin(Pin pin);
 
 	static void update_current_state(uint8_t index, uint8_t state);
   
 	static unordered_map<Pin, size_t> pin_offsets;
-	
+	private:
+		//Private to avoid bad use of this functions from the user
+		static void start_gpio_shared_memory();
+		static void start_state_machine_memory();
 };

--- a/Src/HALALMock/Services/SharedMemory/SharedMemory.cpp
+++ b/Src/HALALMock/Services/SharedMemory/SharedMemory.cpp
@@ -107,19 +107,19 @@ void SharedMemory::close_gpio_shared_memory(){
 		//unmap shared memory
 		if(munmap(gpio_memory,state_machine_memory_size) == -1){
 			std::cout<<"Error unmapping the gpio shared_memory\n";
+			std::terminate();
 		}
 		//put the pointer to null
 		gpio_memory = nullptr;
 	}
 	int delete_shared_gpio_memory = shm_unlink(gpio_memory_name);
-	//check the error
-	if(delete_shared_gpio_memory == EACCES){
-		std::cout<<"Permission is denied to unlink the named shared memory object\n";
-	}else if (delete_shared_gpio_memory == ENOENT){
-		std::cout<<"The named shared memory object does not exist\n";
+	if(delete_shared_gpio_memory == -1){
+		std::cout<<"Error unlinking the shared memory object\n";
+		std::terminate();
 	}
-	if(close(shm_gpio_fd) == -1){
-		std::cout<<"Error closing the file descriptor\n"
+	if(shm_gpio_fd!=-1 && close(shm_gpio_fd) == -1){
+		std::cout<<"Error closing the file descriptor\n";
+		std::terminate();
 	}
 }
 void SharedMemory::update_current_state(uint8_t index, uint8_t state){

--- a/Src/HALALMock/Services/SharedMemory/SharedMemory.cpp
+++ b/Src/HALALMock/Services/SharedMemory/SharedMemory.cpp
@@ -42,11 +42,20 @@ unordered_map<Pin, size_t> SharedMemory::pin_offsets= {
 		{PG14, 110}, {PG15, 111}, {PH0, 112}, {PH1, 113}
 	};
 void SharedMemory::start() {
-  start_state_machine_memory(); // initialize the state machine shared memory
-    //Create GPIO_Memory
+	gpio_memory_name = SHM::gpio_memory_name;
+	start_state_machine_memory(); // initialize the state machine shared memory
+	start_gpio_shared_memory(); // initialize the gpio_shared_memory
+}
+void SharedMemory::start(const char* name){
+	gpio_memory_name = name;
+	start_state_machine_memory(); // initialize the state machine shared memory
+	start_gpio_shared_memory(); //initialize the gpio_shared_memory
+}
+void SharedMemory::start_gpio_shared_memory(){
+	//Create GPIO_Memory
 	int shm_gpio_fd;
 	//create shared memory object
-	shm_gpio_fd = shm_open(SHM::gpio_memory_name, O_CREAT | O_RDWR,0660);
+	shm_gpio_fd = shm_open(gpio_memory_name, O_CREAT | O_RDWR,0660);
 	if(shm_gpio_fd == -1){
 		std::cout<<"Error to Open de Shared Memory";
 		return;
@@ -64,9 +73,7 @@ void SharedMemory::start() {
         close(shm_gpio_fd);  // Close the descriptor if there is a problem with the mapping
         return;
 	}
-
 }
-
 void SharedMemory::start_state_machine_memory(){
 	// shared memory file descriptor
 	int shm_state_machine_fd;


### PR DESCRIPTION
I have overload the start method so you can use the start() and take the one in runes or use start(const char* name) and give a name from the code