### PR TITLE
Add pin lock method to digital out

### DIFF
--- a/Inc/HALAL/Services/DigitalOutputService/DigitalOutputService.hpp
+++ b/Inc/HALAL/Services/DigitalOutputService/DigitalOutputService.hpp
@@ -17,5 +17,5 @@ class DigitalOutputService {
     static void turn_off(uint8_t id);
     static void set_pin_state(uint8_t id, PinState state);
     static void toggle(uint8_t id);
-    static void force_lock_pin_state(uint8_t id, PinState state);
+    static bool force_lock_pin_state(uint8_t id, PinState state);
 };

--- a/Inc/HALAL/Services/DigitalOutputService/DigitalOutputService.hpp
+++ b/Inc/HALAL/Services/DigitalOutputService/DigitalOutputService.hpp
@@ -7,14 +7,15 @@
 #pragma once
 #include "HALAL/Models/PinModel/Pin.hpp"
 
-class DigitalOutputService{
-public:
-	static map<uint8_t,Pin> service_ids;
-	static uint8_t id_counter;
+class DigitalOutputService {
+   public:
+    static map<uint8_t, Pin> service_ids;
+    static uint8_t id_counter;
 
-	static uint8_t inscribe(Pin& pin);
-	static void turn_on(uint8_t id);
-	static void turn_off(uint8_t id);
-	static void set_pin_state(uint8_t id, PinState state);
-	static void toggle(uint8_t id);
+    static uint8_t inscribe(Pin& pin);
+    static void turn_on(uint8_t id);
+    static void turn_off(uint8_t id);
+    static void set_pin_state(uint8_t id, PinState state);
+    static void toggle(uint8_t id);
+    static void force_lock_pin_state(uint8_t id, PinState state);
 };

--- a/Inc/HALAL/Services/DigitalOutputService/DigitalOutputService.hpp
+++ b/Inc/HALAL/Services/DigitalOutputService/DigitalOutputService.hpp
@@ -17,5 +17,5 @@ class DigitalOutputService {
     static void turn_off(uint8_t id);
     static void set_pin_state(uint8_t id, PinState state);
     static void toggle(uint8_t id);
-    static bool force_lock_pin_state(uint8_t id, PinState state);
+    static bool lock_pin_state(uint8_t id, PinState state);
 };

--- a/Inc/HALALMock/Services/DigitalOutputService/DigitalOutputService.hpp
+++ b/Inc/HALALMock/Services/DigitalOutputService/DigitalOutputService.hpp
@@ -19,5 +19,5 @@ class DigitalOutputService {
     static void turn_off(uint8_t id);
     static void set_pin_state(uint8_t id, PinState state);
     static void toggle(uint8_t id);
-    static void force_lock_pin_state(uint8_t id, PinState state);
+    static void lock_pin_state(uint8_t id, PinState state);
 };

--- a/Inc/HALALMock/Services/DigitalOutputService/DigitalOutputService.hpp
+++ b/Inc/HALALMock/Services/DigitalOutputService/DigitalOutputService.hpp
@@ -19,5 +19,5 @@ class DigitalOutputService {
     static void turn_off(uint8_t id);
     static void set_pin_state(uint8_t id, PinState state);
     static void toggle(uint8_t id);
-    static void lock_pin_state(uint8_t id, PinState state);
+    static bool lock_pin_state(uint8_t id, PinState state);
 };

--- a/Inc/HALALMock/Services/DigitalOutputService/DigitalOutputService.hpp
+++ b/Inc/HALALMock/Services/DigitalOutputService/DigitalOutputService.hpp
@@ -19,4 +19,5 @@ class DigitalOutputService {
     static void turn_off(uint8_t id);
     static void set_pin_state(uint8_t id, PinState state);
     static void toggle(uint8_t id);
+    static void force_lock_pin_state(uint8_t id, PinState state);
 };

--- a/Inc/ST-LIB_LOW/DigitalOutput/DigitalOutput.hpp
+++ b/Inc/ST-LIB_LOW/DigitalOutput/DigitalOutput.hpp
@@ -18,7 +18,7 @@ class DigitalOutput {
     void turn_off();
     void toggle();
     void set_pin_state(PinState state);
-    bool force_lock_state(PinState state);
+    bool force_lock_pin_state(PinState state);
 
    private:
     Pin pin;

--- a/Inc/ST-LIB_LOW/DigitalOutput/DigitalOutput.hpp
+++ b/Inc/ST-LIB_LOW/DigitalOutput/DigitalOutput.hpp
@@ -10,17 +10,17 @@
 #include "HALAL/HALAL.hpp"
 
 class DigitalOutput {
-public:
-	DigitalOutput() = default;
-	DigitalOutput(Pin& pin);
+   public:
+    DigitalOutput() = default;
+    DigitalOutput(Pin& pin);
 
-	void turn_on();
-	void turn_off();
-	void toggle();
-	void set_pin_state(PinState state);
-private:
-	Pin pin;
-	uint8_t id;
+    void turn_on();
+    void turn_off();
+    void toggle();
+    void set_pin_state(PinState state);
+    bool force_lock_state(PinState state);
+
+   private:
+    Pin pin;
+    uint8_t id;
 };
-
-

--- a/Inc/ST-LIB_LOW/DigitalOutput/DigitalOutput.hpp
+++ b/Inc/ST-LIB_LOW/DigitalOutput/DigitalOutput.hpp
@@ -18,7 +18,7 @@ class DigitalOutput {
     void turn_off();
     void toggle();
     void set_pin_state(PinState state);
-    bool force_lock_pin_state(PinState state);
+    bool lock_pin_state(PinState state);
 
    private:
     Pin pin;

--- a/Src/HALAL/Services/DigitalOutputService/DigitalOutputService.cpp
+++ b/Src/HALAL/Services/DigitalOutputService/DigitalOutputService.cpp
@@ -58,14 +58,14 @@ void DigitalOutputService::toggle(uint8_t id) {
     HAL_GPIO_TogglePin(pin.port, pin.gpio_pin);
 }
 
-bool DigitalOutputService::force_lock_state(uint8_t id, PinState state) {
+bool DigitalOutputService::force_lock_pin_state(uint8_t id, PinState state) {
     if (not DigitalOutputService::service_ids.contains(id)) {
         ErrorHandler("ID %d is not registered as a DigitalOutput", id);
-        return;
+        return false;
     }
 
     Pin pin = DigitalOutputService::service_ids[id];
-    HAL_StatusTypeDef locked =
-        HAL_GPIO_LockPin(pin.port, pin.gpio_pin, (GPIO_PinState)state);
+    HAL_GPIO_WritePin(pin.port, pin.gpio_pin, (GPIO_PinState)state);
+    HAL_StatusTypeDef locked = HAL_GPIO_LockPin(pin.port, pin.gpio_pin);
     return locked == HAL_OK;
 }

--- a/Src/HALAL/Services/DigitalOutputService/DigitalOutputService.cpp
+++ b/Src/HALAL/Services/DigitalOutputService/DigitalOutputService.cpp
@@ -6,53 +6,66 @@
  */
 
 #include "HALAL/Services/DigitalOutputService/DigitalOutputService.hpp"
+
 #include "ErrorHandler/ErrorHandler.hpp"
 
 uint8_t DigitalOutputService::id_counter = 0;
-map<uint8_t,Pin> DigitalOutputService::service_ids = {};
+map<uint8_t, Pin> DigitalOutputService::service_ids = {};
 
-uint8_t DigitalOutputService::inscribe(Pin& pin){
-        Pin::inscribe(pin, OUTPUT);
-		DigitalOutputService::service_ids[id_counter] = pin;
-		return id_counter++;
+uint8_t DigitalOutputService::inscribe(Pin& pin) {
+    Pin::inscribe(pin, OUTPUT);
+    DigitalOutputService::service_ids[id_counter] = pin;
+    return id_counter++;
 }
 
-void DigitalOutputService::turn_off(uint8_t id){
-	if (not DigitalOutputService::service_ids.contains(id)){
-		ErrorHandler("ID %d is not registered as a DigitalOutput",id);
-		return;
-	}
+void DigitalOutputService::turn_off(uint8_t id) {
+    if (not DigitalOutputService::service_ids.contains(id)) {
+        ErrorHandler("ID %d is not registered as a DigitalOutput", id);
+        return;
+    }
 
-	Pin pin = DigitalOutputService::service_ids[id];
-	HAL_GPIO_WritePin(pin.port, pin.gpio_pin, (GPIO_PinState)PinState::OFF);
+    Pin pin = DigitalOutputService::service_ids[id];
+    HAL_GPIO_WritePin(pin.port, pin.gpio_pin, (GPIO_PinState)PinState::OFF);
 }
 
-void DigitalOutputService::turn_on(uint8_t id){
-	if (not DigitalOutputService::service_ids.contains(id)){
-		ErrorHandler("ID %d is not registered as a DigitalOutput",id);
-		return;
-	}
+void DigitalOutputService::turn_on(uint8_t id) {
+    if (not DigitalOutputService::service_ids.contains(id)) {
+        ErrorHandler("ID %d is not registered as a DigitalOutput", id);
+        return;
+    }
 
-	Pin pin = DigitalOutputService::service_ids[id];
-	HAL_GPIO_WritePin(pin.port, pin.gpio_pin, (GPIO_PinState)PinState::ON);
+    Pin pin = DigitalOutputService::service_ids[id];
+    HAL_GPIO_WritePin(pin.port, pin.gpio_pin, (GPIO_PinState)PinState::ON);
 }
 
-void DigitalOutputService::set_pin_state(uint8_t id, PinState state){
-	if (not DigitalOutputService::service_ids.contains(id)){
-		ErrorHandler("ID %d is not registered as a DigitalOutput",id);
-		return;
-	}
+void DigitalOutputService::set_pin_state(uint8_t id, PinState state) {
+    if (not DigitalOutputService::service_ids.contains(id)) {
+        ErrorHandler("ID %d is not registered as a DigitalOutput", id);
+        return;
+    }
 
-	Pin pin = DigitalOutputService::service_ids[id];
-	HAL_GPIO_WritePin(pin.port, pin.gpio_pin, (GPIO_PinState) state);
+    Pin pin = DigitalOutputService::service_ids[id];
+    HAL_GPIO_WritePin(pin.port, pin.gpio_pin, (GPIO_PinState)state);
 }
 
-void DigitalOutputService::toggle(uint8_t id){
-	if (not DigitalOutputService::service_ids.contains(id)){
-		ErrorHandler("ID %d is not registered as a DigitalOutput",id);
-		return;
-	}
+void DigitalOutputService::toggle(uint8_t id) {
+    if (not DigitalOutputService::service_ids.contains(id)) {
+        ErrorHandler("ID %d is not registered as a DigitalOutput", id);
+        return;
+    }
 
-	Pin pin = DigitalOutputService::service_ids[id];
-	HAL_GPIO_TogglePin(pin.port, pin.gpio_pin);
+    Pin pin = DigitalOutputService::service_ids[id];
+    HAL_GPIO_TogglePin(pin.port, pin.gpio_pin);
+}
+
+bool DigitalOutputService::force_lock_state(uint8_t id, PinState state) {
+    if (not DigitalOutputService::service_ids.contains(id)) {
+        ErrorHandler("ID %d is not registered as a DigitalOutput", id);
+        return;
+    }
+
+    Pin pin = DigitalOutputService::service_ids[id];
+    HAL_StatusTypeDef locked =
+        HAL_GPIO_LockPin(pin.port, pin.gpio_pin, (GPIO_PinState)state);
+    return locked == HAL_OK;
 }

--- a/Src/HALAL/Services/DigitalOutputService/DigitalOutputService.cpp
+++ b/Src/HALAL/Services/DigitalOutputService/DigitalOutputService.cpp
@@ -58,7 +58,7 @@ void DigitalOutputService::toggle(uint8_t id) {
     HAL_GPIO_TogglePin(pin.port, pin.gpio_pin);
 }
 
-bool DigitalOutputService::force_lock_pin_state(uint8_t id, PinState state) {
+bool DigitalOutputService::lock_pin_state(uint8_t id, PinState state) {
     if (not DigitalOutputService::service_ids.contains(id)) {
         ErrorHandler("ID %d is not registered as a DigitalOutput", id);
         return false;

--- a/Src/HALALMock/Services/DigitalOutputService/DigitalOutputService.cpp
+++ b/Src/HALALMock/Services/DigitalOutputService/DigitalOutputService.cpp
@@ -72,4 +72,5 @@ void DigitalOutputService::toggle(uint8_t id) {
 
 bool DigitalOutputService::lock_pin_state(uint8_t id, PinState state) {
     set_pin_state(id, state);
+    return true;
 }

--- a/Src/HALALMock/Services/DigitalOutputService/DigitalOutputService.cpp
+++ b/Src/HALALMock/Services/DigitalOutputService/DigitalOutputService.cpp
@@ -12,11 +12,14 @@ map<uint8_t, Pin> DigitalOutputService::service_ids = {};
 
 uint8_t DigitalOutputService::inscribe(Pin& pin) {
     EmulatedPin& emulated_pin = SharedMemory::get_pin(pin);
-		if (emulated_pin.type != PinType::NOT_USED) {
-		ErrorHandler("Pin %s is not available for DigitalOutput usage, is already using as %s", pin.to_string().c_str(), emulated_pin.type);
-		return 0;
-		}
-	emulated_pin.type = PinType::DigitalOutput;
+    if (emulated_pin.type != PinType::NOT_USED) {
+        ErrorHandler(
+            "Pin %s is not available for DigitalOutput usage, is already using "
+            "as %s",
+            pin.to_string().c_str(), emulated_pin.type);
+        return 0;
+    }
+    emulated_pin.type = PinType::DigitalOutput;
     Pin::inscribe(pin, OUTPUT);
     DigitalOutputService::service_ids[id_counter] = pin;
     return id_counter++;
@@ -62,7 +65,11 @@ void DigitalOutputService::toggle(uint8_t id) {
 
     Pin pin = DigitalOutputService::service_ids[id];
     EmulatedPin& emulated_pin = SharedMemory::get_pin(pin);
-    emulated_pin.PinData.digital_output.state == PinState::ON ?
-           emulated_pin.PinData.digital_output.state = PinState::OFF : 
-           emulated_pin.PinData.digital_output.state = PinState::ON;
+    emulated_pin.PinData.digital_output.state == PinState::ON
+        ? emulated_pin.PinData.digital_output.state = PinState::OFF
+        : emulated_pin.PinData.digital_output.state = PinState::ON;
+}
+
+bool DigitalOutputService::force_lock_state(uint8_t id, PinState state) {
+    set_pin_state(id, state);
 }

--- a/Src/HALALMock/Services/DigitalOutputService/DigitalOutputService.cpp
+++ b/Src/HALALMock/Services/DigitalOutputService/DigitalOutputService.cpp
@@ -70,6 +70,6 @@ void DigitalOutputService::toggle(uint8_t id) {
         : emulated_pin.PinData.digital_output.state = PinState::ON;
 }
 
-bool DigitalOutputService::force_lock_pin_state(uint8_t id, PinState state) {
+bool DigitalOutputService::lock_pin_state(uint8_t id, PinState state) {
     set_pin_state(id, state);
 }

--- a/Src/HALALMock/Services/DigitalOutputService/DigitalOutputService.cpp
+++ b/Src/HALALMock/Services/DigitalOutputService/DigitalOutputService.cpp
@@ -70,6 +70,6 @@ void DigitalOutputService::toggle(uint8_t id) {
         : emulated_pin.PinData.digital_output.state = PinState::ON;
 }
 
-bool DigitalOutputService::force_lock_state(uint8_t id, PinState state) {
+bool DigitalOutputService::force_lock_pin_state(uint8_t id, PinState state) {
     set_pin_state(id, state);
 }

--- a/Src/ST-LIB_LOW/DigitalOutput/DigitalOutput.cpp
+++ b/Src/ST-LIB_LOW/DigitalOutput/DigitalOutput.cpp
@@ -20,6 +20,6 @@ void DigitalOutput::set_pin_state(PinState state) {
 
 void DigitalOutput::toggle() { DigitalOutputService::toggle(id); }
 
-bool DigitalOutput::force_lock_pin_state(PinState state) {
-    return DigitalOutputService::force_lock_pin_state(id, state);
+bool DigitalOutput::lock_pin_state(PinState state) {
+    return DigitalOutputService::lock_pin_state(id, state);
 }

--- a/Src/ST-LIB_LOW/DigitalOutput/DigitalOutput.cpp
+++ b/Src/ST-LIB_LOW/DigitalOutput/DigitalOutput.cpp
@@ -7,20 +7,19 @@
 
 #include "DigitalOutput/DigitalOutput.hpp"
 
-DigitalOutput::DigitalOutput(Pin& pin) : pin(pin), id(DigitalOutputService::inscribe(pin)) {}
+DigitalOutput::DigitalOutput(Pin& pin)
+    : pin(pin), id(DigitalOutputService::inscribe(pin)) {}
 
-void DigitalOutput::turn_on() {
-	DigitalOutputService::turn_on(id);
-}
+void DigitalOutput::turn_on() { DigitalOutputService::turn_on(id); }
 
-void DigitalOutput::turn_off() {
-	DigitalOutputService::turn_off(id);
-}
+void DigitalOutput::turn_off() { DigitalOutputService::turn_off(id); }
 
 void DigitalOutput::set_pin_state(PinState state) {
-	DigitalOutputService::set_pin_state(id, state);
+    DigitalOutputService::set_pin_state(id, state);
 }
 
-void DigitalOutput::toggle(){
-	DigitalOutputService::toggle(id);
+void DigitalOutput::toggle() { DigitalOutputService::toggle(id); }
+
+bool DigitalOutput::force_lock_state(PinState state) {
+    return DigitalOutputService::force_lock_state(id, state);
 }

--- a/Src/ST-LIB_LOW/DigitalOutput/DigitalOutput.cpp
+++ b/Src/ST-LIB_LOW/DigitalOutput/DigitalOutput.cpp
@@ -20,6 +20,6 @@ void DigitalOutput::set_pin_state(PinState state) {
 
 void DigitalOutput::toggle() { DigitalOutputService::toggle(id); }
 
-bool DigitalOutput::force_lock_state(PinState state) {
-    return DigitalOutputService::force_lock_state(id, state);
+bool DigitalOutput::force_lock_pin_state(PinState state) {
+    return DigitalOutputService::force_lock_pin_state(id, state);
 }


### PR DESCRIPTION
The HAL has a method that can lock a GPIO in a certain state until the board resets (using HAL_GPIO_LockPin). This could be useful for the contactors as an example, where once you enter fault you don't want to close them until you reset the board after fixing the fault cause. This is the same for the GD reset and enable, brakes, etc. All driven by a GPIO.

Also I took the chance to run the linter through the digital out code, the logic of this modification is minimal. The interesting methods are named force_lock_state