### PR TITLE
Fixed bad-ordered params in PWMSensor

### DIFF
--- a/Inc/ST-LIB_LOW/Sensors/PWMSensor/PWMSensor.hpp
+++ b/Inc/ST-LIB_LOW/Sensors/PWMSensor/PWMSensor.hpp
@@ -33,7 +33,7 @@ PWMSensor<Type>::PWMSensor(Pin &pin, Type &frequency, Type &duty_cycle)
 
 template <class Type>
 PWMSensor<Type>::PWMSensor(Pin &pin, Type *frequency, Type *duty_cycle)
-    : duty_cycle(duty_cycle), frequency(frequency) {
+    : frequency(frequency), duty_cycle(duty_cycle) {
     id = InputCapture::inscribe(pin);
     Sensor::inputcapture_id_list.push_back(id);
 }

--- a/Inc/ST-LIB_LOW/Sensors/PWMSensor/PWMSensor.hpp
+++ b/Inc/ST-LIB_LOW/Sensors/PWMSensor/PWMSensor.hpp
@@ -9,43 +9,41 @@
 #pragma once
 #include "ErrorHandler/ErrorHandler.hpp"
 #include "HALAL/HALAL.hpp"
-template<class Type>
+template <class Type>
 class PWMSensor {
-protected:
-	uint8_t id;
-	Type *frequency;
-	Type *duty_cycle;
-	
+   protected:
+    uint8_t id;
+    Type *frequency;
+    Type *duty_cycle;
 
-public:
-	PWMSensor() = default;
-	PWMSensor(Pin &pin, Type &frequency, Type &duty_cycle);
-	PWMSensor(Pin &pin, Type *frequency, Type *duty_cycle);
-	void read();
-	uint8_t get_id();
+   public:
+    PWMSensor() = default;
+    PWMSensor(Pin &pin, Type &frequency, Type &duty_cycle);
+    PWMSensor(Pin &pin, Type *frequency, Type *duty_cycle);
+    void read();
+    uint8_t get_id();
 };
 
-template<class Type>
-PWMSensor<Type>::PWMSensor(Pin &pin, Type &frequency, Type &duty_cycle) :
-	duty_cycle(&duty_cycle), frequency(&frequency)  {
-		id = InputCapture::inscribe(pin);
-		Sensor::inputcapture_id_list.push_back(id);
+template <class Type>
+PWMSensor<Type>::PWMSensor(Pin &pin, Type &frequency, Type &duty_cycle)
+    : frequency(&frequency), duty_cycle(&duty_cycle) {
+    id = InputCapture::inscribe(pin);
+    Sensor::inputcapture_id_list.push_back(id);
 }
 
-template<class Type>
-PWMSensor<Type>::PWMSensor(Pin &pin, Type *frequency, Type *duty_cycle) :
-	duty_cycle(duty_cycle), frequency(frequency) {
-		id = InputCapture::inscribe(pin);
-		Sensor::inputcapture_id_list.push_back(id);
+template <class Type>
+PWMSensor<Type>::PWMSensor(Pin &pin, Type *frequency, Type *duty_cycle)
+    : duty_cycle(duty_cycle), frequency(frequency) {
+    id = InputCapture::inscribe(pin);
+    Sensor::inputcapture_id_list.push_back(id);
 }
 
-template<class Type>
+template <class Type>
 void PWMSensor<Type>::read() {
-	*duty_cycle = InputCapture::read_duty_cycle(id);
-	*frequency = InputCapture::read_frequency(id);
+    *duty_cycle = InputCapture::read_duty_cycle(id);
+    *frequency = InputCapture::read_frequency(id);
 }
-template<class Type>
+template <class Type>
 uint8_t PWMSensor<Type>::get_id() {
-	return id;
+    return id;
 }
-


### PR DESCRIPTION
PWMSensor has a problem in constructor due to bad order. It has been fixed. Y also applied the formatter.