### PR TITLE
Protections enhancements

### DIFF
--- a/Inc/ST-LIB_HIGH/Protections/Boundary.hpp
+++ b/Inc/ST-LIB_HIGH/Protections/Boundary.hpp
@@ -107,10 +107,10 @@ struct Boundary<Type, BELOW> : public BoundaryInterface{
 				warn_message = new HeapOrder(uint16_t{2000},&format_id,&boundary_type_id,&name,&this->warning_threshold,this->src,
 				&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
-				ok_message = new HeapOrder(uint16_t{3000},&format_id,&boundary_type_id,&name,&this->warning_threshold,this->src,
+			}
+			ok_message = new HeapOrder(uint16_t{3000},&format_id,&boundary_type_id,&name,&this->warning_threshold,this->src,
 				&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
-			}
 			fault_message = new HeapOrder(uint16_t{1000},&format_id,&boundary_type_id,&name,&this->boundary,this->src,
 				&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
@@ -156,10 +156,11 @@ struct Boundary<Type, ABOVE> : public BoundaryInterface{
 				warn_message = new HeapOrder(uint16_t{2111},&format_id,&boundary_type_id,&name,&this->warning_threshold,this->src,
 				&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
-				ok_message = new HeapOrder(uint16_t{3111},&format_id,&boundary_type_id,&name,&this->warning_threshold,this->src,
+				
+			}
+			ok_message = new HeapOrder(uint16_t{3111},&format_id,&boundary_type_id,&name,&this->warning_threshold,this->src,
 				&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
-			}
 			fault_message = new HeapOrder(uint16_t{1111},&format_id,&boundary_type_id,&name,&this->boundary,this->src,
 				&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
@@ -248,10 +249,11 @@ struct Boundary<Type, OUT_OF_RANGE> : public BoundaryInterface{
 			warn_message = new HeapOrder(uint16_t{2222},&format_id,&boundary_type_id,&name,&boundary.lower_boundary,&boundary.upper_boundary,this->src,
 			&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 			&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
-			ok_message = new HeapOrder(uint16_t{3222},&format_id,&boundary_type_id,&name,&boundary.lower_boundary,&boundary.upper_boundary,this->src,
+			
+		}
+		ok_message = new HeapOrder(uint16_t{3222},&format_id,&boundary_type_id,&name,&boundary.lower_boundary,&boundary.upper_boundary,this->src,
 			&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 			&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
-		}
 		fault_message = new HeapOrder(uint16_t{1222},&format_id,&boundary_type_id,&name,&this->lower_boundary,&this->upper_boundary,this->src,
 			&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 			&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);

--- a/Inc/ST-LIB_HIGH/Protections/Boundary.hpp
+++ b/Inc/ST-LIB_HIGH/Protections/Boundary.hpp
@@ -83,7 +83,8 @@ struct Boundary<Type, BELOW> : public BoundaryInterface{
 	Type* src = nullptr;
 	Type boundary;
 	Type warning_threshold;
-
+	//to get a snapshot of the value when the protection is triggered
+	Type frozen_value;
 	constexpr Boundary(const Type warn, const Type bound)
 	: has_warning_level{true}, boundary(bound), warning_threshold(warn){
 		// i havent been able to find a way to do a static_assertion.
@@ -104,19 +105,19 @@ struct Boundary<Type, BELOW> : public BoundaryInterface{
 			name.reserve(NAME_MAX_LEN);
 			if(this->has_warning_level){
 				warning_threshold = boundary.warning_threshold;
-				warn_message = new HeapOrder(uint16_t{2000},&format_id,&boundary_type_id,&name,&this->warning_threshold,this->src,
+				warn_message = new HeapOrder(uint16_t{2000},&format_id,&boundary_type_id,&name,&this->warning_threshold,&this->frozen_value,
 				&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
-				ok_message = new HeapOrder(uint16_t{3000},&format_id,&boundary_type_id,&name,&this->warning_threshold,this->src,
+				ok_message = new HeapOrder(uint16_t{3000},&format_id,&boundary_type_id,&name,&this->warning_threshold,&this->frozen_value,
 					&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 					&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
 			}else{
-				ok_message = new HeapOrder(uint16_t{3000},&format_id,&boundary_type_id,&name,&this->boundary,this->src,
+				ok_message = new HeapOrder(uint16_t{3000},&format_id,&boundary_type_id,&name,&this->boundary,&this->frozen_value,
 					&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 					&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
 			}
 
-			fault_message = new HeapOrder(uint16_t{1000},&format_id,&boundary_type_id,&name,&this->boundary,this->src,
+			fault_message = new HeapOrder(uint16_t{1000},&format_id,&boundary_type_id,&name,&this->boundary,&this->frozen_value,
 				&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
 			
@@ -125,7 +126,10 @@ struct Boundary<Type, BELOW> : public BoundaryInterface{
 
 	Boundary(Type* src, Type boundary): src(src),boundary(boundary){}
 	Protections::FaultType check_bounds()override{
-		if(*src < boundary) return Protections::FAULT;
+		frozen_value = *src;
+		if(*src < boundary){
+			return Protections::FAULT;
+		} 
 		if(has_warning_level && *src < warning_threshold){
 			return Protections::WARNING;
 		}
@@ -140,6 +144,7 @@ struct Boundary<Type, ABOVE> : public BoundaryInterface{
 	Type* src = nullptr;
 	Type boundary;
 	Type warning_threshold;
+	Type frozen_value;
 
 	Boundary(Type warning_threshold, Type boundary): has_warning_level{true}, boundary(boundary), warning_threshold(warning_threshold){
 		if(warning_threshold > boundary){
@@ -158,26 +163,27 @@ struct Boundary<Type, ABOVE> : public BoundaryInterface{
 			name.reserve(NAME_MAX_LEN);
 			if(this->has_warning_level){
 				warning_threshold = boundary.warning_threshold;
-				warn_message = new HeapOrder(uint16_t{2111},&format_id,&boundary_type_id,&name,&this->warning_threshold,this->src,
+				warn_message = new HeapOrder(uint16_t{2111},&format_id,&boundary_type_id,&name,&this->warning_threshold,&this->frozen_value,
 				&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
-				ok_message = new HeapOrder(uint16_t{3111},&format_id,&boundary_type_id,&name,&this->warning_threshold,this->src,
+				ok_message = new HeapOrder(uint16_t{3111},&format_id,&boundary_type_id,&name,&this->warning_threshold,&this->frozen_value,
 					&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 					&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
 				
 			}else{
-				ok_message = new HeapOrder(uint16_t{3111},&format_id,&boundary_type_id,&name,&this->boundary,this->src,
+				ok_message = new HeapOrder(uint16_t{3111},&format_id,&boundary_type_id,&name,&this->boundary,&this->frozen_value,
 					&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 					&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
 			}
 
-			fault_message = new HeapOrder(uint16_t{1111},&format_id,&boundary_type_id,&name,&this->boundary,this->src,
+			fault_message = new HeapOrder(uint16_t{1111},&format_id,&boundary_type_id,&name,&this->boundary,&this->frozen_value,
 				&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
 			
 		}
 	Boundary(Type* src, Type boundary): src(src),boundary(boundary){}
 	Protections::FaultType check_bounds()override{
+		frozen_value = *src;
 		if(*src > boundary) return Protections::FAULT;
 		if(has_warning_level && *src > warning_threshold){
 			 return Protections::WARNING;
@@ -191,7 +197,8 @@ struct Boundary<Type, EQUALS> : public BoundaryInterface{
 	static constexpr ProtectionType Protector = EQUALS;
 	Type* src = nullptr;
 	Type boundary;
-	
+	Type frozen_value;
+
 	Boundary(Type boundary): boundary(boundary){};
 	Boundary(Type* src, Boundary<Type, Protector> boundary): 
 		src(src),boundary(boundary.boundary)
@@ -199,7 +206,7 @@ struct Boundary<Type, EQUALS> : public BoundaryInterface{
 			boundary_type_id = Protector;	
 			format_id = BoundaryInterface::format_look_up.at(type_id<Type>);
 			name.reserve(NAME_MAX_LEN);
-			fault_message = new HeapOrder(uint16_t{1333},&format_id,&boundary_type_id,&name,&this->boundary,this->src,
+			fault_message = new HeapOrder(uint16_t{1333},&format_id,&boundary_type_id,&name,&this->boundary,&this->frozen_value,
 				&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
 		}
@@ -215,6 +222,9 @@ struct Boundary<Type, NOT_EQUALS> : public BoundaryInterface{
 	static constexpr ProtectionType Protector = NOT_EQUALS;
 	Type* src = nullptr;
 	Type boundary;
+	Type frozen_value;
+
+
 	Boundary(Type boundary): boundary(boundary){};
 	Boundary(Type* src, Boundary<Type, Protector> boundary): 
 		src(src),boundary(boundary.boundary)
@@ -222,12 +232,13 @@ struct Boundary<Type, NOT_EQUALS> : public BoundaryInterface{
 			boundary_type_id = Protector;
 			format_id = BoundaryInterface::format_look_up.at(type_id<Type>);
 			name.reserve(NAME_MAX_LEN);			
-			fault_message = new HeapOrder(uint16_t{1444},&format_id,&boundary_type_id,&name,&this->boundary,this->src,
+			fault_message = new HeapOrder(uint16_t{1444},&format_id,&boundary_type_id,&name,&this->boundary,&this->frozen_value,
 				&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
 		}
 	Boundary(Type* src, Type boundary): src(src),boundary(boundary){}
 	Protections::FaultType check_bounds()override{
+		frozen_value = *src;
 		if(*src != boundary) return Protections::FAULT;
 		return Protections::OK;
 	}
@@ -239,6 +250,9 @@ struct Boundary<Type, OUT_OF_RANGE> : public BoundaryInterface{
 	Type* src = nullptr;
 	Type lower_boundary, upper_boundary;
 	Type lower_warning, upper_warning;
+	Type frozen_value;
+
+
 	bool has_warning_level{false};
 	Boundary(Type lower_warning, Type upper_warning,Type lower_boundary, Type upper_boundary): lower_boundary(lower_boundary), upper_boundary(upper_boundary),
 	has_warning_level{true}, lower_warning(lower_warning), upper_warning(upper_warning){
@@ -256,26 +270,27 @@ struct Boundary<Type, OUT_OF_RANGE> : public BoundaryInterface{
 		if(boundary.has_warning_level){
 			lower_warning = boundary.lower_warning;
 			upper_warning = boundary.upper_warning;
-			warn_message = new HeapOrder(uint16_t{2222},&format_id,&boundary_type_id,&name,&boundary.lower_boundary,&boundary.upper_boundary,this->src,
+			warn_message = new HeapOrder(uint16_t{2222},&format_id,&boundary_type_id,&name,&boundary.lower_boundary,&boundary.upper_boundary,&this->frozen_value,
 			&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 			&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
-			ok_message = new HeapOrder(uint16_t{3222},&format_id,&boundary_type_id,&name,&boundary.lower_warning,&boundary.upper_warning,this->src,
+			ok_message = new HeapOrder(uint16_t{3222},&format_id,&boundary_type_id,&name,&boundary.lower_warning,&boundary.upper_warning,&this->frozen_value,
 				&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
 			
 		}else{
-			ok_message = new HeapOrder(uint16_t{3222},&format_id,&boundary_type_id,&name,&this->lower_boundary,&this->upper_boundary,this->src,
+			ok_message = new HeapOrder(uint16_t{3222},&format_id,&boundary_type_id,&name,&this->lower_boundary,&this->upper_boundary,&this->frozen_value,
 				&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
 		}
 		
-		fault_message = new HeapOrder(uint16_t{1222},&format_id,&boundary_type_id,&name,&this->lower_boundary,&this->upper_boundary,this->src,
+		fault_message = new HeapOrder(uint16_t{1222},&format_id,&boundary_type_id,&name,&this->lower_boundary,&this->upper_boundary,&this->frozen_value,
 			&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 			&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
 		
 	}
 	Boundary(Type* src, Type lower_boundary, Type upper_boundary): src(src), lower_boundary(lower_boundary), upper_boundary(upper_boundary){}
 	Protections::FaultType check_bounds()override{
+		frozen_value = *src;
 		if(*src < lower_boundary || *src > upper_boundary) return Protections::FAULT;
 		if(has_warning_level && ((*src < lower_boundary) || (*src > upper_boundary))){
 				return Protections::WARNING;
@@ -382,14 +397,14 @@ struct Boundary<Type, TIME_ACCUMULATION> : public BoundaryInterface {
 		name.reserve(NAME_MAX_LEN);
 		if(boundary.has_warning_level){
 			warning_threshold = boundary.warning_threshold;
-			warn_message = new HeapOrder(uint16_t{2666},&format_id,&boundary_type_id,&name,&this->warning_threshold,&this->bound,this->src,&this->time_limit,&this->frequency,
+			warn_message = new HeapOrder(uint16_t{2666},&format_id,&boundary_type_id,&name,&this->warning_threshold,&this->bound,&this->frozen_value,&this->time_limit,&this->frequency,
 			&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 			&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
-			ok_message = new HeapOrder(uint16_t{2666},&format_id,&boundary_type_id,&name,&this->warning_threshold,&this->bound,this->src,&this->time_limit,&this->frequency,
+			ok_message = new HeapOrder(uint16_t{3666},&format_id,&boundary_type_id,&name,&this->warning_threshold,&this->bound,&this->frozen_value,&this->time_limit,&this->frequency,
 			&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 			&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
 		}
-		fault_message = new HeapOrder(uint16_t{1666},&format_id,&boundary_type_id,&name,&this->bound,this->src,&this->time_limit,&this->frequency,
+		fault_message = new HeapOrder(uint16_t{1666},&format_id,&boundary_type_id,&name,&this->bound,&this->frozen_value,&this->time_limit,&this->frequency,
 			&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 			&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
 		

--- a/Inc/ST-LIB_HIGH/Protections/Boundary.hpp
+++ b/Inc/ST-LIB_HIGH/Protections/Boundary.hpp
@@ -264,7 +264,7 @@ struct Boundary<Type, OUT_OF_RANGE> : public BoundaryInterface{
 				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
 			
 		}else{
-			ok_message = new HeapOrder(uint16_t{3222},&format_id,&boundary_type_id,&name,&boundary.lower_boundary,&boundary.upper_boundary,this->src,
+			ok_message = new HeapOrder(uint16_t{3222},&format_id,&boundary_type_id,&name,&this->lower_boundary,&this->upper_boundary,this->src,
 				&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
 		}

--- a/Inc/ST-LIB_HIGH/Protections/Boundary.hpp
+++ b/Inc/ST-LIB_HIGH/Protections/Boundary.hpp
@@ -107,10 +107,15 @@ struct Boundary<Type, BELOW> : public BoundaryInterface{
 				warn_message = new HeapOrder(uint16_t{2000},&format_id,&boundary_type_id,&name,&this->warning_threshold,this->src,
 				&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
+				ok_message = new HeapOrder(uint16_t{3000},&format_id,&boundary_type_id,&name,&this->warning_threshold,this->src,
+					&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
+					&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
+			}else{
+				ok_message = new HeapOrder(uint16_t{3000},&format_id,&boundary_type_id,&name,&this->boundary,this->src,
+					&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
+					&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
 			}
-			ok_message = new HeapOrder(uint16_t{3000},&format_id,&boundary_type_id,&name,&this->warning_threshold,this->src,
-				&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
-				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
+
 			fault_message = new HeapOrder(uint16_t{1000},&format_id,&boundary_type_id,&name,&this->boundary,this->src,
 				&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
@@ -156,11 +161,16 @@ struct Boundary<Type, ABOVE> : public BoundaryInterface{
 				warn_message = new HeapOrder(uint16_t{2111},&format_id,&boundary_type_id,&name,&this->warning_threshold,this->src,
 				&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
+				ok_message = new HeapOrder(uint16_t{3111},&format_id,&boundary_type_id,&name,&this->warning_threshold,this->src,
+					&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
+					&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
 				
+			}else{
+				ok_message = new HeapOrder(uint16_t{3111},&format_id,&boundary_type_id,&name,&this->boundary,this->src,
+					&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
+					&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
 			}
-			ok_message = new HeapOrder(uint16_t{3111},&format_id,&boundary_type_id,&name,&this->warning_threshold,this->src,
-				&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
-				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
+
 			fault_message = new HeapOrder(uint16_t{1111},&format_id,&boundary_type_id,&name,&this->boundary,this->src,
 				&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
@@ -249,11 +259,16 @@ struct Boundary<Type, OUT_OF_RANGE> : public BoundaryInterface{
 			warn_message = new HeapOrder(uint16_t{2222},&format_id,&boundary_type_id,&name,&boundary.lower_boundary,&boundary.upper_boundary,this->src,
 			&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 			&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
+			ok_message = new HeapOrder(uint16_t{3222},&format_id,&boundary_type_id,&name,&boundary.lower_warning,&boundary.upper_warning,this->src,
+				&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
+				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
 			
+		}else{
+			ok_message = new HeapOrder(uint16_t{3222},&format_id,&boundary_type_id,&name,&boundary.lower_boundary,&boundary.upper_boundary,this->src,
+				&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
+				&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
 		}
-		ok_message = new HeapOrder(uint16_t{3222},&format_id,&boundary_type_id,&name,&boundary.lower_boundary,&boundary.upper_boundary,this->src,
-			&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
-			&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);
+		
 		fault_message = new HeapOrder(uint16_t{1222},&format_id,&boundary_type_id,&name,&this->lower_boundary,&this->upper_boundary,this->src,
 			&Global_RTC::global_RTC.counter,&Global_RTC::global_RTC.second,&Global_RTC::global_RTC.minute,
 			&Global_RTC::global_RTC.hour,&Global_RTC::global_RTC.day,&Global_RTC::global_RTC.month,&Global_RTC::global_RTC.year);

--- a/Inc/ST-LIB_HIGH/Protections/Protection.hpp
+++ b/Inc/ST-LIB_HIGH/Protections/Protection.hpp
@@ -14,7 +14,14 @@ private:
     static constexpr Protections::FaultType fault_type = Protections::FaultType::FAULT;
     uint8_t triggered_protecions_idx[4]{};
     uint8_t triggered_oks_idx[4]{};
+    uint64_t last_notify_tick{0};
 public:
+    const uint64_t get_last_notify_tick()const{
+        return last_notify_tick;
+    }
+    void update_last_notify_tick(uint64_t new_tick){
+        last_notify_tick = new_tick;
+    }
     vector<shared_ptr<BoundaryInterface>> warnings_triggered;
     vector<shared_ptr<BoundaryInterface>> oks_triggered;
     template<class Type, ProtectionType... Protector, template<class,ProtectionType> class Boundaries>

--- a/Inc/ST-LIB_HIGH/Protections/Protection.hpp
+++ b/Inc/ST-LIB_HIGH/Protections/Protection.hpp
@@ -51,6 +51,10 @@ public:
                     fault_protection = bound.get();
                     // adding the fault_protection to the vector is not desired,
                     // the fault signal should propagate as fast as possible
+                    if(bound->warning_already_triggered){}
+                    else{
+                        bound->warning_already_triggered = true;
+                    }
                     return Protections::FAULT;
                 case Protections::WARNING:
                     //warnings are non fatal, but we cannot waste time, we need to check if any

--- a/Inc/ST-LIB_HIGH/Protections/Protection.hpp
+++ b/Inc/ST-LIB_HIGH/Protections/Protection.hpp
@@ -45,6 +45,7 @@ public:
         for(shared_ptr<BoundaryInterface>& bound: boundaries){
             auto fault_type = bound->check_bounds();
             idx++;
+            fault_protection = nullptr;
             switch(fault_type){
                 // in case a Protection has more than one boundary, give priority to fault messages
                 case Protections::FAULT:

--- a/Src/ST-LIB_HIGH/Protections/ProtectionManager.cpp
+++ b/Src/ST-LIB_HIGH/Protections/ProtectionManager.cpp
@@ -115,13 +115,12 @@ void ProtectionManager::warn(string message) {
 }
 
 void ProtectionManager::notify(Protection& protection) {
-    if (protection.fault_protection->boundary_type_id == ERROR_HANDLER) {
-        protection.fault_protection->update_error_handler_message(
-            protection.fault_protection->get_error_handler_string());
-    }
     for (OrderProtocol* socket : OrderProtocol::sockets) {
         if (protection.fault_protection) {
-
+            if (protection.fault_protection->boundary_type_id == ERROR_HANDLER) {
+                    protection.fault_protection->update_error_handler_message(
+                        protection.fault_protection->get_error_handler_string());
+                }
                 socket->send_order(*protection.fault_protection->fault_message);
                 ErrorHandlerModel::error_to_communicate = false;
         }

--- a/Src/ST-LIB_HIGH/Protections/ProtectionManager.cpp
+++ b/Src/ST-LIB_HIGH/Protections/ProtectionManager.cpp
@@ -83,9 +83,9 @@ void ProtectionManager::check_protections() {
             ProtectionManager::to_fault();
         }
         Global_RTC::update_rtc_data();
-        if(Time::get_global_tick() > last_notify + notify_delay_in_nanoseconds) {
+        if(Time::get_global_tick() > protection.get_last_notify_tick() + notify_delay_in_nanoseconds) {
             ProtectionManager::notify(protection);
-            last_notify = Time::get_global_tick();
+            protection.update_last_notify_tick(Time::get_global_tick());
         }
     }
 }
@@ -143,10 +143,6 @@ void ProtectionManager::notify(Protection& protection) {
 }
 
 void ProtectionManager::propagate_fault() {
-    if (!test_fault) {
-        ErrorHandler("Fail on Board with ID:", NULL,
-                     ProtectionManager::board_id);
-    }
     for (OrderProtocol* socket : OrderProtocol::sockets) {
         socket->send_order(ProtectionManager::fault_order);
     }
@@ -155,7 +151,6 @@ void ProtectionManager::propagate_fault() {
 Boards::ID ProtectionManager::board_id = Boards::ID::NOBOARD;
 size_t ProtectionManager::message_size = 0;
 char* ProtectionManager::message = nullptr;
-bool ProtectionManager::test_fault = false;
 ProtectionManager::state_id ProtectionManager::fault_state_id = 255;
 vector<Protection> ProtectionManager::low_frequency_protections = {};
 vector<Protection> ProtectionManager::high_frequency_protections = {};

--- a/Src/ST-LIB_HIGH/Protections/ProtectionManager.cpp
+++ b/Src/ST-LIB_HIGH/Protections/ProtectionManager.cpp
@@ -103,12 +103,10 @@ void ProtectionManager::check_high_frequency_protections() {
             ProtectionManager::to_fault();
         }   
         Global_RTC::update_rtc_data();
-        if (Time::get_global_tick() > last_notify + notify_delay_in_nanoseconds) {
+        if(Time::get_global_tick() > protection.get_last_notify_tick() + notify_delay_in_nanoseconds) {
             ProtectionManager::notify(protection);
-            last_notify = Time::get_global_tick();
+            protection.update_last_notify_tick(Time::get_global_tick());
         }
-   
-        ProtectionManager::notify(protection);
     }
 }
 


### PR DESCRIPTION
Sorry for the incredible amount of duplicated code, runtime polymorphism and some other abnormalities.

I basically added a frozen value so that that value is sent when the message is issued, this way we ensure integrity with the value that triggered the protection, this is achieved my storing a copy of the value pointed by the pointer.


I also fixed some discrepancies between the high frequency and low frequency protections checks.

I also added individual time tracking for the notification of ProtectionMessages, as otherwise only one would be sent.

I removed some code with test_fault that in the past seemed to indicate whether the Fault was coming from TCP or the board itself, because the naming wasn't clear and the Backend was doing weird stuff with Transport module and connections being closed I completely removed that part. This feature might be interesing to bring back in the future, but with more time and though put into it.

Added new functionality regarding values coming back to normal values, even while the board stays in a Fault state if the variable gets back to a normal state that should be shown in the GUI, as it is no longer dangerous.

This idea was only implemented when Warnings were used, now it is also working with only Fault and OK. I attach some screenshots showing the messages on the GUI.

![image](https://github.com/user-attachments/assets/4eaa7da9-670d-4431-84b9-cdbbefa60b71)
I haven't tested the Warning parts. But it works for FAULTs and OKs
```c++
#define TESTING_WARNINGS 0
int current_2 = 0;

int main(void) {
#ifdef SIM_ON
    SharedMemory::start();
#endif
        int current = 0;
    #if TESTING_WARNINGS
        add_protection(&current,Boundary<int,ABOVE>(5,10));
        add_protection(&current,Boundary<int,BELOW>(-5,-10));
        add_protection(&current,Boundary<int,OUT_OF_RANGE>(-20,-15,15,20));
    #else
        add_protection(&current,Boundary<int,OUT_OF_RANGE>(-20,20));
        add_protection(&current_2,Boundary<int,ABOVE>(10));
        add_protection(&current,Boundary<int,BELOW>(-10));
    #endif
    ProtectionManager::initialize();

    STLIB::start();
    ServerSocket control_station{"192.168.1.4",50500};
    Time::register_low_precision_alarm(1000,[&current](){
        current++;
        current_2++;
        if(current > 30 || current_2 > 30)
        {
            current = -25;
            current_2 = 5;
        }
    });
    StateMachine sm{1};
    sm.add_state(0);
    ProtectionManager::link_state_machine(sm,0);


    while (1) {
        STLIB::update();
        ProtectionManager::check_protections();
    }
}
```


For reference I attach the code that I have used to test, 
template_project branch: main
STLIB: branched from latest development