### PR TITLE
FIX Inputcapture Inscribe

### DIFF
--- a/Src/HALAL/Services/InputCapture/InputCapture.cpp
+++ b/Src/HALAL/Services/InputCapture/InputCapture.cpp
@@ -38,6 +38,7 @@ uint8_t InputCapture::inscribe(Pin& pin){
 	Pin::inscribe(pin, TIMER_ALTERNATE_FUNCTION);
 
  	Instance data = available_instances[pin];
+	id_counter++;
 	active_instances[id_counter] = data;
 	active_instances[id_counter].id = id_counter;
 
@@ -45,7 +46,7 @@ uint8_t InputCapture::inscribe(Pin& pin){
 	uint32_t channel_rising = active_instances[id_counter].channel_rising;
 	uint32_t channel_falling = active_instances[id_counter].channel_falling;
 	channels.push_back({channel_rising, channel_falling});
-	return ++id_counter;
+	return id_counter;
 }
 
 void InputCapture::turn_on(uint8_t id){

--- a/Src/HALALMock/Services/InputCapture/InputCapture.cpp
+++ b/Src/HALALMock/Services/InputCapture/InputCapture.cpp
@@ -24,6 +24,7 @@ uint8_t InputCapture::inscribe(Pin& pin){
 	Pin::inscribe(pin, TIMER_ALTERNATE_FUNCTION);
 
  	Instance& data = available_instances[pin];
+	id_counter++;
 	active_instances[id_counter] = data;
 	active_instances[id_counter].id = id_counter;
 
@@ -34,7 +35,7 @@ uint8_t InputCapture::inscribe(Pin& pin){
 	*active_instances[id_counter].duty_cycle = 0;
 	*active_instances[id_counter].frequency = 0;
 
-	return ++id_counter;
+	return id_counter;
 
 	
 }

--- a/Tests/InputCaptureTest.cpp
+++ b/Tests/InputCaptureTest.cpp
@@ -8,27 +8,30 @@
 
 map<Pin, InputCapture::Instance> InputCapture::available_instances = {
     {PF0, InputCapture::Instance(PF0, htim, TIM_CHANNEL_1, TIM_CHANNEL_2)},
-    {PB0, InputCapture::Instance(PF0, htim, TIM_CHANNEL_1, TIM_CHANNEL_2)}
+    {PB0, InputCapture::Instance(PB0, htim, TIM_CHANNEL_1, TIM_CHANNEL_2)},
+    {PE1, InputCapture::Instance(PE1, htim, TIM_CHANNEL_1, TIM_CHANNEL_2)},
+    {PE2, InputCapture::Instance(PE2, htim, TIM_CHANNEL_1, TIM_CHANNEL_2)}
     };
 
+uint8_t id1, id2;
 TEST(InputCapture, Inscribe){
 
     SharedMemory::start("GPIO_Name", "State_Machine_Name");
 
     //inscribe correct PIN
-    uint8_t id = InputCapture::inscribe(PF0);
+    uint8_t id1 = InputCapture::inscribe(PF0);
 
-    EXPECT_EQ(id, 1);
+    EXPECT_EQ(id1, 1);
     EXPECT_EQ(InputCapture::id_counter, 1);
 
     //inscribe wrong PIN
-    id = InputCapture::inscribe(PA0);
+    uint8_t id = InputCapture::inscribe(PA0);
     EXPECT_EQ(id, 0);
     EXPECT_EQ(InputCapture::id_counter, 1);
 
     //inscribe another correct PIN
-    id = InputCapture::inscribe(PB0);
-    EXPECT_EQ(id, 2);
+    id2 = InputCapture::inscribe(PB0);
+    EXPECT_EQ(id2, 2);
     EXPECT_EQ(InputCapture::id_counter, 2);
 
     //inscribe repeated PIN
@@ -43,14 +46,13 @@ TEST(InputCapture, TurnOn){
 
     SharedMemory::start("GPIO_Name", "State_Machine_Name");
 
-    uint8_t id = InputCapture::inscribe(PF0);
     EmulatedPin &pin = SharedMemory::get_pin(PF0);
 
     bool is_on;
-    is_on = InputCapture::active_instances[id].is_active;
+    is_on = InputCapture::active_instances[id1].is_active;
     ASSERT_FALSE(is_on);
-    InputCapture::turn_on(id);
-    is_on = InputCapture::active_instances[id].is_active;
+    InputCapture::turn_on(id1);
+    is_on = InputCapture::active_instances[id1].is_active;
     ASSERT_TRUE(is_on);
 
     SharedMemory::close();
@@ -60,18 +62,17 @@ TEST(InputCapture, TurnOff){
 
     SharedMemory::start("GPIO_Name", "State_Machine_Name");
 
-    uint8_t id = InputCapture::inscribe(PF0);
     EmulatedPin &pin = SharedMemory::get_pin(PF0);
 
-    InputCapture::turn_on(id);
+    InputCapture::turn_on(id1);
 
     bool is_on;
-    is_on = InputCapture::active_instances[id].is_active;
-    InputCapture::turn_on(id);
+    is_on = InputCapture::active_instances[id1].is_active;
+    InputCapture::turn_on(id1);
     ASSERT_TRUE(is_on);
 
-    InputCapture::turn_off(id);
-    is_on = InputCapture::active_instances[id].is_active;
+    InputCapture::turn_off(id1);
+    is_on = InputCapture::active_instances[id1].is_active;
     ASSERT_FALSE(is_on);
 
     SharedMemory::close();
@@ -81,8 +82,8 @@ TEST(InputCapture, ReadFrequency){
 
     SharedMemory::start("GPIO_Name", "State_Machine_Name");
 
-    uint8_t id = InputCapture::inscribe(PF0);
-    EmulatedPin &pin = SharedMemory::get_pin(PF0);
+    EmulatedPin &pin = SharedMemory::get_pin(PE1);
+    uint8_t id = InputCapture::inscribe(PE1);
 
     uint32_t value = 1000;
     pin.PinData.input_capture.frequency = value;
@@ -110,8 +111,8 @@ TEST(InputCapture, ReadDutyCycle){
 
     SharedMemory::start("GPIO_Name", "State_Machine_Name");
 
-    uint8_t id = InputCapture::inscribe(PF0);
-    EmulatedPin &pin = SharedMemory::get_pin(PF0);
+    EmulatedPin &pin = SharedMemory::get_pin(PE2);
+    uint8_t id = InputCapture::inscribe(PE2);
 
     uint8_t value = 80;
     pin.PinData.input_capture.duty_cycle = value;


### PR DESCRIPTION
On previous commit I update InputCapture Inscribe to send 0 when it doesn't register the pin, I didn't do it correctly.
Test don't notice the error because shared memory reinit  at each test