### PR TITLE
[FW-117] New start function for StateMachine shared memory and close() function

### DIFF
--- a/Inc/HALALMock/Services/SharedMemory/SharedMemory.hpp
+++ b/Inc/HALALMock/Services/SharedMemory/SharedMemory.hpp
@@ -14,6 +14,7 @@ class SharedMemory {
   	static EmulatedPin *gpio_memory;
 	static uint8_t* state_machine_memory;
 	static char* gpio_memory_name;
+	static char* state_machine_memory_name;
   	static constexpr  uint8_t total_pins= 114;
 	static constexpr int gpio_memory_size = total_pins * sizeof(EmulatedPin);
   
@@ -21,7 +22,7 @@ class SharedMemory {
 	static uint8_t* state_machine_count;
 
 	static void start();
-	static void start(char* name);
+	static void start(const char* gpio_memory_name,const char* state_machine_memory_name);
 	static void close();
 	static void close_gpio_shared_memory();
 	

--- a/Inc/HALALMock/Services/SharedMemory/SharedMemory.hpp
+++ b/Inc/HALALMock/Services/SharedMemory/SharedMemory.hpp
@@ -13,7 +13,7 @@ class SharedMemory {
 	
   	static EmulatedPin *gpio_memory;
 	static uint8_t* state_machine_memory;
-  
+	char* gpio_memory_name;
   	constexpr static uint8_t total_pins= 114;
 	static constexpr int gpio_memory_size = total_pins * sizeof(EmulatedPin);
   
@@ -21,6 +21,8 @@ class SharedMemory {
 	static uint8_t* state_machine_count;
 
 	static void start();
+	static void start(char* name);
+	static void start_gpio_shared_memory();
 	static void start_state_machine_memory();
 
 	static EmulatedPin &get_pin(Pin pin);

--- a/Inc/HALALMock/Services/SharedMemory/SharedMemory.hpp
+++ b/Inc/HALALMock/Services/SharedMemory/SharedMemory.hpp
@@ -24,8 +24,6 @@ class SharedMemory {
 	static void start();
 	static void start(const char* gpio_memory_name,const char* state_machine_memory_name);
 	static void close();
-	static void close_gpio_shared_memory();
-	
 	static EmulatedPin &get_pin(Pin pin);
 
 	static void update_current_state(uint8_t index, uint8_t state);
@@ -35,4 +33,6 @@ class SharedMemory {
 		//Private to avoid bad use of this functions from the user
 		static void start_gpio_shared_memory();
 		static void start_state_machine_memory();
+		static void close_gpio_shared_memory();
+		static void close_state_machine_memory();
 };

--- a/Inc/HALALMock/Services/SharedMemory/SharedMemory.hpp
+++ b/Inc/HALALMock/Services/SharedMemory/SharedMemory.hpp
@@ -13,8 +13,8 @@ class SharedMemory {
 	
   	static EmulatedPin *gpio_memory;
 	static uint8_t* state_machine_memory;
-	char* gpio_memory_name;
-  	constexpr static uint8_t total_pins= 114;
+	static char* gpio_memory_name;
+  	static constexpr  uint8_t total_pins= 114;
 	static constexpr int gpio_memory_size = total_pins * sizeof(EmulatedPin);
   
 	constexpr static size_t state_machine_memory_size=16;
@@ -22,13 +22,16 @@ class SharedMemory {
 
 	static void start();
 	static void start(char* name);
-	static void start_gpio_shared_memory();
-	static void start_state_machine_memory();
-
+	static void close();
+	static void close_gpio_shared_memory();
+	
 	static EmulatedPin &get_pin(Pin pin);
 
 	static void update_current_state(uint8_t index, uint8_t state);
   
 	static unordered_map<Pin, size_t> pin_offsets;
-	
+	private:
+		//Private to avoid bad use of this functions from the user
+		static void start_gpio_shared_memory();
+		static void start_state_machine_memory();
 };

--- a/Src/HALALMock/Services/SharedMemory/SharedMemory.cpp
+++ b/Src/HALALMock/Services/SharedMemory/SharedMemory.cpp
@@ -43,13 +43,15 @@ unordered_map<Pin, size_t> SharedMemory::pin_offsets= {
 	};
 void SharedMemory::start() {
 	gpio_memory_name = SHM::gpio_memory_name;
+	state_machine_memory_name = SHM::state_machine_memory_name;
 	start_state_machine_memory(); // initialize the state machine shared memory
 	start_gpio_shared_memory(); // initialize the gpio_shared_memory
 }
-void SharedMemory::start(const char* name){
-	gpio_memory_name = name;
+void SharedMemory::start(const char* gpio_memory_name, const char* state_machine_memory_name) {
+	this->gpio_memory_name = gpio_memory_name;
+	this->state_machine_memory_name = state_machine_memory_name;
 	start_state_machine_memory(); // initialize the state machine shared memory
-	start_gpio_shared_memory(); //initialize the gpio_shared_memory
+	start_gpio_shared_memory(); // initialize the gpio_shared_memory
 }
 void SharedMemory::start_gpio_shared_memory(){
 	//Create GPIO_Memory
@@ -79,7 +81,7 @@ void SharedMemory::start_state_machine_memory(){
 	int shm_state_machine_fd;
 
 	// create the shared memory object
-	shm_state_machine_fd=shm_open(SHM::state_machine_memory_name,O_CREAT | O_RDWR, 0660);
+	shm_state_machine_fd=shm_open(state_machine_memory_name,O_CREAT | O_RDWR, 0660);
 	if(shm_state_machine_fd==-1){
 		std::cout<<"Error creating the shared memory object\n";
 		std::terminate();

--- a/Src/HALALMock/Services/SharedMemory/SharedMemory.cpp
+++ b/Src/HALALMock/Services/SharedMemory/SharedMemory.cpp
@@ -104,6 +104,33 @@ void SharedMemory::start_state_machine_memory(){
 	*state_machine_count=0;
 }
 
+void SharedMemory::close(){
+	close_gpio_shared_memory();
+	close_state_machine_memory();
+}
+
+void SharedMemory::close_state_machine_memory(){
+	if (state_machine_memory!=nullptr){
+		// unmap the shared memory object
+		if(munmap(state_machine_memory,state_machine_memory_size)==-1){
+			std::cout<<"Error unmapping the shared memory object\n";
+			std::terminate();
+		}
+
+		// point the shared memory object to NULL
+		state_machine_memory=nullptr;
+	}
+	
+	if(shm_unlink(state_machine_memory_name)==-1){
+		std::cout<<"Error unlinking the shared memory object\n";
+		std::terminate();
+	}
+
+	if(shm_state_machine_fd !=-1 && close(shm_state_machine_fd)==-1){
+		std::cout<<"Error closing the shared memory file descriptor\n";
+		std::terminate();
+	}
+}
 void SharedMemory::update_current_state(uint8_t index, uint8_t state){
 	state_machine_memory[index]=state;
 }

--- a/Src/HALALMock/Services/SharedMemory/SharedMemory.cpp
+++ b/Src/HALALMock/Services/SharedMemory/SharedMemory.cpp
@@ -42,11 +42,20 @@ unordered_map<Pin, size_t> SharedMemory::pin_offsets= {
 		{PG14, 110}, {PG15, 111}, {PH0, 112}, {PH1, 113}
 	};
 void SharedMemory::start() {
-  start_state_machine_memory(); // initialize the state machine shared memory
-    //Create GPIO_Memory
+	gpio_memory_name = SHM::gpio_memory_name;
+	start_state_machine_memory(); // initialize the state machine shared memory
+	start_gpio_shared_memory(); // initialize the gpio_shared_memory
+}
+void SharedMemory::start(const char* name){
+	gpio_memory_name = name;
+	start_state_machine_memory(); // initialize the state machine shared memory
+	start_gpio_shared_memory(); //initialize the gpio_shared_memory
+}
+void SharedMemory::start_gpio_shared_memory(){
+	//Create GPIO_Memory
 	int shm_gpio_fd;
 	//create shared memory object
-	shm_gpio_fd = shm_open(SHM::gpio_memory_name, O_CREAT | O_RDWR,0660);
+	shm_gpio_fd = shm_open(gpio_memory_name, O_CREAT | O_RDWR,0660);
 	if(shm_gpio_fd == -1){
 		std::cout<<"Error to Open de Shared Memory";
 		return;
@@ -64,9 +73,7 @@ void SharedMemory::start() {
         close(shm_gpio_fd);  // Close the descriptor if there is a problem with the mapping
         return;
 	}
-
 }
-
 void SharedMemory::start_state_machine_memory(){
 	// shared memory file descriptor
 	int shm_state_machine_fd;


### PR DESCRIPTION
1. Implemented a new start() function where we can pass a char* manually for the memory name so as to perform the unitary tests.
2. Implemented close() and close_state_machine_memory() functions too make sure that the shared memory is being closed correctly.
3. The SharedMemory class structure has also been modified by adding a start() and a close() function that call the specific start and close functions for the gpio and the state machine. This has been done following @oganigl's implementation in his PR [FW-116].

[FW-116]: https://firmware-hyperloop-upv.atlassian.net/browse/FW-116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ