### PR TITLE
Added method to LinearSensor to set slope

### DIFF
--- a/Inc/ST-LIB_LOW/Sensors/LinearSensor/LinearSensor.hpp
+++ b/Inc/ST-LIB_LOW/Sensors/LinearSensor/LinearSensor.hpp
@@ -17,11 +17,16 @@ class LinearSensor {
     LinearSensor() = default;
     LinearSensor(Pin &pin, Type slope, Type offset, Type *value);
     LinearSensor(Pin &pin, Type slope, Type offset, Type &value);
+
     void read();
     uint8_t get_id();
+
     void set_offset(Type new_offset);
     Type get_offset();
+
+    void set_gain(Type new_gain);
     Type get_gain();
+
     Type *get_value_pointer() const;
 
    protected:
@@ -75,6 +80,12 @@ template <class Type>
     requires std::is_integral_v<Type> || std::is_floating_point_v<Type>
 void LinearSensor<Type>::set_offset(Type new_offset) {
     offset = new_offset;
+}
+
+template <class Type>
+    requires std::is_integral_v<Type> || std::is_floating_point_v<Type>
+void LinearSensor<Type>::set_gain(Type new_gain) {
+    slope = new_gain;
 }
 
 template <class Type>


### PR DESCRIPTION
A method has been added to LinearSensor class to be able to modify the slope/gain. 

The reason to include it has been to be able to characterize sensors in runtime.