### PR TITLE
[FW-137] Add turn_on() method to PWMSensor

### DIFF
--- a/Inc/ST-LIB_LOW/Sensors/PWMSensor/PWMSensor.hpp
+++ b/Inc/ST-LIB_LOW/Sensors/PWMSensor/PWMSensor.hpp
@@ -28,12 +28,14 @@ template<class Type>
 PWMSensor<Type>::PWMSensor(Pin &pin, Type &frequency, Type &duty_cycle) :
 	frequency(&frequency), duty_cycle(&duty_cycle) {
 		id = InputCapture::inscribe(pin);
+		InputCapture::turn_on(id);
 }
 
 template<class Type>
 PWMSensor<Type>::PWMSensor(Pin &pin, Type *frequency, Type *duty_cycle) :
-	duty_cycle(duty_cycle), frequency(frequency) {
+	duty_cycle(duty_cycle), frequency(frequency) {>
 		id = InputCapture::inscribe(pin);
+		InputCapture::turn_on(id);
 }
 
 template<class Type>

--- a/Inc/ST-LIB_LOW/Sensors/PWMSensor/PWMSensor.hpp
+++ b/Inc/ST-LIB_LOW/Sensors/PWMSensor/PWMSensor.hpp
@@ -33,7 +33,7 @@ PWMSensor<Type>::PWMSensor(Pin &pin, Type &frequency, Type &duty_cycle) :
 
 template<class Type>
 PWMSensor<Type>::PWMSensor(Pin &pin, Type *frequency, Type *duty_cycle) :
-	duty_cycle(duty_cycle), frequency(frequency) {>
+	duty_cycle(duty_cycle), frequency(frequency) {
 		id = InputCapture::inscribe(pin);
 		InputCapture::turn_on(id);
 }

--- a/Inc/ST-LIB_LOW/Sensors/PWMSensor/PWMSensor.hpp
+++ b/Inc/ST-LIB_LOW/Sensors/PWMSensor/PWMSensor.hpp
@@ -28,14 +28,14 @@ template<class Type>
 PWMSensor<Type>::PWMSensor(Pin &pin, Type &frequency, Type &duty_cycle) :
 	frequency(&frequency), duty_cycle(&duty_cycle) {
 		id = InputCapture::inscribe(pin);
-		InputCapture::turn_on(id);
+		Sensor::inputcapture_id_list.push_back(id);
 }
 
 template<class Type>
 PWMSensor<Type>::PWMSensor(Pin &pin, Type *frequency, Type *duty_cycle) :
 	duty_cycle(duty_cycle), frequency(frequency) {
 		id = InputCapture::inscribe(pin);
-		InputCapture::turn_on(id);
+		Sensor::inputcapture_id_list.push_back(id);
 }
 
 template<class Type>

--- a/Inc/ST-LIB_LOW/Sensors/Sensor/Sensor.hpp
+++ b/Inc/ST-LIB_LOW/Sensors/Sensor/Sensor.hpp
@@ -14,5 +14,6 @@ public:
 	static void start();
 	static vector<uint8_t> adc_id_list;
 	static vector<uint8_t> EXTI_id_list;
+	static vector<uint8_t> inputcapture_id_list;
 };
 

--- a/Src/ST-LIB_LOW/Sensors/Sensor/Sensor.cpp
+++ b/Src/ST-LIB_LOW/Sensors/Sensor/Sensor.cpp
@@ -2,6 +2,7 @@
 
 vector<uint8_t> Sensor::adc_id_list{};
 vector<uint8_t> Sensor::EXTI_id_list{};
+vector<uint8_t> Sensor::inputcapture_id_list{};
 
 void Sensor::start(){
 	for(uint8_t adc_id : adc_id_list){
@@ -10,6 +11,10 @@ void Sensor::start(){
 
 	for(uint8_t exti_id : EXTI_id_list){
 		ExternalInterrupt::turn_on(exti_id);
+	}
+
+	for(uint8_t inputcapture_id : inputcapture_id_list){
+		InputCapture::turn_on(inputcapture_id);
 	}
 
 }


### PR DESCRIPTION
PWMSensor inscribed an InputCapture pin but did not include the call to the turn_on() method, so it was not working.