### PR TITLE
Fix boundary to respect logical priorities

### DIFF
--- a/Inc/ST-LIB_HIGH/Protections/Boundary.hpp
+++ b/Inc/ST-LIB_HIGH/Protections/Boundary.hpp
@@ -260,7 +260,7 @@ struct Boundary<Type, OUT_OF_RANGE> : public BoundaryInterface{
 	Boundary(Type* src, Type lower_boundary, Type upper_boundary): src(src), lower_boundary(lower_boundary), upper_boundary(upper_boundary){}
 	Protections::FaultType check_bounds()override{
 		if(*src < lower_boundary || *src > upper_boundary) return Protections::FAULT;
-		if(has_warning_level && *src < lower_boundary || *src > upper_boundary){
+		if(has_warning_level && ((*src < lower_boundary) || (*src > upper_boundary))){
 				return Protections::WARNING;
 		}
 		return Protections::OK;


### PR DESCRIPTION
A check in protections wasn't respecting logical priorities, as C++ doesn't respect them by default, because `and` operation has the most priority. This results as a warning when compiling, preventing compilation with warnings as errors.