### PR TITLE
[FW-100] Fixed SPI

### DIFF
--- a/Inc/HALALMock/Services/Communication/SPI/SPI.hpp
+++ b/Inc/HALALMock/Services/Communication/SPI/SPI.hpp
@@ -42,7 +42,7 @@ class SPI {
         Pin* MOSI; /**< MOSI pin. */
         Pin* MISO; /**< MISO pin. */
         Pin* SS;   /**< Slave select pin. */
-        std::pair<char*, uint16_t> destination_address;
+        std::pair<const char*, uint16_t> destination_address;
         int socket;
         Pin* RS; /**< Ready Slave pin (optional)*/
         uint8_t RShandler;
@@ -77,18 +77,6 @@ class SPI {
         std::mutex transmission_mx;
         std::condition_variable cv_transmission;
 
-        std::jthread receiver_thread;
-        std::queue<span<uint8_t>> reception_queue;
-        std::mutex reception_mx;
-        std::condition_variable cv_reception;
-
-        std::jthread sender_receiver_thread;
-        std::queue<std::pair<span<uint8_t>, span<uint8_t>>>
-            transmission_reception_queue;
-        std::mutex transmission_reception_mx;
-        std::condition_variable cv_transmission_reception;
-
-        std::atomic<bool> selected = false;
         std::condition_variable cv_selected;
         std::mutex selected_mx;
 

--- a/Src/HALAL/HALAL.cpp
+++ b/Src/HALAL/HALAL.cpp
@@ -83,7 +83,6 @@ void HALAL::start(IPV4 ip, IPV4 subnet_mask, IPV4 gateway,
 #else
 // Simulator start
 void HALAL::start(IPV4 ip, IPV4 subnet_mask, IPV4 gateway, UART::Peripheral& printf_peripheral) {
-    SharedMemory::start();
     Ethernet::inscribe();
     Pin::start();
     ADC::start();


### PR DESCRIPTION
All these changes are what I need to do to make SPI works. Yes, I know there are a lot.

## Highlights
- Receiver and sender-receiver threads have been erased, as they weren't needed.
- Receive method is blocking until it is selected and has data to receive.
- Now master can select/deselect simulated slaves, and also slave can be selected by a simulated master (it doesn't work before)
- Several minor fixes.