### PR TITLE
[FW-120] Added Logger for simulator mode

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -36,7 +36,7 @@ jobs:
   Run-Tests:
     name: Run Simulator tests
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - name: Download test binary compressed

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         build_type: [hardware,simulator]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - uses: carlosperate/arm-none-eabi-gcc-action@v1

--- a/Inc/HALAL/HALAL.hpp
+++ b/Inc/HALAL/HALAL.hpp
@@ -65,6 +65,7 @@
 #include "HALALMock/Models/Packets/OrderProtocol.hpp"
 #include "HALALMock/Models/BoardID/BoardID.hpp"
 #include "HALALMock/Models/Concepts/Concepts.hpp"
+#include "HALALMock/Services/Logger/Logger.hpp"
 #endif
 
 namespace HALAL {

--- a/Inc/HALALMock/Services/Logger/Logger.hpp
+++ b/Inc/HALALMock/Services/Logger/Logger.hpp
@@ -5,6 +5,16 @@
 #include <memory>
 #include <fstream>
 
+#include <stdio.h>
+
+#define ANSI_COLOR_RED     "\x1b[31m"
+#define ANSI_COLOR_GREEN   "\x1b[32m"
+#define ANSI_COLOR_YELLOW  "\x1b[33m"
+#define ANSI_COLOR_MAGENTA "\x1b[35m"
+#define ANSI_COLOR_GREY    "\x1b[37m"
+#define ANSI_COLOR_RESET   "\x1b[0m"
+
+
 class FileManager {
   public:
     FileManager(const std::ios_base::openmode file_mode);
@@ -16,8 +26,21 @@ class FileManager {
 
 };
 
+/** @brief Class used to Log info in simulator mode.
+ * You can log in five levels: DEBUG, INFO, WARNING, ERROR and FATAL.
+ * 
+ * To configure it, you must set in the extern variable config
+ * a mask 'oring' the bits that represents what you want. 
+ * You can configure which level of logs you want (DEBUG, INFO...),
+ * if you want to write logs on the console and/or on a file,
+ * and if you want to erase or not the log file.
+ * 
+ * To use it, you must use one of the five MACROS defined in this file,
+ * each one representing the level of the log you want to print.
+*/
 class Logger {
   public:
+
     enum class LogLevel : unsigned int {
         DEBUG   = 0b00001,
         INFO    = 0b00010,
@@ -46,23 +69,23 @@ class Logger {
         DestructiveLog  = 0b10000000
     };
 
-    static void log(const std::string& msg, const LogLevel level);
+    static void log(const std::string& msg, const LogLevel level, const char *colour);
     static void set_metadata(int line, const char *function, const char *file);
 
-    #define debug(x) do { Logger::set_metadata(__LINE__, __FUNCTION__, __FILE__); \
-					           	   Logger::log(x, Logger::LogLevel::DEBUG);}while(0)
+    #define LOG_DEBUG(x) do { Logger::set_metadata(__LINE__, __FUNCTION__, __FILE__); \
+					           	   Logger::log(x, Logger::LogLevel::DEBUG, ANSI_COLOR_GREY);}while(0)
 
-    #define info(x) do { Logger::set_metadata(__LINE__, __FUNCTION__, __FILE__); \
-					           	   Logger::log(x, Logger::LogLevel::INFO);}while(0)
+    #define LOG_INFO(x) do { Logger::set_metadata(__LINE__, __FUNCTION__, __FILE__); \
+					           	   Logger::log(x, Logger::LogLevel::INFO, ANSI_COLOR_GREEN);}while(0)
 
-    #define warning(x) do { Logger::set_metadata(__LINE__, __FUNCTION__, __FILE__); \
-					           	   Logger::log(x, Logger::LogLevel::WARNING);}while(0)
+    #define LOG_WARNING(x) do { Logger::set_metadata(__LINE__, __FUNCTION__, __FILE__); \
+					           	   Logger::log(x, Logger::LogLevel::WARNING, ANSI_COLOR_YELLOW);}while(0)
 
-    #define error(x) do { Logger::set_metadata(__LINE__, __FUNCTION__, __FILE__); \
-					           	   Logger::log(x, Logger::LogLevel::ERROR);}while(0)
+    #define LOG_ERROR(x) do { Logger::set_metadata(__LINE__, __FUNCTION__, __FILE__); \
+					           	   Logger::log(x, Logger::LogLevel::ERROR, ANSI_COLOR_RED);}while(0)
 
-    #define fatal(x) do { Logger::set_metadata(__LINE__, __FUNCTION__, __FILE__); \
-					           	   Logger::log(x, Logger::LogLevel::FATAL);}while(0)
+    #define LOG_FATAL(x) do { Logger::set_metadata(__LINE__, __FUNCTION__, __FILE__); \
+					           	   Logger::log(x, Logger::LogLevel::FATAL, ANSI_COLOR_MAGENTA);}while(0)
 
     friend class FileManager;
 

--- a/Inc/HALALMock/Services/Logger/Logger.hpp
+++ b/Inc/HALALMock/Services/Logger/Logger.hpp
@@ -13,42 +13,6 @@
 #define ANSI_COLOR_GREY "\x1b[37m"
 #define ANSI_COLOR_RESET "\x1b[0m"
 
-class FileManager {
-   public:
-    FileManager(const std::ios_base::openmode file_mode);
-    void add(const std::string& msg);
-    ~FileManager();
-
-   private:
-    std::ofstream file_stream;
-};
-
-/** @brief Class used to Log info in simulator mode.
- * You can log in five levels: DEBUG, INFO, WARNING, ERROR and FATAL.
- *
- * To configure it, you must set in the extern variable config
- * a mask 'oring' the bits that represents what you want.
- * You can configure which level of logs you want (DEBUG, INFO...),
- * if you want to write logs on the console and/or on a file,
- * and if you want to erase or not the log file.
- *
- * To use it, you must use one of the five MACROS defined in this file,
- * each one representing the level of the log you want to print.
- */
-class Logger {
-   public:
-    enum class LogLevel : unsigned int {
-        DEBUG = 0b00001,
-        INFO = 0b00010,
-        WARNING = 0b00100,
-        ERROR = 0b01000,
-        FATAL = 0b10000,
-    };
-
-    static void log(const std::string& msg, const LogLevel level,
-                    const char* colour);
-    static void set_metadata(int line, const char* function, const char* file);
-
 #define LOG_DEBUG(x)                                              \
     do {                                                          \
         Logger::set_metadata(__LINE__, __FUNCTION__, __FILE__);   \
@@ -78,6 +42,44 @@ class Logger {
         Logger::set_metadata(__LINE__, __FUNCTION__, __FILE__);      \
         Logger::log(x, Logger::LogLevel::FATAL, ANSI_COLOR_MAGENTA); \
     } while (0)
+
+class FileManager {
+   public:
+    FileManager(const std::ios_base::openmode file_mode);
+    void add(const std::string& msg);
+    ~FileManager();
+
+   private:
+    std::ofstream file_stream;
+};
+
+/** @brief Class used to Log info in simulator mode.
+ * You can log in five levels: DEBUG, INFO, WARNING, ERROR and FATAL.
+ *
+ * To configure it, you must set in the extern variable config
+ * a mask 'oring' the bits that represents what you want.
+ * You can configure which level of logs you want (DEBUG, INFO...),
+ * if you want to write logs on the console and/or on a file,
+ * and if you want to erase or not the log file.
+ *
+ * To use it, you must use one of the five MACROS defined in this file,
+ * each one representing the level of the log you want to print.
+ *
+ * As a tip, you can use std::format to log formatted messages
+ */
+class Logger {
+   public:
+    enum class LogLevel : unsigned int {
+        DEBUG = 0b00001,
+        INFO = 0b00010,
+        WARNING = 0b00100,
+        ERROR = 0b01000,
+        FATAL = 0b10000,
+    };
+
+    static void log(const std::string& msg, const LogLevel level,
+                    const char* colour);
+    static void set_metadata(int line, const char* function, const char* file);
 
     friend class FileManager;
 

--- a/Inc/HALALMock/Services/Logger/Logger.hpp
+++ b/Inc/HALALMock/Services/Logger/Logger.hpp
@@ -98,15 +98,15 @@ extern std::string filename;
 /// @brief Bitmask that represents log configuration
 enum class LogConf : unsigned int {
     /// @brief Includes Debug messages in logs
-    Debug = 0b00000001,
+    Debug = static_cast<int>(Logger::LogLevel::DEBUG),
     /// @brief Includes Info messages in logs
-    Info = 0b00000010,
+    Info = static_cast<int>(Logger::LogLevel::INFO),
     /// @brief Includes Warning messages in logs
-    Warning = 0b00000100,
+    Warning = static_cast<int>(Logger::LogLevel::WARNING),
     /// @brief Includes Error messages in logs
-    Error = 0b00001000,
+    Error = static_cast<int>(Logger::LogLevel::ERROR),
     /// @brief Includes Fatal messages in logs
-    Fatal = 0b00010000,
+    Fatal = static_cast<int>(Logger::LogLevel::FATAL),
     /// @brief Writes logs into the console
     Console = 0b00100000,
     /// @brief Writes logs into a file, defined in filename_log external

--- a/Inc/HALALMock/Services/Logger/Logger.hpp
+++ b/Inc/HALALMock/Services/Logger/Logger.hpp
@@ -81,8 +81,6 @@ class Logger {
                     const char* colour);
     static void set_metadata(int line, const char* function, const char* file);
 
-    friend class FileManager;
-
    private:
     static std::unique_ptr<FileManager> file_manager;
     static int line;

--- a/Inc/HALALMock/Services/Logger/Logger.hpp
+++ b/Inc/HALALMock/Services/Logger/Logger.hpp
@@ -1,30 +1,82 @@
 #include <string>
 
+// Overload bit operators for LogConf enum
+constexpr Logger::LogConf operator|(const Logger::LogConf& conf1, const Logger::LogConf& conf2) {
+    return static_cast<Logger::LogConf>(static_cast<int>(conf1) | static_cast<int>(conf2));
+};
+constexpr Logger::LogConf operator&(const Logger::LogConf& conf, const Logger::LogLevel& level) {
+    return static_cast<Logger::LogConf>(static_cast<int>(conf) & static_cast<int>(level));
+};
+constexpr Logger::LogConf operator&(const Logger::LogConf& conf1, const Logger::LogConf& conf2) {
+    return static_cast<Logger::LogConf>(static_cast<int>(conf1) & static_cast<int>(conf2));
+};
+
+/// @brief Check if a flag is activated in a mask
+/// @param mask Mask where you want to check the flag
+/// @param flag Flag which you want to check in the mask
+/// @return If the flag is activated in the mask
+constexpr bool hasFlag(Logger::LogConf mask, Logger::LogConf flag) {
+    return (mask & flag) == flag;
+};
+constexpr bool hasFlag(Logger::LogConf mask, Logger::LogLevel flag) {
+    return (mask & flag) == static_cast<Logger::LogConf>(flag);
+};
+
 class Logger {
   public:
-    enum class LogLevel {
-        DEBUG,
-        INFO,
-        WARNING,
-        ERROR,
-        FATAL
-    };
-    enum class LogDest {
-        Console = 0b10,
-        File = 0b01
+    enum class LogLevel : unsigned int {
+        DEBUG   = 0b00001,
+        INFO    = 0b00010,
+        WARNING = 0b00100,
+        ERROR   = 0b01000,
+        FATAL   = 0b10000,
     };
 
-    static void log(std::string, LogLevel level);
-    static void debug(std::string msg);
-    static void info(std::string msg);
-    static void warning(std::string msg);
-    static void error(std::string msg);
-    static void fatal(std::string msg);
+    /// @brief Bitmask that represents log configuration
+    enum class LogConf : unsigned int {
+        /// @brief Includes Debug messages in logs
+        Debug           = 0b00000001,
+        /// @brief Includes Info messages in logs
+        Info            = 0b00000010,
+        /// @brief Includes Warning messages in logs
+        Warning         = 0b00000100,
+        /// @brief Includes Error messages in logs
+        Error           = 0b00001000,
+        /// @brief Includes Fatal messages in logs
+        Fatal           = 0b00010000,
+        /// @brief Writes logs into the console
+        Console         = 0b00100000,
+        /// @brief Writes logs into a file, defined in filename_log external variable
+        File            = 0b01000000,
+        /// @brief Erase previous logs
+        DestructiveLog  = 0b10000000
+    };
 
-    static void setDest(LogDest dest);
+    static void log(const std::string& msg, const LogLevel level);
+    static void debug(const std::string& msg);
+    static void info(const std::string& msg);
+    static void warning(const std::string& msg);
+    static void error(const std::string& msg);
+    static void fatal(const std::string& msg);
+
+    static void setConf(const LogConf conf);
+    static void setFilename(const std::string& filename);
+
+    friend class FileManager;
 
   private:
-    static int config;
-    static void logToConsole(std::string msg);
-    static void logToFile(std::string msg);
+    static LogConf config;
+    static std::unique_ptr<FileManager> file_manager;
+    static std::string log_filename;
+};
+
+class FileManager {
+  public:
+    FileManager(const std::ios_base::openmode file_mode);
+    void add(const std::string& msg);
+    ~FileManager();
+
+  private:
+    std::ofstream file_stream;
+
 };

--- a/Inc/HALALMock/Services/Logger/Logger.hpp
+++ b/Inc/HALALMock/Services/Logger/Logger.hpp
@@ -82,7 +82,7 @@ class Logger {
         FATAL = 0b10000,
     };
 
-    static void log(const std::string& msg, const std::string& level,
+    static void __log(const std::string& msg, const std::string& level,
                     const char* colour);
     static void set_metadata(int line, const char* function, const char* file);
 

--- a/Inc/HALALMock/Services/Logger/Logger.hpp
+++ b/Inc/HALALMock/Services/Logger/Logger.hpp
@@ -17,35 +17,35 @@
     do {                                                        \
         Logger::set_metadata(__LINE__, __FUNCTION__, __FILE__); \
         if (hasFlag(Log::config, Logger::LogLevel::DEBUG))      \
-            Logger::log(x, "DEBUG", ANSI_COLOR_GREY);           \
+            Logger::__log(x, "DEBUG", ANSI_COLOR_GREY);           \
     } while (0)
 
 #define LOG_INFO(x)                                             \
     do {                                                        \
         Logger::set_metadata(__LINE__, __FUNCTION__, __FILE__); \
         if (hasFlag(Log::config, Logger::LogLevel::INFO))       \
-            Logger::log(x, "INFO", ANSI_COLOR_GREEN);           \
+            Logger::__log(x, "INFO", ANSI_COLOR_GREEN);           \
     } while (0)
 
 #define LOG_WARNING(x)                                          \
     do {                                                        \
         Logger::set_metadata(__LINE__, __FUNCTION__, __FILE__); \
         if (hasFlag(Log::config, Logger::LogLevel::WARNING))    \
-            Logger::log(x, "WARNING", ANSI_COLOR_YELLOW);       \
+            Logger::__log(x, "WARNING", ANSI_COLOR_YELLOW);       \
     } while (0)
 
 #define LOG_ERROR(x)                                            \
     do {                                                        \
         Logger::set_metadata(__LINE__, __FUNCTION__, __FILE__); \
         if (hasFlag(Log::config, Logger::LogLevel::ERROR))      \
-            Logger::log(x, "ERROR", ANSI_COLOR_RED);            \
+            Logger::__log(x, "ERROR", ANSI_COLOR_RED);            \
     } while (0)
 
 #define LOG_FATAL(x)                                            \
     do {                                                        \
         Logger::set_metadata(__LINE__, __FUNCTION__, __FILE__); \
         if (hasFlag(Log::config, Logger::LogLevel::FATAL))      \
-            Logger::log(x, "FATAL", ANSI_COLOR_MAGENTA);        \
+            Logger::__log(x, "FATAL", ANSI_COLOR_MAGENTA);        \
     } while (0)
 
 class FileManager {

--- a/Inc/HALALMock/Services/Logger/Logger.hpp
+++ b/Inc/HALALMock/Services/Logger/Logger.hpp
@@ -47,21 +47,30 @@ class Logger {
     };
 
     static void log(const std::string& msg, const LogLevel level);
-    static void debug(const std::string& msg);
-    static void info(const std::string& msg);
-    static void warning(const std::string& msg);
-    static void error(const std::string& msg);
-    static void fatal(const std::string& msg);
+    static void set_metadata(int line, const char *function, const char *file);
 
-    static void setConf(const LogConf conf);
-    static void setFilename(const std::string& filename);
+    #define debug(x) do { Logger::set_metadata(__LINE__, __FUNCTION__, __FILE__); \
+					           	   Logger::log(x, Logger::LogLevel::DEBUG);}while(0)
+
+    #define info(x) do { Logger::set_metadata(__LINE__, __FUNCTION__, __FILE__); \
+					           	   Logger::log(x, Logger::LogLevel::INFO);}while(0)
+
+    #define warning(x) do { Logger::set_metadata(__LINE__, __FUNCTION__, __FILE__); \
+					           	   Logger::log(x, Logger::LogLevel::WARNING);}while(0)
+
+    #define error(x) do { Logger::set_metadata(__LINE__, __FUNCTION__, __FILE__); \
+					           	   Logger::log(x, Logger::LogLevel::ERROR);}while(0)
+
+    #define fatal(x) do { Logger::set_metadata(__LINE__, __FUNCTION__, __FILE__); \
+					           	   Logger::log(x, Logger::LogLevel::FATAL);}while(0)
 
     friend class FileManager;
 
   private:
-    static LogConf config;
     static std::unique_ptr<FileManager> file_manager;
-    static std::string log_filename;
+    static int line;
+    static const char *function;
+    static const char *file;
 };
 
 // Overload bit operators for LogConf enum
@@ -79,11 +88,16 @@ constexpr Logger::LogConf operator&(const Logger::LogConf& conf1, const Logger::
 /// @param mask Mask where you want to check the flag
 /// @param flag Flag which you want to check in the mask
 /// @return If the flag is activated in the mask
-constexpr bool hasFlag(Logger::LogConf mask, Logger::LogConf flag) {
+constexpr bool hasFlag(const Logger::LogConf mask, const Logger::LogConf flag) {
     return (mask & flag) == flag;
 };
-constexpr bool hasFlag(Logger::LogConf mask, Logger::LogLevel flag) {
+constexpr bool hasFlag(const Logger::LogConf mask, const Logger::LogLevel flag) {
     return (mask & flag) == static_cast<Logger::LogConf>(flag);
 };
+
+namespace Log {
+  extern const Logger::LogConf config;
+  extern const char* filename;
+}
 
 #endif

--- a/Inc/HALALMock/Services/Logger/Logger.hpp
+++ b/Inc/HALALMock/Services/Logger/Logger.hpp
@@ -1,0 +1,30 @@
+#include <string>
+
+class Logger {
+  public:
+    enum class LogLevel {
+        DEBUG,
+        INFO,
+        WARNING,
+        ERROR,
+        FATAL
+    };
+    enum class LogDest {
+        Console = 0b10,
+        File = 0b01
+    };
+
+    static void log(std::string, LogLevel level);
+    static void debug(std::string msg);
+    static void info(std::string msg);
+    static void warning(std::string msg);
+    static void error(std::string msg);
+    static void fatal(std::string msg);
+
+    static void setDest(LogDest dest);
+
+  private:
+    static int config;
+    static void logToConsole(std::string msg);
+    static void logToFile(std::string msg);
+};

--- a/Inc/HALALMock/Services/Logger/Logger.hpp
+++ b/Inc/HALALMock/Services/Logger/Logger.hpp
@@ -1,3 +1,6 @@
+#ifndef LOGGER_HPP
+#define LOGGER_HPP
+
 #include <string>
 #include <memory>
 #include <fstream>
@@ -82,3 +85,5 @@ constexpr bool hasFlag(Logger::LogConf mask, Logger::LogConf flag) {
 constexpr bool hasFlag(Logger::LogConf mask, Logger::LogLevel flag) {
     return (mask & flag) == static_cast<Logger::LogConf>(flag);
 };
+
+#endif

--- a/Inc/HALALMock/Services/Logger/Logger.hpp
+++ b/Inc/HALALMock/Services/Logger/Logger.hpp
@@ -1,25 +1,16 @@
 #include <string>
+#include <memory>
+#include <fstream>
 
-// Overload bit operators for LogConf enum
-constexpr Logger::LogConf operator|(const Logger::LogConf& conf1, const Logger::LogConf& conf2) {
-    return static_cast<Logger::LogConf>(static_cast<int>(conf1) | static_cast<int>(conf2));
-};
-constexpr Logger::LogConf operator&(const Logger::LogConf& conf, const Logger::LogLevel& level) {
-    return static_cast<Logger::LogConf>(static_cast<int>(conf) & static_cast<int>(level));
-};
-constexpr Logger::LogConf operator&(const Logger::LogConf& conf1, const Logger::LogConf& conf2) {
-    return static_cast<Logger::LogConf>(static_cast<int>(conf1) & static_cast<int>(conf2));
-};
+class FileManager {
+  public:
+    FileManager(const std::ios_base::openmode file_mode);
+    void add(const std::string& msg);
+    ~FileManager();
 
-/// @brief Check if a flag is activated in a mask
-/// @param mask Mask where you want to check the flag
-/// @param flag Flag which you want to check in the mask
-/// @return If the flag is activated in the mask
-constexpr bool hasFlag(Logger::LogConf mask, Logger::LogConf flag) {
-    return (mask & flag) == flag;
-};
-constexpr bool hasFlag(Logger::LogConf mask, Logger::LogLevel flag) {
-    return (mask & flag) == static_cast<Logger::LogConf>(flag);
+  private:
+    std::ofstream file_stream;
+
 };
 
 class Logger {
@@ -70,13 +61,24 @@ class Logger {
     static std::string log_filename;
 };
 
-class FileManager {
-  public:
-    FileManager(const std::ios_base::openmode file_mode);
-    void add(const std::string& msg);
-    ~FileManager();
+// Overload bit operators for LogConf enum
+constexpr Logger::LogConf operator|(const Logger::LogConf& conf1, const Logger::LogConf& conf2) {
+    return static_cast<Logger::LogConf>(static_cast<int>(conf1) | static_cast<int>(conf2));
+};
+constexpr Logger::LogConf operator&(const Logger::LogConf& conf, const Logger::LogLevel& level) {
+    return static_cast<Logger::LogConf>(static_cast<int>(conf) & static_cast<int>(level));
+};
+constexpr Logger::LogConf operator&(const Logger::LogConf& conf1, const Logger::LogConf& conf2) {
+    return static_cast<Logger::LogConf>(static_cast<int>(conf1) & static_cast<int>(conf2));
+};
 
-  private:
-    std::ofstream file_stream;
-
+/// @brief Check if a flag is activated in a mask
+/// @param mask Mask where you want to check the flag
+/// @param flag Flag which you want to check in the mask
+/// @return If the flag is activated in the mask
+constexpr bool hasFlag(Logger::LogConf mask, Logger::LogConf flag) {
+    return (mask & flag) == flag;
+};
+constexpr bool hasFlag(Logger::LogConf mask, Logger::LogLevel flag) {
+    return (mask & flag) == static_cast<Logger::LogConf>(flag);
 };

--- a/Inc/HALALMock/Services/Logger/Logger.hpp
+++ b/Inc/HALALMock/Services/Logger/Logger.hpp
@@ -13,34 +13,39 @@
 #define ANSI_COLOR_GREY "\x1b[37m"
 #define ANSI_COLOR_RESET "\x1b[0m"
 
-#define LOG_DEBUG(x)                                              \
-    do {                                                          \
-        Logger::set_metadata(__LINE__, __FUNCTION__, __FILE__);   \
-        Logger::log(x, Logger::LogLevel::DEBUG, ANSI_COLOR_GREY); \
+#define LOG_DEBUG(x)                                            \
+    do {                                                        \
+        Logger::set_metadata(__LINE__, __FUNCTION__, __FILE__); \
+        if (hasFlag(Log::config, Logger::LogLevel::DEBUG))      \
+            Logger::log(x, "DEBUG", ANSI_COLOR_GREY);           \
     } while (0)
 
-#define LOG_INFO(x)                                               \
-    do {                                                          \
-        Logger::set_metadata(__LINE__, __FUNCTION__, __FILE__);   \
-        Logger::log(x, Logger::LogLevel::INFO, ANSI_COLOR_GREEN); \
+#define LOG_INFO(x)                                             \
+    do {                                                        \
+        Logger::set_metadata(__LINE__, __FUNCTION__, __FILE__); \
+        if (hasFlag(Log::config, Logger::LogLevel::INFO))       \
+            Logger::log(x, "INFO", ANSI_COLOR_GREEN);           \
     } while (0)
 
-#define LOG_WARNING(x)                                                \
-    do {                                                              \
-        Logger::set_metadata(__LINE__, __FUNCTION__, __FILE__);       \
-        Logger::log(x, Logger::LogLevel::WARNING, ANSI_COLOR_YELLOW); \
+#define LOG_WARNING(x)                                          \
+    do {                                                        \
+        Logger::set_metadata(__LINE__, __FUNCTION__, __FILE__); \
+        if (hasFlag(Log::config, Logger::LogLevel::WARNING))    \
+            Logger::log(x, "WARNING", ANSI_COLOR_YELLOW);       \
     } while (0)
 
-#define LOG_ERROR(x)                                             \
-    do {                                                         \
-        Logger::set_metadata(__LINE__, __FUNCTION__, __FILE__);  \
-        Logger::log(x, Logger::LogLevel::ERROR, ANSI_COLOR_RED); \
+#define LOG_ERROR(x)                                            \
+    do {                                                        \
+        Logger::set_metadata(__LINE__, __FUNCTION__, __FILE__); \
+        if (hasFlag(Log::config, Logger::LogLevel::ERROR))      \
+            Logger::log(x, "ERROR", ANSI_COLOR_RED);            \
     } while (0)
 
-#define LOG_FATAL(x)                                                 \
-    do {                                                             \
-        Logger::set_metadata(__LINE__, __FUNCTION__, __FILE__);      \
-        Logger::log(x, Logger::LogLevel::FATAL, ANSI_COLOR_MAGENTA); \
+#define LOG_FATAL(x)                                            \
+    do {                                                        \
+        Logger::set_metadata(__LINE__, __FUNCTION__, __FILE__); \
+        if (hasFlag(Log::config, Logger::LogLevel::FATAL))      \
+            Logger::log(x, "FATAL", ANSI_COLOR_MAGENTA);        \
     } while (0)
 
 class FileManager {
@@ -77,7 +82,7 @@ class Logger {
         FATAL = 0b10000,
     };
 
-    static void log(const std::string& msg, const LogLevel level,
+    static void log(const std::string& msg, const std::string& level,
                     const char* colour);
     static void set_metadata(int line, const char* function, const char* file);
 

--- a/Inc/HALALMock/Services/Logger/Logger.hpp
+++ b/Inc/HALALMock/Services/Logger/Logger.hpp
@@ -1,126 +1,141 @@
-#ifndef LOGGER_HPP
-#define LOGGER_HPP
-
-#include <string>
-#include <memory>
-#include <fstream>
+#pragma once
 
 #include <stdio.h>
 
-#define ANSI_COLOR_RED     "\x1b[31m"
-#define ANSI_COLOR_GREEN   "\x1b[32m"
-#define ANSI_COLOR_YELLOW  "\x1b[33m"
-#define ANSI_COLOR_MAGENTA "\x1b[35m"
-#define ANSI_COLOR_GREY    "\x1b[37m"
-#define ANSI_COLOR_RESET   "\x1b[0m"
+#include <fstream>
+#include <memory>
+#include <string>
 
+#define ANSI_COLOR_RED "\x1b[31m"
+#define ANSI_COLOR_GREEN "\x1b[32m"
+#define ANSI_COLOR_YELLOW "\x1b[33m"
+#define ANSI_COLOR_MAGENTA "\x1b[35m"
+#define ANSI_COLOR_GREY "\x1b[37m"
+#define ANSI_COLOR_RESET "\x1b[0m"
 
 class FileManager {
-  public:
+   public:
     FileManager(const std::ios_base::openmode file_mode);
     void add(const std::string& msg);
     ~FileManager();
 
-  private:
+   private:
     std::ofstream file_stream;
-
 };
 
 /** @brief Class used to Log info in simulator mode.
  * You can log in five levels: DEBUG, INFO, WARNING, ERROR and FATAL.
- * 
+ *
  * To configure it, you must set in the extern variable config
- * a mask 'oring' the bits that represents what you want. 
+ * a mask 'oring' the bits that represents what you want.
  * You can configure which level of logs you want (DEBUG, INFO...),
  * if you want to write logs on the console and/or on a file,
  * and if you want to erase or not the log file.
- * 
+ *
  * To use it, you must use one of the five MACROS defined in this file,
  * each one representing the level of the log you want to print.
-*/
+ */
 class Logger {
-  public:
-
+   public:
     enum class LogLevel : unsigned int {
-        DEBUG   = 0b00001,
-        INFO    = 0b00010,
+        DEBUG = 0b00001,
+        INFO = 0b00010,
         WARNING = 0b00100,
-        ERROR   = 0b01000,
-        FATAL   = 0b10000,
+        ERROR = 0b01000,
+        FATAL = 0b10000,
     };
 
-    /// @brief Bitmask that represents log configuration
-    enum class LogConf : unsigned int {
-        /// @brief Includes Debug messages in logs
-        Debug           = 0b00000001,
-        /// @brief Includes Info messages in logs
-        Info            = 0b00000010,
-        /// @brief Includes Warning messages in logs
-        Warning         = 0b00000100,
-        /// @brief Includes Error messages in logs
-        Error           = 0b00001000,
-        /// @brief Includes Fatal messages in logs
-        Fatal           = 0b00010000,
-        /// @brief Writes logs into the console
-        Console         = 0b00100000,
-        /// @brief Writes logs into a file, defined in filename_log external variable
-        File            = 0b01000000,
-        /// @brief Erase previous logs
-        DestructiveLog  = 0b10000000
-    };
+    static void log(const std::string& msg, const LogLevel level,
+                    const char* colour);
+    static void set_metadata(int line, const char* function, const char* file);
 
-    static void log(const std::string& msg, const LogLevel level, const char *colour);
-    static void set_metadata(int line, const char *function, const char *file);
+#define LOG_DEBUG(x)                                              \
+    do {                                                          \
+        Logger::set_metadata(__LINE__, __FUNCTION__, __FILE__);   \
+        Logger::log(x, Logger::LogLevel::DEBUG, ANSI_COLOR_GREY); \
+    } while (0)
 
-    #define LOG_DEBUG(x) do { Logger::set_metadata(__LINE__, __FUNCTION__, __FILE__); \
-					           	   Logger::log(x, Logger::LogLevel::DEBUG, ANSI_COLOR_GREY);}while(0)
+#define LOG_INFO(x)                                               \
+    do {                                                          \
+        Logger::set_metadata(__LINE__, __FUNCTION__, __FILE__);   \
+        Logger::log(x, Logger::LogLevel::INFO, ANSI_COLOR_GREEN); \
+    } while (0)
 
-    #define LOG_INFO(x) do { Logger::set_metadata(__LINE__, __FUNCTION__, __FILE__); \
-					           	   Logger::log(x, Logger::LogLevel::INFO, ANSI_COLOR_GREEN);}while(0)
+#define LOG_WARNING(x)                                                \
+    do {                                                              \
+        Logger::set_metadata(__LINE__, __FUNCTION__, __FILE__);       \
+        Logger::log(x, Logger::LogLevel::WARNING, ANSI_COLOR_YELLOW); \
+    } while (0)
 
-    #define LOG_WARNING(x) do { Logger::set_metadata(__LINE__, __FUNCTION__, __FILE__); \
-					           	   Logger::log(x, Logger::LogLevel::WARNING, ANSI_COLOR_YELLOW);}while(0)
+#define LOG_ERROR(x)                                             \
+    do {                                                         \
+        Logger::set_metadata(__LINE__, __FUNCTION__, __FILE__);  \
+        Logger::log(x, Logger::LogLevel::ERROR, ANSI_COLOR_RED); \
+    } while (0)
 
-    #define LOG_ERROR(x) do { Logger::set_metadata(__LINE__, __FUNCTION__, __FILE__); \
-					           	   Logger::log(x, Logger::LogLevel::ERROR, ANSI_COLOR_RED);}while(0)
-
-    #define LOG_FATAL(x) do { Logger::set_metadata(__LINE__, __FUNCTION__, __FILE__); \
-					           	   Logger::log(x, Logger::LogLevel::FATAL, ANSI_COLOR_MAGENTA);}while(0)
+#define LOG_FATAL(x)                                                 \
+    do {                                                             \
+        Logger::set_metadata(__LINE__, __FUNCTION__, __FILE__);      \
+        Logger::log(x, Logger::LogLevel::FATAL, ANSI_COLOR_MAGENTA); \
+    } while (0)
 
     friend class FileManager;
 
-  private:
+   private:
     static std::unique_ptr<FileManager> file_manager;
     static int line;
-    static const char *function;
-    static const char *file;
+    static const char* function;
+    static const char* file;
 };
 
+namespace Log {
+extern std::string filename;
+/// @brief Bitmask that represents log configuration
+enum class LogConf : unsigned int {
+    /// @brief Includes Debug messages in logs
+    Debug = 0b00000001,
+    /// @brief Includes Info messages in logs
+    Info = 0b00000010,
+    /// @brief Includes Warning messages in logs
+    Warning = 0b00000100,
+    /// @brief Includes Error messages in logs
+    Error = 0b00001000,
+    /// @brief Includes Fatal messages in logs
+    Fatal = 0b00010000,
+    /// @brief Writes logs into the console
+    Console = 0b00100000,
+    /// @brief Writes logs into a file, defined in filename_log external
+    /// variable
+    File = 0b01000000,
+    /// @brief Erase previous logs
+    DestructiveLog = 0b10000000
+};
+extern LogConf config;
+}  // namespace Log
+
+using namespace Log;
 // Overload bit operators for LogConf enum
-constexpr Logger::LogConf operator|(const Logger::LogConf& conf1, const Logger::LogConf& conf2) {
-    return static_cast<Logger::LogConf>(static_cast<int>(conf1) | static_cast<int>(conf2));
+constexpr LogConf operator|(const LogConf& conf1, const LogConf& conf2) {
+    return static_cast<LogConf>(static_cast<int>(conf1) |
+                                static_cast<int>(conf2));
 };
-constexpr Logger::LogConf operator&(const Logger::LogConf& conf, const Logger::LogLevel& level) {
-    return static_cast<Logger::LogConf>(static_cast<int>(conf) & static_cast<int>(level));
+constexpr LogConf operator&(const LogConf& conf,
+                            const Logger::LogLevel& level) {
+    return static_cast<LogConf>(static_cast<int>(conf) &
+                                static_cast<int>(level));
 };
-constexpr Logger::LogConf operator&(const Logger::LogConf& conf1, const Logger::LogConf& conf2) {
-    return static_cast<Logger::LogConf>(static_cast<int>(conf1) & static_cast<int>(conf2));
+constexpr LogConf operator&(const LogConf& conf1, const LogConf& conf2) {
+    return static_cast<LogConf>(static_cast<int>(conf1) &
+                                static_cast<int>(conf2));
 };
 
 /// @brief Check if a flag is activated in a mask
 /// @param mask Mask where you want to check the flag
 /// @param flag Flag which you want to check in the mask
 /// @return If the flag is activated in the mask
-constexpr bool hasFlag(const Logger::LogConf mask, const Logger::LogConf flag) {
+constexpr bool hasFlag(const LogConf mask, const LogConf flag) {
     return (mask & flag) == flag;
 };
-constexpr bool hasFlag(const Logger::LogConf mask, const Logger::LogLevel flag) {
-    return (mask & flag) == static_cast<Logger::LogConf>(flag);
+constexpr bool hasFlag(const LogConf mask, const Logger::LogLevel flag) {
+    return (mask & flag) == static_cast<LogConf>(flag);
 };
-
-namespace Log {
-  extern const Logger::LogConf config;
-  extern const char* filename;
-}
-
-#endif

--- a/Inc/ST-LIB_LOW/ErrorHandler/ErrorHandler.hpp
+++ b/Inc/ST-LIB_LOW/ErrorHandler/ErrorHandler.hpp
@@ -14,6 +14,7 @@
 #else
 #include "HALALMock/Services/Time/Time.hpp"
 #include "HALALMock/Services/Communication/UART/UART.hpp"
+#include "HALALMock/Services/Logger/Logger.hpp"
 #endif
 
 class ErrorHandlerModel {

--- a/Src/HALALMock/Services/Logger/Logger.cpp
+++ b/Src/HALALMock/Services/Logger/Logger.cpp
@@ -50,13 +50,21 @@ FileManager::FileManager(const std::ios_base::openmode file_mode) {
     file_stream = std::ofstream(Log::filename, file_mode);
     if (!file_stream.is_open()) {
         std::cerr << "LOGGER ERROR. Couldn't open file " << Log::filename
-                  << ", writing logs in STLIB.log" << std::endl;
+                  << ", trying to write logs in STLIB.log" << std::endl;
         file_stream = std::ofstream("STLIB.log", file_mode);
+        if (!file_stream.is_open()) {
+            std::cerr << "LOGGER FATAL ERROR. Couldn't open file STLIB.log. "
+                         "Your logs will NOT write on any file. Check your "
+                         "permissions on this file"
+                      << std::endl;
+        }
     }
 }
 
 void FileManager::add(const std::string &msg) {
-    file_stream << msg << std::endl;
+    if (file_stream.is_open()) {
+        file_stream << msg << std::endl;
+    }
 }
 
 FileManager::~FileManager() { file_stream.close(); }

--- a/Src/HALALMock/Services/Logger/Logger.cpp
+++ b/Src/HALALMock/Services/Logger/Logger.cpp
@@ -11,7 +11,7 @@ Logger::LogConf Logger::config = Logger::LogConf::Error
                                 | Logger::LogConf::Console
                                 | Logger::LogConf::File;
 
-std::unique_ptr<FileManager> Logger::file_manager = nullptr;
+std::unique_ptr<FileManager> Logger::file_manager = std::make_unique<FileManager>(std::ios_base::trunc);
 
 /// @brief Default log filename. To change it, use setFilename()
 std::string Logger::log_filename = "STLIB.log";
@@ -26,14 +26,19 @@ void Logger::log(const std::string& msg, const LogLevel level) {
     switch (level) {
         case LogLevel::DEBUG:
             log_level = "DEBUG";
+            break;
         case LogLevel::INFO:
             log_level = "INFO";
+            break;
         case LogLevel::WARNING:
             log_level = "WARNING";
+            break;
         case LogLevel::ERROR:
             log_level = "ERROR";
+            break;
         case LogLevel::FATAL:
             log_level = "FATAL";
+            break;
     }
 
     // Format message to include timestamp and Level
@@ -46,7 +51,7 @@ void Logger::log(const std::string& msg, const LogLevel level) {
 
     // Print message where has been configured to print
     if (hasFlag(config, LogConf::Console)) {  // Print msg into console
-        std::cout << formatted_message;
+        std::cout << formatted_message << std::endl;
     }
 
     if (hasFlag(config, LogConf::File)) {  // Write message into a file

--- a/Src/HALALMock/Services/Logger/Logger.cpp
+++ b/Src/HALALMock/Services/Logger/Logger.cpp
@@ -5,21 +5,15 @@
 #include <memory> // To manage FileManager ptr
 
 // === Class Logger ===
-
-Logger::LogConf Logger::config = Logger::LogConf::Error
-                                | Logger::LogConf::Fatal
-                                | Logger::LogConf::Console
-                                | Logger::LogConf::File;
-
 std::unique_ptr<FileManager> Logger::file_manager = std::make_unique<FileManager>(std::ios_base::trunc);
-
-/// @brief Default log filename. To change it, use setFilename()
-std::string Logger::log_filename = "STLIB.log";
+int Logger::line = 0;
+const char *Logger::function = nullptr;
+const char *Logger::file = nullptr;
 
 void Logger::log(const std::string& msg, const LogLevel level) {
 
     // Check if this level is activated in config bitmask
-    if(!hasFlag(config, level)) return;
+    if(!hasFlag(Log::config, level)) return;
 
     // Reach Log Level
     std::string log_level;
@@ -44,64 +38,37 @@ void Logger::log(const std::string& msg, const LogLevel level) {
     // Format message to include timestamp and Level
     // Reach timestamp
     time_t current_time = time(nullptr);
-    std::string timestamp = ctime(&current_time);
+    char timestamp[19];
+    strftime(timestamp, sizeof(timestamp), "%d/%m/%y %T", localtime(&current_time));
 
     // Reach message to be printed
-    std::string formatted_message = "[" + timestamp + "] " + "[" + log_level + "] " + msg;
+    std::string formatted_message = "[" + std::string(timestamp) + "] " +
+                                    "[" + log_level + "] " + "[" + file + 
+                                    "->" + function + "->" +
+                                    std::to_string(line) + "] " + msg;
 
     // Print message where has been configured to print
-    if (hasFlag(config, LogConf::Console)) {  // Print msg into console
+    if (hasFlag(Log::config, LogConf::Console)) {  // Print msg into console
         std::cout << formatted_message << std::endl;
     }
 
-    if (hasFlag(config, LogConf::File)) {  // Write message into a file
+    if (hasFlag(Log::config, LogConf::File)) {  // Write message into a file
         file_manager->add(formatted_message);
     }
 }
 
-void Logger::debug(const std::string& msg) {
-    log(msg, LogLevel::DEBUG);
+void Logger::set_metadata(int line, const char *function, const char *file) {
+    Logger::line = line;
+    Logger::function = function;
+    Logger::file = file;
 }
-
-void Logger::info(const std::string& msg) {
-    log(msg, LogLevel::INFO);
-}
-
-void Logger::warning(const std::string& msg) {
-    log(msg, LogLevel::WARNING);
-}
-
-void Logger::error(const std::string& msg) {
-    log(msg, LogLevel::ERROR);
-}
-
-void Logger::fatal(const std::string& msg) {
-    log(msg, LogLevel::FATAL);
-}
-
-/// @brief Sets the Logger configuration
-/// @param conf Configuration of the Logger. It must be a bit mask of LogConf values, using '|' operator.
-void Logger::setConf(const LogConf conf) {
-    config = conf;
-    if (hasFlag(conf, LogConf::File)) {
-        if (hasFlag(conf, LogConf::DestructiveLog)) {
-            Logger::file_manager = std::make_unique<FileManager>(std::ios_base::trunc);
-        } else {
-            Logger::file_manager = std::make_unique<FileManager>(std::ios_base::app);
-        }
-    } 
-}
-
-void Logger::setFilename(const std::string& filename) {
-        log_filename = filename;
-    }
 
 // === Class FileManager ===
 
 FileManager::FileManager(const std::ios_base::openmode file_mode) {
-    file_stream = std::ofstream(Logger::log_filename, file_mode);
+    file_stream = std::ofstream(Log::filename, file_mode);
     if (!file_stream.is_open()) {
-        std::cerr << "LOGGER ERROR. Couldn't open file " << Logger::log_filename << ", writing logs in STLIB.log" << std::endl;
+        std::cerr << "LOGGER ERROR. Couldn't open file " << Log::filename << ", writing logs in STLIB.log" << std::endl;
         file_stream = std::ofstream("STLIB.log", file_mode);
     }
 }

--- a/Src/HALALMock/Services/Logger/Logger.cpp
+++ b/Src/HALALMock/Services/Logger/Logger.cpp
@@ -1,0 +1,49 @@
+#include "HALALMock/Services/Logger/Logger.hpp"
+#include <ctime>
+#include <iostream>
+
+void Logger::log(std::string msg, LogLevel level) {
+    // Format message to include timestamp and Level
+    // Reach timestamp
+    time_t current_time = time(nullptr);
+    std::string timestamp = ctime(&current_time);
+
+    // Reach Log Level
+    std::string log_level;
+    switch (level) {
+        case LogLevel::DEBUG:
+            log_level = "DEBUG";
+        case LogLevel::INFO:
+            log_level = "INFO";
+        case LogLevel::WARNING:
+            log_level = "WARNING";
+        case LogLevel::ERROR:
+            log_level = "ERROR";
+        case LogLevel::FATAL:
+            log_level = "FATAL";
+    }
+
+    // Reach message to be printed
+    std::string formatted_message = "[" + timestamp + "] " + "[" + log_level + "] " + msg + "\n";
+
+    // Print message where has been configured to print
+    if (config & static_cast<int>(LogDest::Console)) {  // Print msg into console
+        std::cout << formatted_message;
+    }
+}
+
+void Logger::debug(std::string msg) { log(msg, LogLevel::DEBUG); }
+
+void Logger::info(std::string msg) { log(msg, LogLevel::INFO); }
+
+void Logger::warning(std::string msg) { log(msg, LogLevel::WARNING); }
+
+void Logger::error(std::string msg) { log(msg, LogLevel::ERROR); }
+
+void Logger::fatal(std::string msg) { log(msg, LogLevel::FATAL); }
+
+void Logger::setDest(LogDest dest) { config = config | static_cast<int>(dest); }
+
+void Logger::logToConsole(std::string msg) {}
+
+void Logger::logToFile(std::string msg) {}

--- a/Src/HALALMock/Services/Logger/Logger.cpp
+++ b/Src/HALALMock/Services/Logger/Logger.cpp
@@ -12,30 +12,8 @@ int Logger::line = 0;
 const char *Logger::function = nullptr;
 const char *Logger::file = nullptr;
 
-void Logger::log(const std::string &msg, const LogLevel level,
+void Logger::log(const std::string &msg, const std::string &level,
                  const char *colour) {
-    // Check if this level is activated in config bitmask
-    if (!hasFlag(Log::config, level)) return;
-
-    // Reach Log Level
-    std::string log_level;
-    switch (level) {
-        case LogLevel::DEBUG:
-            log_level = "DEBUG";
-            break;
-        case LogLevel::INFO:
-            log_level = "INFO";
-            break;
-        case LogLevel::WARNING:
-            log_level = "WARNING";
-            break;
-        case LogLevel::ERROR:
-            log_level = "ERROR";
-            break;
-        case LogLevel::FATAL:
-            log_level = "FATAL";
-            break;
-    }
 
     // Format message to include timestamp and Level
     // Reach timestamp
@@ -44,9 +22,9 @@ void Logger::log(const std::string &msg, const LogLevel level,
     strftime(timestamp, sizeof(timestamp), "%d/%m/%y %T",
              localtime(&current_time));
 
-    // Reach message to be printed
+    // Get message to be printed
     std::string formatted_message =
-        "[" + std::string(timestamp) + "] " + "[" + colour + log_level +
+        "[" + std::string(timestamp) + "] " + "[" + colour + level +
         ANSI_COLOR_RESET + "] " + "[" + file + ":" + std::to_string(line) +
         " in " + function + "] " + msg;
 

--- a/Src/HALALMock/Services/Logger/Logger.cpp
+++ b/Src/HALALMock/Services/Logger/Logger.cpp
@@ -1,19 +1,21 @@
 #include "HALALMock/Services/Logger/Logger.hpp"
-#include <ctime> // To manage time
-#include <iostream> // To write in console
-#include <fstream> // To write in a file
-#include <memory> // To manage FileManager ptr
+
+#include <ctime>     // To manage time
+#include <fstream>   // To write in a file
+#include <iostream>  // To write in console
+#include <memory>    // To manage FileManager ptr
 
 // === Class Logger ===
-std::unique_ptr<FileManager> Logger::file_manager = std::make_unique<FileManager>(std::ios_base::trunc);
+std::unique_ptr<FileManager> Logger::file_manager =
+    std::make_unique<FileManager>(std::ios_base::trunc);
 int Logger::line = 0;
 const char *Logger::function = nullptr;
 const char *Logger::file = nullptr;
 
-void Logger::log(const std::string& msg, const LogLevel level, const char *colour) {
-
+void Logger::log(const std::string &msg, const LogLevel level,
+                 const char *colour) {
     // Check if this level is activated in config bitmask
-    if(!hasFlag(Log::config, level)) return;
+    if (!hasFlag(Log::config, level)) return;
 
     // Reach Log Level
     std::string log_level;
@@ -39,13 +41,14 @@ void Logger::log(const std::string& msg, const LogLevel level, const char *colou
     // Reach timestamp
     time_t current_time = time(nullptr);
     char timestamp[19];
-    strftime(timestamp, sizeof(timestamp), "%d/%m/%y %T", localtime(&current_time));
+    strftime(timestamp, sizeof(timestamp), "%d/%m/%y %T",
+             localtime(&current_time));
 
     // Reach message to be printed
-    std::string formatted_message = "[" + std::string(timestamp) + "] " +
-                                    "[" + colour + log_level + ANSI_COLOR_RESET +
-                                    "] " + "[" + file + ":" + std::to_string(line) +
-                                    " in " + function + "] " + msg;
+    std::string formatted_message =
+        "[" + std::string(timestamp) + "] " + "[" + colour + log_level +
+        ANSI_COLOR_RESET + "] " + "[" + file + ":" + std::to_string(line) +
+        " in " + function + "] " + msg;
 
     // Print message where has been configured to print
     if (hasFlag(Log::config, LogConf::Console)) {  // Print msg into console
@@ -68,15 +71,14 @@ void Logger::set_metadata(int line, const char *function, const char *file) {
 FileManager::FileManager(const std::ios_base::openmode file_mode) {
     file_stream = std::ofstream(Log::filename, file_mode);
     if (!file_stream.is_open()) {
-        std::cerr << "LOGGER ERROR. Couldn't open file " << Log::filename << ", writing logs in STLIB.log" << std::endl;
+        std::cerr << "LOGGER ERROR. Couldn't open file " << Log::filename
+                  << ", writing logs in STLIB.log" << std::endl;
         file_stream = std::ofstream("STLIB.log", file_mode);
     }
 }
 
-void FileManager::add(const std::string& msg) {
+void FileManager::add(const std::string &msg) {
     file_stream << msg << std::endl;
 }
 
-FileManager::~FileManager() {
-    file_stream.close();
-}
+FileManager::~FileManager() { file_stream.close(); }

--- a/Src/HALALMock/Services/Logger/Logger.cpp
+++ b/Src/HALALMock/Services/Logger/Logger.cpp
@@ -13,7 +13,7 @@ int Logger::line = 0;
 const char *Logger::function = nullptr;
 const char *Logger::file = nullptr;
 
-void Logger::log(const std::string &msg, const std::string &level,
+void Logger::__log(const std::string &msg, const std::string &level,
                  const char *colour) {
     // Format message to include timestamp and Level
     // Reach timestamp

--- a/Src/HALALMock/Services/Logger/Logger.cpp
+++ b/Src/HALALMock/Services/Logger/Logger.cpp
@@ -1,12 +1,25 @@
 #include "HALALMock/Services/Logger/Logger.hpp"
-#include <ctime>
-#include <iostream>
+#include <ctime> // To manage time
+#include <iostream> // To write in console
+#include <fstream> // To write in a file
+#include <memory> // To manage FileManager ptr
 
-void Logger::log(std::string msg, LogLevel level) {
-    // Format message to include timestamp and Level
-    // Reach timestamp
-    time_t current_time = time(nullptr);
-    std::string timestamp = ctime(&current_time);
+// === Class Logger ===
+
+Logger::LogConf Logger::config = Logger::LogConf::Error
+                                | Logger::LogConf::Fatal
+                                | Logger::LogConf::Console
+                                | Logger::LogConf::File;
+
+std::unique_ptr<FileManager> Logger::file_manager = nullptr;
+
+/// @brief Default log filename. To change it, use setFilename()
+std::string Logger::log_filename = "STLIB.log";
+
+void Logger::log(const std::string& msg, const LogLevel level) {
+
+    // Check if this level is activated in config bitmask
+    if(!hasFlag(config, level)) return;
 
     // Reach Log Level
     std::string log_level;
@@ -23,27 +36,75 @@ void Logger::log(std::string msg, LogLevel level) {
             log_level = "FATAL";
     }
 
+    // Format message to include timestamp and Level
+    // Reach timestamp
+    time_t current_time = time(nullptr);
+    std::string timestamp = ctime(&current_time);
+
     // Reach message to be printed
-    std::string formatted_message = "[" + timestamp + "] " + "[" + log_level + "] " + msg + "\n";
+    std::string formatted_message = "[" + timestamp + "] " + "[" + log_level + "] " + msg;
 
     // Print message where has been configured to print
-    if (config & static_cast<int>(LogDest::Console)) {  // Print msg into console
+    if (hasFlag(config, LogConf::Console)) {  // Print msg into console
         std::cout << formatted_message;
+    }
+
+    if (hasFlag(config, LogConf::File)) {  // Write message into a file
+        file_manager->add(formatted_message);
     }
 }
 
-void Logger::debug(std::string msg) { log(msg, LogLevel::DEBUG); }
+void Logger::debug(const std::string& msg) {
+    log(msg, LogLevel::DEBUG);
+}
 
-void Logger::info(std::string msg) { log(msg, LogLevel::INFO); }
+void Logger::info(const std::string& msg) {
+    log(msg, LogLevel::INFO);
+}
 
-void Logger::warning(std::string msg) { log(msg, LogLevel::WARNING); }
+void Logger::warning(const std::string& msg) {
+    log(msg, LogLevel::WARNING);
+}
 
-void Logger::error(std::string msg) { log(msg, LogLevel::ERROR); }
+void Logger::error(const std::string& msg) {
+    log(msg, LogLevel::ERROR);
+}
 
-void Logger::fatal(std::string msg) { log(msg, LogLevel::FATAL); }
+void Logger::fatal(const std::string& msg) {
+    log(msg, LogLevel::FATAL);
+}
 
-void Logger::setDest(LogDest dest) { config = config | static_cast<int>(dest); }
+/// @brief Sets the Logger configuration
+/// @param conf Configuration of the Logger. It must be a bit mask of LogConf values, using '|' operator.
+void Logger::setConf(const LogConf conf) {
+    config = conf;
+    if (hasFlag(conf, LogConf::File)) {
+        if (hasFlag(conf, LogConf::DestructiveLog)) {
+            Logger::file_manager = std::make_unique<FileManager>(std::ios_base::trunc);
+        } else {
+            Logger::file_manager = std::make_unique<FileManager>(std::ios_base::app);
+        }
+    } 
+}
 
-void Logger::logToConsole(std::string msg) {}
+void Logger::setFilename(const std::string& filename) {
+        log_filename = filename;
+    }
 
-void Logger::logToFile(std::string msg) {}
+// === Class FileManager ===
+
+FileManager::FileManager(const std::ios_base::openmode file_mode) {
+    file_stream = std::ofstream(Logger::log_filename, file_mode);
+    if (!file_stream.is_open()) {
+        std::cerr << "LOGGER ERROR. Couldn't open file " << Logger::log_filename << ", writing logs in STLIB.log" << std::endl;
+        file_stream = std::ofstream("STLIB.log", file_mode);
+    }
+}
+
+void FileManager::add(const std::string& msg) {
+    file_stream << msg << std::endl;
+}
+
+FileManager::~FileManager() {
+    file_stream.close();
+}

--- a/Src/HALALMock/Services/Logger/Logger.cpp
+++ b/Src/HALALMock/Services/Logger/Logger.cpp
@@ -10,7 +10,7 @@ int Logger::line = 0;
 const char *Logger::function = nullptr;
 const char *Logger::file = nullptr;
 
-void Logger::log(const std::string& msg, const LogLevel level) {
+void Logger::log(const std::string& msg, const LogLevel level, const char *colour) {
 
     // Check if this level is activated in config bitmask
     if(!hasFlag(Log::config, level)) return;
@@ -43,9 +43,9 @@ void Logger::log(const std::string& msg, const LogLevel level) {
 
     // Reach message to be printed
     std::string formatted_message = "[" + std::string(timestamp) + "] " +
-                                    "[" + log_level + "] " + "[" + file + 
-                                    "->" + function + "->" +
-                                    std::to_string(line) + "] " + msg;
+                                    "[" + colour + log_level + ANSI_COLOR_RESET +
+                                    "] " + "[" + file + ":" + std::to_string(line) +
+                                    " in " + function + "] " + msg;
 
     // Print message where has been configured to print
     if (hasFlag(Log::config, LogConf::Console)) {  // Print msg into console

--- a/Src/HALALMock/Services/Logger/Logger.cpp
+++ b/Src/HALALMock/Services/Logger/Logger.cpp
@@ -1,6 +1,7 @@
 #include "HALALMock/Services/Logger/Logger.hpp"
 
 #include <ctime>     // To manage time
+#include <format>    // To build formatted strings
 #include <fstream>   // To write in a file
 #include <iostream>  // To write in console
 #include <memory>    // To manage FileManager ptr
@@ -14,7 +15,6 @@ const char *Logger::file = nullptr;
 
 void Logger::log(const std::string &msg, const std::string &level,
                  const char *colour) {
-
     // Format message to include timestamp and Level
     // Reach timestamp
     time_t current_time = time(nullptr);
@@ -22,19 +22,19 @@ void Logger::log(const std::string &msg, const std::string &level,
     strftime(timestamp, sizeof(timestamp), "%d/%m/%y %T",
              localtime(&current_time));
 
-    // Get message to be printed
-    std::string formatted_message =
-        "[" + std::string(timestamp) + "] " + "[" + colour + level +
-        ANSI_COLOR_RESET + "] " + "[" + file + ":" + std::to_string(line) +
-        " in " + function + "] " + msg;
-
     // Print message where has been configured to print
     if (hasFlag(Log::config, LogConf::Console)) {  // Print msg into console
-        std::cout << formatted_message << std::endl;
+        std::string terminal_message = std::format(
+            "[{}] [{}{}{}] [{}:{} in {}] {}", std::string(timestamp), colour,
+            level, ANSI_COLOR_RESET, file, std::to_string(line), function, msg);
+        std::cout << terminal_message << std::endl;
     }
 
     if (hasFlag(Log::config, LogConf::File)) {  // Write message into a file
-        file_manager->add(formatted_message);
+        std::string file_message =
+            std::format("[{}] [{}] [{}:{} in {}] {}", std::string(timestamp),
+                        level, file, std::to_string(line), function, msg);
+        file_manager->add(file_message);
     }
 }
 

--- a/Src/ST-LIB_LOW/ErrorHandler/ErrorHandler.cpp
+++ b/Src/ST-LIB_LOW/ErrorHandler/ErrorHandler.cpp
@@ -46,6 +46,10 @@ void ErrorHandlerModel::ErrorHandlerTrigger(string format, ... ){
 
 	description += string(buffer.get(), buffer.get() + size - 1) + " | Line: " + ErrorHandlerModel::line
 							+ " Function: '" + ErrorHandlerModel::func + "' File: " + ErrorHandlerModel::file ;
+	
+	#ifdef SIM_ON
+	LOG_FATAL(string(buffer.get(), buffer.get() + size - 1));
+	#endif
 
 #ifdef HAL_TIM_MODULE_ENABLED
 	 description += " | TimeStamp: " + to_string(Time::get_global_tick());

--- a/Tests/Runes/SimRunes.cpp
+++ b/Tests/Runes/SimRunes.cpp
@@ -1,40 +1,46 @@
 #include "HALAL/HALAL.hpp"
 
-const char* SHM::gpio_memory_name = nullptr;  
-const char* SHM::state_machine_memory_name = nullptr;
-std::unordered_map<Pin, size_t> SHM::pin_offsets = {
-    		{PA0, 0}, {PA1, 1}, {PA2, 2}, {PA3, 3}, {PA4, 4},
-		{PA5, 5}, {PA6, 6}, {PA7, 7}, {PA8, 8}, {PA9, 9},
-		{PA10, 10}, {PA11, 11}, {PA12, 12}, {PA13, 13}, 
-		{PA14, 14}, {PA15, 15}, {PB0, 16}, {PB1, 17},
-		{PB2, 18}, {PB3, 19}, {PB4, 20}, {PB5, 21},
-		{PB6, 22}, {PB7, 23}, {PB8, 24}, {PB9, 25},
-		{PB10, 26}, {PB11, 27}, {PB12, 28}, {PB13, 29},
-		{PB14, 30}, {PB15, 31}, {PC0, 32}, {PC1, 33},
-		{PC2, 34}, {PC3, 35}, {PC4, 36}, {PC5, 37},
-		{PC6, 38}, {PC7, 39}, {PC8, 40}, {PC9, 41},
-		{PC10, 42}, {PC11, 43}, {PC12, 44}, {PC13, 45},
-		{PC14, 46}, {PC15, 47}, {PD0, 48}, {PD1, 49},
-		{PD2, 50}, {PD3, 51}, {PD4, 52}, {PD5, 53},
-		{PD6, 54}, {PD7, 55}, {PD8, 56}, {PD9, 57},
-		{PD10, 58}, {PD11, 59}, {PD12, 60}, {PD13, 61},
-		{PD14, 62}, {PD15, 63}, {PE0, 64}, {PE1, 65},
-		{PE2, 66}, {PE3, 67}, {PE4, 68}, {PE5, 69},
-		{PE6, 70}, {PE7, 71}, {PE8, 72}, {PE9, 73},
-		{PE10, 74}, {PE11, 75}, {PE12, 76}, {PE13, 77},
-		{PE14, 78}, {PE15, 79}, {PF0, 80}, {PF1, 81},
-		{PF2, 82}, {PF3, 83}, {PF4, 84}, {PF5, 85},
-		{PF6, 86}, {PF7, 87}, {PF8, 88}, {PF9, 89},
-		{PF10, 90}, {PF11, 91}, {PF12, 92}, {PF13, 93},
-		{PF14, 94}, {PF15, 95}, {PG0, 96}, {PG1, 97},
-		{PG2, 98}, {PG3, 99}, {PG4, 100}, {PG5, 101},
-		{PG6, 102}, {PG7, 103}, {PG8, 104}, {PG9, 105},
-		{PG10, 106}, {PG11, 107}, {PG12, 108}, {PG13, 109},
-		{PG14, 110}, {PG15, 111}, {PH0, 112}, {PH1, 113}
-};
+/************************************************
+ *                 Logger
+ ***********************************************/
+
+LogConf Log::config =
+    LogConf::Error | LogConf::Fatal | LogConf::Console | LogConf::File;
+std::string Log::filename = "STLIB.log";
 
 /************************************************
-         					   ADC
+ *                 Shared Memory
+ ***********************************************/
+
+const char* SHM::gpio_memory_name = nullptr;
+const char* SHM::state_machine_memory_name = nullptr;
+std::unordered_map<Pin, size_t> SHM::pin_offsets = {
+    {PA0, 0},    {PA1, 1},    {PA2, 2},    {PA3, 3},    {PA4, 4},
+    {PA5, 5},    {PA6, 6},    {PA7, 7},    {PA8, 8},    {PA9, 9},
+    {PA10, 10},  {PA11, 11},  {PA12, 12},  {PA13, 13},  {PA14, 14},
+    {PA15, 15},  {PB0, 16},   {PB1, 17},   {PB2, 18},   {PB3, 19},
+    {PB4, 20},   {PB5, 21},   {PB6, 22},   {PB7, 23},   {PB8, 24},
+    {PB9, 25},   {PB10, 26},  {PB11, 27},  {PB12, 28},  {PB13, 29},
+    {PB14, 30},  {PB15, 31},  {PC0, 32},   {PC1, 33},   {PC2, 34},
+    {PC3, 35},   {PC4, 36},   {PC5, 37},   {PC6, 38},   {PC7, 39},
+    {PC8, 40},   {PC9, 41},   {PC10, 42},  {PC11, 43},  {PC12, 44},
+    {PC13, 45},  {PC14, 46},  {PC15, 47},  {PD0, 48},   {PD1, 49},
+    {PD2, 50},   {PD3, 51},   {PD4, 52},   {PD5, 53},   {PD6, 54},
+    {PD7, 55},   {PD8, 56},   {PD9, 57},   {PD10, 58},  {PD11, 59},
+    {PD12, 60},  {PD13, 61},  {PD14, 62},  {PD15, 63},  {PE0, 64},
+    {PE1, 65},   {PE2, 66},   {PE3, 67},   {PE4, 68},   {PE5, 69},
+    {PE6, 70},   {PE7, 71},   {PE8, 72},   {PE9, 73},   {PE10, 74},
+    {PE11, 75},  {PE12, 76},  {PE13, 77},  {PE14, 78},  {PE15, 79},
+    {PF0, 80},   {PF1, 81},   {PF2, 82},   {PF3, 83},   {PF4, 84},
+    {PF5, 85},   {PF6, 86},   {PF7, 87},   {PF8, 88},   {PF9, 89},
+    {PF10, 90},  {PF11, 91},  {PF12, 92},  {PF13, 93},  {PF14, 94},
+    {PF15, 95},  {PG0, 96},   {PG1, 97},   {PG2, 98},   {PG3, 99},
+    {PG4, 100},  {PG5, 101},  {PG6, 102},  {PG7, 103},  {PG8, 104},
+    {PG9, 105},  {PG10, 106}, {PG11, 107}, {PG12, 108}, {PG13, 109},
+    {PG14, 110}, {PG15, 111}, {PH0, 112},  {PH1, 113}};
+
+/************************************************
+                    ADC
  ***********************************************/
 
 std::map<Pin, ADC::Instance> ADC::available_instances = {
@@ -58,11 +64,10 @@ std::map<Pin, ADC::Instance> ADC::available_instances = {
     {PA5, Instance(ADC::ADCResolution::ADC_RES_16BITS)},
     {PA6, Instance(ADC::ADCResolution::ADC_RES_16BITS)},
     {PB0, Instance(ADC::ADCResolution::ADC_RES_16BITS)},
-    {PB1, Instance(ADC::ADCResolution::ADC_RES_16BITS)}
-};
-  
+    {PB1, Instance(ADC::ADCResolution::ADC_RES_16BITS)}};
+
 /************************************************
-                  	  PWM
+                          PWM
  ***********************************************/
 
 // Define TimerPeripheral objects
@@ -80,33 +85,44 @@ TimerPeripheral timer23;
 #define TIM_CHANNEL_3 3
 #define TIM_CHANNEL_4 4
 
-std::unordered_map<Pin,std::pair<std::reference_wrapper<TimerPeripheral>, TimerPeripheral::PWMData>> PWM::available_pwm {
-    {PB14, {timer12, {TIM_CHANNEL_1, TimerPeripheral::PWM_MODE::NORMAL}}},
-    {PB15, {timer12, {TIM_CHANNEL_2, TimerPeripheral::PWM_MODE::NORMAL}}},
-    {PB4, {timer3, {TIM_CHANNEL_1, TimerPeripheral::PWM_MODE::PHASED}}},
-    {PB5, {timer3, {TIM_CHANNEL_2, TimerPeripheral::PWM_MODE::NORMAL}}},
-    {PC8, {timer3, {TIM_CHANNEL_3, TimerPeripheral::PWM_MODE::NORMAL}}},
-    {PD12, {timer4, {TIM_CHANNEL_1, TimerPeripheral::PWM_MODE::NORMAL}}},
-    {PD13, {timer4, {TIM_CHANNEL_2, TimerPeripheral::PWM_MODE::NORMAL}}},
-    {PD15, {timer4, {TIM_CHANNEL_4, TimerPeripheral::PWM_MODE::NORMAL}}},
-    {PE14, {timer1, {TIM_CHANNEL_4, TimerPeripheral::PWM_MODE::PHASED}}},
-    {PE6, {timer15, {TIM_CHANNEL_2, TimerPeripheral::PWM_MODE::NORMAL}}},
-    {PF1, {timer23, {TIM_CHANNEL_2, TimerPeripheral::PWM_MODE::NORMAL}}},
-    {PF2, {timer23, {TIM_CHANNEL_3, TimerPeripheral::PWM_MODE::NORMAL}}},
-    {PF3, {timer23, {TIM_CHANNEL_4, TimerPeripheral::PWM_MODE::NORMAL}}},
-    {PE5, {timer15, {TIM_CHANNEL_1, TimerPeripheral::PWM_MODE::NORMAL}}},
-    {PE11, {timer1, {TIM_CHANNEL_2, TimerPeripheral::PWM_MODE::NORMAL}}},
-};
+std::unordered_map<Pin, std::pair<std::reference_wrapper<TimerPeripheral>,
+                                  TimerPeripheral::PWMData>>
+    PWM::available_pwm{
+        {PB14, {timer12, {TIM_CHANNEL_1, TimerPeripheral::PWM_MODE::NORMAL}}},
+        {PB15, {timer12, {TIM_CHANNEL_2, TimerPeripheral::PWM_MODE::NORMAL}}},
+        {PB4, {timer3, {TIM_CHANNEL_1, TimerPeripheral::PWM_MODE::PHASED}}},
+        {PB5, {timer3, {TIM_CHANNEL_2, TimerPeripheral::PWM_MODE::NORMAL}}},
+        {PC8, {timer3, {TIM_CHANNEL_3, TimerPeripheral::PWM_MODE::NORMAL}}},
+        {PD12, {timer4, {TIM_CHANNEL_1, TimerPeripheral::PWM_MODE::NORMAL}}},
+        {PD13, {timer4, {TIM_CHANNEL_2, TimerPeripheral::PWM_MODE::NORMAL}}},
+        {PD15, {timer4, {TIM_CHANNEL_4, TimerPeripheral::PWM_MODE::NORMAL}}},
+        {PE14, {timer1, {TIM_CHANNEL_4, TimerPeripheral::PWM_MODE::PHASED}}},
+        {PE6, {timer15, {TIM_CHANNEL_2, TimerPeripheral::PWM_MODE::NORMAL}}},
+        {PF1, {timer23, {TIM_CHANNEL_2, TimerPeripheral::PWM_MODE::NORMAL}}},
+        {PF2, {timer23, {TIM_CHANNEL_3, TimerPeripheral::PWM_MODE::NORMAL}}},
+        {PF3, {timer23, {TIM_CHANNEL_4, TimerPeripheral::PWM_MODE::NORMAL}}},
+        {PE5, {timer15, {TIM_CHANNEL_1, TimerPeripheral::PWM_MODE::NORMAL}}},
+        {PE11, {timer1, {TIM_CHANNEL_2, TimerPeripheral::PWM_MODE::NORMAL}}},
+    };
 
 /************************************************
-                  	Dual PWM
+                        Dual PWM
  ***********************************************/
 
-std::unordered_map<std::pair<Pin,Pin>,std::pair<std::reference_wrapper<TimerPeripheral>, TimerPeripheral::PWMData>> DualPWM::available_dual_pwms {
-    {{PB8, PB6}, {timer16, {TIM_CHANNEL_1, TimerPeripheral::PWM_MODE::NORMAL}}},
-    {{PB9, PB7}, {timer17, {TIM_CHANNEL_1, TimerPeripheral::PWM_MODE::PHASED}}},
-    {{PE11, PE10}, {timer1, {TIM_CHANNEL_2, TimerPeripheral::PWM_MODE::PHASED}}},
-    {{PE13, PE12}, {timer1, {TIM_CHANNEL_3, TimerPeripheral::PWM_MODE::PHASED}}},
-    {{PE5, PE4}, {timer15, {TIM_CHANNEL_1, TimerPeripheral::PWM_MODE::NORMAL}}},
-    {{PE9, PE8}, {timer1, {TIM_CHANNEL_1, TimerPeripheral::PWM_MODE::NORMAL}}},
-};
+std::unordered_map<std::pair<Pin, Pin>,
+                   std::pair<std::reference_wrapper<TimerPeripheral>,
+                             TimerPeripheral::PWMData>>
+    DualPWM::available_dual_pwms{
+        {{PB8, PB6},
+         {timer16, {TIM_CHANNEL_1, TimerPeripheral::PWM_MODE::NORMAL}}},
+        {{PB9, PB7},
+         {timer17, {TIM_CHANNEL_1, TimerPeripheral::PWM_MODE::PHASED}}},
+        {{PE11, PE10},
+         {timer1, {TIM_CHANNEL_2, TimerPeripheral::PWM_MODE::PHASED}}},
+        {{PE13, PE12},
+         {timer1, {TIM_CHANNEL_3, TimerPeripheral::PWM_MODE::PHASED}}},
+        {{PE5, PE4},
+         {timer15, {TIM_CHANNEL_1, TimerPeripheral::PWM_MODE::NORMAL}}},
+        {{PE9, PE8},
+         {timer1, {TIM_CHANNEL_1, TimerPeripheral::PWM_MODE::NORMAL}}},
+    };


### PR DESCRIPTION
Class used to Log info in simulator mode. You can log in five levels: DEBUG, INFO, WARNING, ERROR and FATAL.
 
To configure it, you must set in the extern variable config a mask 'oring' the bits that represents what you want.  You can configure which level of logs you want (DEBUG, INFO...), if you want to write logs on the console and/or on a file, and if you want to erase or not the log file.

To use it, you must use one of the five MACROS defined in the hpp file, each one representing the level of the log you want to print. This MACROS are:

- LOG_DEBUG
- LOG_INFO
- LOG_WARNING
- LOG_ERROR
- LOG_FATAL

Also when you call ErrorHandler and you are compiling for simulator, ErrorHandler calls LOG_FATAL by itself, so you don't have to do it