### PR TITLE
Fixed EXTI

### DIFF
--- a/Inc/HALAL/Models/PinModel/Pin.hpp
+++ b/Inc/HALAL/Models/PinModel/Pin.hpp
@@ -7,121 +7,115 @@
 #pragma once
 #include "C++Utilities/CppUtils.hpp"
 
-
 #define PERIPHERAL_BASE 0x40000000UL
-#define DOMAIN3_ADVANCED_HIGH_PERFORMANCE_BUS1 PERIPHERAL_BASE+0x18020000UL
+#define DOMAIN3_ADVANCED_HIGH_PERFORMANCE_BUS1 PERIPHERAL_BASE + 0x18020000UL
 
-enum GPIOPin : uint16_t{
-	PIN_0 = 0x0001,
-	PIN_1 = 0x0002,
-	PIN_2 = 0x0004,
-	PIN_3 = 0x0008,
-	PIN_4 = 0x0010,
-	PIN_5 = 0x0020,
-	PIN_6 = 0x0040,
-	PIN_7 = 0x0080,
-	PIN_8 = 0x0100,
-	PIN_9 = 0x0200,
-	PIN_10 = 0x0400,
-	PIN_11 = 0x0800,
-	PIN_12 = 0x1000,
-	PIN_13 = 0x2000,
-	PIN_14 = 0x4000,
-	PIN_15 = 0x8000,
-	PIN_ALL = 0xFFFF
+enum GPIOPin : uint16_t {
+    PIN_0 = 0x0001,
+    PIN_1 = 0x0002,
+    PIN_2 = 0x0004,
+    PIN_3 = 0x0008,
+    PIN_4 = 0x0010,
+    PIN_5 = 0x0020,
+    PIN_6 = 0x0040,
+    PIN_7 = 0x0080,
+    PIN_8 = 0x0100,
+    PIN_9 = 0x0200,
+    PIN_10 = 0x0400,
+    PIN_11 = 0x0800,
+    PIN_12 = 0x1000,
+    PIN_13 = 0x2000,
+    PIN_14 = 0x4000,
+    PIN_15 = 0x8000,
+    PIN_ALL = 0xFFFF
 };
 
 enum GPIOPort : uint32_t {
-	PORT_A = DOMAIN3_ADVANCED_HIGH_PERFORMANCE_BUS1 + 0x0000UL,
-	PORT_B = DOMAIN3_ADVANCED_HIGH_PERFORMANCE_BUS1 + 0x0400UL,
-	PORT_C = DOMAIN3_ADVANCED_HIGH_PERFORMANCE_BUS1 + 0x0800UL,
-	PORT_D = DOMAIN3_ADVANCED_HIGH_PERFORMANCE_BUS1 + 0x0C00UL,
-	PORT_E = DOMAIN3_ADVANCED_HIGH_PERFORMANCE_BUS1 + 0x1000UL,
-	PORT_F = DOMAIN3_ADVANCED_HIGH_PERFORMANCE_BUS1 + 0x1400UL,
-	PORT_G = DOMAIN3_ADVANCED_HIGH_PERFORMANCE_BUS1 + 0x1800UL,
-	PORT_H = DOMAIN3_ADVANCED_HIGH_PERFORMANCE_BUS1 + 0x1C00UL,
+    PORT_A = DOMAIN3_ADVANCED_HIGH_PERFORMANCE_BUS1 + 0x0000UL,
+    PORT_B = DOMAIN3_ADVANCED_HIGH_PERFORMANCE_BUS1 + 0x0400UL,
+    PORT_C = DOMAIN3_ADVANCED_HIGH_PERFORMANCE_BUS1 + 0x0800UL,
+    PORT_D = DOMAIN3_ADVANCED_HIGH_PERFORMANCE_BUS1 + 0x0C00UL,
+    PORT_E = DOMAIN3_ADVANCED_HIGH_PERFORMANCE_BUS1 + 0x1000UL,
+    PORT_F = DOMAIN3_ADVANCED_HIGH_PERFORMANCE_BUS1 + 0x1400UL,
+    PORT_G = DOMAIN3_ADVANCED_HIGH_PERFORMANCE_BUS1 + 0x1800UL,
+    PORT_H = DOMAIN3_ADVANCED_HIGH_PERFORMANCE_BUS1 + 0x1C00UL,
 };
 
-enum AlternativeFunction: uint8_t {
-	AF0 = 0x00,
-	AF1 = 0x01,
-	AF2 = 0x02,
-	AF3 = 0x03,
-	AF4 = 0x04,
-	AF5 = 0x05,
-	AF6 = 0x06,
-	AF7 = 0x07,
-	AF8 = 0x08,
-	AF9 = 0x09,
-	AF10 = 0x0A,
-	AF11 = 0x0B,
-	AF12 = 0x0C,
-	AF13 = 0x0D,
-	AF14 = 0x0E,
-	AF15 = 0x0F,
+enum AlternativeFunction : uint8_t {
+    AF0 = 0x00,
+    AF1 = 0x01,
+    AF2 = 0x02,
+    AF3 = 0x03,
+    AF4 = 0x04,
+    AF5 = 0x05,
+    AF6 = 0x06,
+    AF7 = 0x07,
+    AF8 = 0x08,
+    AF9 = 0x09,
+    AF10 = 0x0A,
+    AF11 = 0x0B,
+    AF12 = 0x0C,
+    AF13 = 0x0D,
+    AF14 = 0x0E,
+    AF15 = 0x0F,
 };
 
-enum OperationMode{
-	NOT_USED,
-	INPUT,
-	OUTPUT,
-	ANALOG,
-	EXTERNAL_INTERRUPT_RISING,
-	EXTERNAL_INTERRUPT_FALLING,
-	TIMER_ALTERNATE_FUNCTION,
-	ALTERNATIVE,
+enum OperationMode {
+    NOT_USED,
+    INPUT,
+    OUTPUT,
+    ANALOG,
+    EXTERNAL_INTERRUPT_RISING,
+    EXTERNAL_INTERRUPT_FALLING,
+    EXTERNAL_INTERRUPT_RISING_FALLING,
+    TIMER_ALTERNATE_FUNCTION,
+    ALTERNATIVE,
 };
 
-enum PinState: uint8_t{
-	OFF,
-	ON
-};
+enum PinState : uint8_t { OFF, ON };
 
-enum TRIGGER: uint8_t{
-    RISING_EDGE = 1,
-    FAILING_EDGE = 0,
-    BOTH_EDGES = 2
-};
+enum TRIGGER : uint8_t { RISING_EDGE = 1, FAILING_EDGE = 0, BOTH_EDGES = 2 };
 
 class Pin {
-public:
-	GPIO_TypeDef * port;
-	GPIOPin gpio_pin;
-	AlternativeFunction alternative_function;
-	OperationMode mode = OperationMode::NOT_USED;
-	static const vector<reference_wrapper<Pin>> pinVector;
-	static const map<GPIO_TypeDef*,const string> port_to_string;
-	static const map<GPIOPin,const string> gpio_pin_to_string;
-	Pin();
-	Pin(GPIOPort port, GPIOPin pin);
-	Pin(GPIOPort port, GPIOPin pin, AlternativeFunction alternative_function);
-	const string to_string() const;
-	static void inscribe(Pin& pin, OperationMode mode);
-	static void start();
+   public:
+    GPIO_TypeDef* port;
+    GPIOPin gpio_pin;
+    AlternativeFunction alternative_function;
+    OperationMode mode = OperationMode::NOT_USED;
+    static const vector<reference_wrapper<Pin>> pinVector;
+    static const map<GPIO_TypeDef*, const string> port_to_string;
+    static const map<GPIOPin, const string> gpio_pin_to_string;
+    Pin();
+    Pin(GPIOPort port, GPIOPin pin);
+    Pin(GPIOPort port, GPIOPin pin, AlternativeFunction alternative_function);
+    const string to_string() const;
+    static void inscribe(Pin& pin, OperationMode mode);
+    static void start();
 
-	bool operator== (const Pin &other) const {
-		return (gpio_pin == other.gpio_pin && port == other.port);
-	}
+    bool operator==(const Pin& other) const {
+        return (gpio_pin == other.gpio_pin && port == other.port);
+    }
 
-	bool operator< (const Pin &other) const {
-		if (port == other.port)
-			return gpio_pin < other.gpio_pin;
-		return port < other.port;
-	}
+    bool operator<(const Pin& other) const {
+        if (port == other.port) return gpio_pin < other.gpio_pin;
+        return port < other.port;
+    }
 };
 
 namespace std {
-	template <>
-	struct hash<Pin> {
-		std::size_t operator()(const Pin& k) const {
-		    using std::size_t;
-		    using std::hash;
-		    using std::string;
+template <>
+struct hash<Pin> {
+    std::size_t operator()(const Pin& k) const {
+        using std::hash;
+        using std::size_t;
+        using std::string;
 
-		    return ((hash<uint16_t>()(k.gpio_pin) ^ (hash<uint32_t>()((uint32_t)(k.port)) << 1)) >> 1);
-		}
-	  };
-}
+        return ((hash<uint16_t>()(k.gpio_pin) ^
+                 (hash<uint32_t>()((uint32_t)(k.port)) << 1)) >>
+                1);
+    }
+};
+}  // namespace std
 
 extern Pin PA0;
 extern Pin PA1;

--- a/Inc/HALAL/Services/EXTI/EXTI.hpp
+++ b/Inc/HALAL/Services/EXTI/EXTI.hpp
@@ -9,7 +9,6 @@
 #include "HALAL/Models/PinModel/Pin.hpp"
 
 #ifdef HAL_EXTI_MODULE_ENABLED
-#define GPIO_PORT GPIOE
 
 class ExternalInterrupt {
 public:

--- a/Src/HALAL/Models/PinModel/Pin.cpp
+++ b/Src/HALAL/Models/PinModel/Pin.cpp
@@ -6,100 +6,120 @@
  */
 
 #include "HALAL/Models/PinModel/Pin.hpp"
+
 #include "ErrorHandler/ErrorHandler.hpp"
 
-Pin::Pin(){}
+Pin::Pin() {}
 
-Pin::Pin(GPIOPort port, GPIOPin gpio_pin) : port((GPIO_TypeDef*)port), gpio_pin(gpio_pin){}
+Pin::Pin(GPIOPort port, GPIOPin gpio_pin)
+    : port((GPIO_TypeDef*)port), gpio_pin(gpio_pin) {}
 
-Pin::Pin(GPIOPort port, GPIOPin gpio_pin, AlternativeFunction alternative_function) :
-		port((GPIO_TypeDef*)port),
-		gpio_pin(gpio_pin),
-		alternative_function(alternative_function)
-		{}
+Pin::Pin(GPIOPort port, GPIOPin gpio_pin,
+         AlternativeFunction alternative_function)
+    : port((GPIO_TypeDef*)port),
+      gpio_pin(gpio_pin),
+      alternative_function(alternative_function) {}
 
-const vector<reference_wrapper<Pin>> Pin::pinVector = {PA0,PA1,PA10,PA11,PA12,
-PA9,PB0,PB1,PB10,PB11,PB12,PB13,PB14,PB15,PB2,PB4,PB5,PB6,PB7,PB8,PB9,PC0,PC1,PC10,
-PC11,PC12,PC13,PC14,PC15,PC2,PC3,PC4,PC5,PC6,PC7,PC8,PC9,PD0,PD1,PD10,PD11,PD12,PD13,
-PD14,PD15,PD2,PD3,PD4,PD5,PD6,PD7,PD8,PD9,PE0,PE1,PE10,PE11,PE12,PE13,PE14,PE15,PE2,PE3,
-PE4,PE5,PE6,PE7,PE8,PE9,PF0,PF1,PF10,PF11,PF12,PF13,PF14,PF15,PF2,PF3,PF4,PF5,PF6,PF7,
-PF8,PF9,PG0,PG1,PG10,PG11,PG12,PG13,PG14,PG15,PG2,PG3,PG4,PG5,PG6,PG7,PG8,PG9,PH0,PH1,
-PA2,PA3,PA4,PA5,PA6,PA7,PA8};
+const vector<reference_wrapper<Pin>> Pin::pinVector = {
+    PA0,  PA1,  PA10, PA11, PA12, PA9,  PB0,  PB1,  PB10, PB11, PB12,
+    PB13, PB14, PB15, PB2,  PB4,  PB5,  PB6,  PB7,  PB8,  PB9,  PC0,
+    PC1,  PC10, PC11, PC12, PC13, PC14, PC15, PC2,  PC3,  PC4,  PC5,
+    PC6,  PC7,  PC8,  PC9,  PD0,  PD1,  PD10, PD11, PD12, PD13, PD14,
+    PD15, PD2,  PD3,  PD4,  PD5,  PD6,  PD7,  PD8,  PD9,  PE0,  PE1,
+    PE10, PE11, PE12, PE13, PE14, PE15, PE2,  PE3,  PE4,  PE5,  PE6,
+    PE7,  PE8,  PE9,  PF0,  PF1,  PF10, PF11, PF12, PF13, PF14, PF15,
+    PF2,  PF3,  PF4,  PF5,  PF6,  PF7,  PF8,  PF9,  PG0,  PG1,  PG10,
+    PG11, PG12, PG13, PG14, PG15, PG2,  PG3,  PG4,  PG5,  PG6,  PG7,
+    PG8,  PG9,  PH0,  PH1,  PA2,  PA3,  PA4,  PA5,  PA6,  PA7,  PA8};
 
-const map<GPIOPin,const string> Pin::gpio_pin_to_string = {{PIN_0,"0"}, {PIN_1,"1"}, {PIN_2,"2"}, {PIN_3,"3"}, {PIN_4,"4"}, {PIN_5,"5"}, {PIN_6,"6"}, {PIN_7,"7"}, {PIN_8,"8"}, {PIN_9,"9"}, {PIN_10,"10"}, {PIN_11,"11"}, {PIN_12,"12"}, {PIN_13,"13"}, {PIN_14,"14"}, {PIN_15,"15"},{PIN_ALL,"ALL"}};
-const map<GPIO_TypeDef*,const string> Pin::port_to_string = {{(GPIO_TypeDef*)PORT_A,"PA"}, {(GPIO_TypeDef*)PORT_B,"PB"}, {(GPIO_TypeDef*)PORT_C,"PC"}, {(GPIO_TypeDef*)PORT_D,"PD"}, {(GPIO_TypeDef*)PORT_E,"PE"}, {(GPIO_TypeDef*)PORT_F,"PF"}, {(GPIO_TypeDef*)PORT_G,"PG"}, {(GPIO_TypeDef*)PORT_H,"PH"}};
+const map<GPIOPin, const string> Pin::gpio_pin_to_string = {
+    {PIN_0, "0"},    {PIN_1, "1"},   {PIN_2, "2"},   {PIN_3, "3"},
+    {PIN_4, "4"},    {PIN_5, "5"},   {PIN_6, "6"},   {PIN_7, "7"},
+    {PIN_8, "8"},    {PIN_9, "9"},   {PIN_10, "10"}, {PIN_11, "11"},
+    {PIN_12, "12"},  {PIN_13, "13"}, {PIN_14, "14"}, {PIN_15, "15"},
+    {PIN_ALL, "ALL"}};
+const map<GPIO_TypeDef*, const string> Pin::port_to_string = {
+    {(GPIO_TypeDef*)PORT_A, "PA"}, {(GPIO_TypeDef*)PORT_B, "PB"},
+    {(GPIO_TypeDef*)PORT_C, "PC"}, {(GPIO_TypeDef*)PORT_D, "PD"},
+    {(GPIO_TypeDef*)PORT_E, "PE"}, {(GPIO_TypeDef*)PORT_F, "PF"},
+    {(GPIO_TypeDef*)PORT_G, "PG"}, {(GPIO_TypeDef*)PORT_H, "PH"}};
 
 const string Pin::to_string() const {
-	return (port_to_string.at(port) + gpio_pin_to_string.at(gpio_pin));
+    return (port_to_string.at(port) + gpio_pin_to_string.at(gpio_pin));
 }
 
-void Pin::inscribe(Pin& pin, OperationMode mode){
-	if(pin.mode != OperationMode::NOT_USED){
-		ErrorHandler("Pin %s is already registered, cannot register twice", pin.to_string().c_str());
-		return;
-	}
-	pin.mode = mode;
+void Pin::inscribe(Pin& pin, OperationMode mode) {
+    if (pin.mode != OperationMode::NOT_USED) {
+        ErrorHandler("Pin %s is already registered, cannot register twice",
+                     pin.to_string().c_str());
+        return;
+    }
+    pin.mode = mode;
 }
 
-void Pin::start(){
-	GPIO_InitTypeDef GPIO_InitStruct;
-	__HAL_RCC_GPIOB_CLK_ENABLE();
-	__HAL_RCC_GPIOA_CLK_ENABLE();
-	__HAL_RCC_GPIOC_CLK_ENABLE();
-	__HAL_RCC_GPIOD_CLK_ENABLE();
-	__HAL_RCC_GPIOE_CLK_ENABLE();
-	__HAL_RCC_GPIOF_CLK_ENABLE();
-	__HAL_RCC_GPIOG_CLK_ENABLE();
+void Pin::start() {
+    GPIO_InitTypeDef GPIO_InitStruct;
+    __HAL_RCC_GPIOB_CLK_ENABLE();
+    __HAL_RCC_GPIOA_CLK_ENABLE();
+    __HAL_RCC_GPIOC_CLK_ENABLE();
+    __HAL_RCC_GPIOD_CLK_ENABLE();
+    __HAL_RCC_GPIOE_CLK_ENABLE();
+    __HAL_RCC_GPIOF_CLK_ENABLE();
+    __HAL_RCC_GPIOG_CLK_ENABLE();
 
-	for(Pin& pin : Pin::pinVector){
-		GPIO_InitStruct = {0};
-		GPIO_InitStruct.Pin = pin.gpio_pin;
-		switch(pin.mode){
+    for (Pin& pin : Pin::pinVector) {
+        GPIO_InitStruct = {0};
+        GPIO_InitStruct.Pin = pin.gpio_pin;
+        switch (pin.mode) {
+            case OperationMode::NOT_USED:
+                GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
+                GPIO_InitStruct.Pull = GPIO_PULLDOWN;
+                HAL_GPIO_Init(pin.port, &GPIO_InitStruct);
+                break;
 
-		case OperationMode::NOT_USED:
-			GPIO_InitStruct.Mode =  GPIO_MODE_INPUT;
-			GPIO_InitStruct.Pull = GPIO_PULLDOWN;
-			HAL_GPIO_Init(pin.port, &GPIO_InitStruct);
-			break;
+            case OperationMode::OUTPUT:
+                GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+                GPIO_InitStruct.Pull = GPIO_NOPULL;
+                GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+                HAL_GPIO_Init(pin.port, &GPIO_InitStruct);
+                break;
 
-		case OperationMode::OUTPUT:
-			GPIO_InitStruct.Mode =  GPIO_MODE_OUTPUT_PP;
-			GPIO_InitStruct.Pull = GPIO_NOPULL;
-			GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-			HAL_GPIO_Init(pin.port, &GPIO_InitStruct);
-			break;
+            case OperationMode::INPUT:
+                GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
+                GPIO_InitStruct.Pull = GPIO_NOPULL;
+                HAL_GPIO_Init(pin.port, &GPIO_InitStruct);
+                break;
 
-		case OperationMode::INPUT:
-			GPIO_InitStruct.Mode =  GPIO_MODE_INPUT;
-			GPIO_InitStruct.Pull = GPIO_NOPULL;
-			HAL_GPIO_Init(pin.port, &GPIO_InitStruct);
-			break;
+            case OperationMode::ANALOG:
+                GPIO_InitStruct.Mode = GPIO_MODE_ANALOG;
+                GPIO_InitStruct.Pull = GPIO_NOPULL;
+                HAL_GPIO_Init(pin.port, &GPIO_InitStruct);
+                break;
+            case OperationMode::EXTERNAL_INTERRUPT_RISING:
+                GPIO_InitStruct.Mode = GPIO_MODE_IT_RISING;
+                GPIO_InitStruct.Pull = GPIO_PULLDOWN;
+                HAL_GPIO_Init(pin.port, &GPIO_InitStruct);
+                break;
+            case OperationMode::EXTERNAL_INTERRUPT_FALLING:
+                GPIO_InitStruct.Mode = GPIO_MODE_IT_FALLING;
+                GPIO_InitStruct.Pull = GPIO_PULLDOWN;
+                HAL_GPIO_Init(pin.port, &GPIO_InitStruct);
+                break;
+            case OperationMode::EXTERNAL_INTERRUPT_RISING_FALLING:
+                GPIO_InitStruct.Mode = GPIO_MODE_IT_RISING_FALLING;
+                GPIO_InitStruct.Pull = GPIO_PULLDOWN;
+                HAL_GPIO_Init(pin.port, &GPIO_InitStruct);
+                break;
+            case OperationMode::TIMER_ALTERNATE_FUNCTION:
+                GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+                GPIO_InitStruct.Pull = GPIO_NOPULL;
+                GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+                GPIO_InitStruct.Alternate = pin.alternative_function;
+                HAL_GPIO_Init(pin.port, &GPIO_InitStruct);
+                break;
 
-		case OperationMode::ANALOG:
-			GPIO_InitStruct.Mode =  GPIO_MODE_ANALOG;
-			GPIO_InitStruct.Pull = GPIO_NOPULL;
-			HAL_GPIO_Init(pin.port, &GPIO_InitStruct);
-			break;
-		case OperationMode::EXTERNAL_INTERRUPT_RISING:
-			GPIO_InitStruct.Mode = GPIO_MODE_IT_RISING;
-			GPIO_InitStruct.Pull = GPIO_PULLDOWN;
-			HAL_GPIO_Init(pin.port, &GPIO_InitStruct);
-			break;
-		case OperationMode::EXTERNAL_INTERRUPT_FALLING:
-			GPIO_InitStruct.Mode = GPIO_MODE_IT_FALLING;
-			GPIO_InitStruct.Pull = GPIO_PULLDOWN;
-			HAL_GPIO_Init(pin.port, &GPIO_InitStruct);
-			break;
-		case OperationMode::TIMER_ALTERNATE_FUNCTION:
-			GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
-			GPIO_InitStruct.Pull = GPIO_NOPULL;
-			GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-			GPIO_InitStruct.Alternate = pin.alternative_function;
-			HAL_GPIO_Init(pin.port, &GPIO_InitStruct);
-			break;
-
-		default:
-			break;
-		}
-	}
+            default:
+                break;
+        }
+    }
 }

--- a/Src/HALAL/Services/EXTI/EXTI.cpp
+++ b/Src/HALAL/Services/EXTI/EXTI.cpp
@@ -2,68 +2,73 @@
  * EXTI.cpp
  *
  *  Created on: Nov 5, 2022
- *      Author: alejandro 
+ *      Author: alejandro
  */
 
 #include "HALAL/Services/EXTI/EXTI.hpp"
+
 #include "ErrorHandler/ErrorHandler.hpp"
 
 uint8_t ExternalInterrupt::id_counter = 0;
 map<uint8_t, Pin> ExternalInterrupt::service_ids = {};
 
-ExternalInterrupt::Instance::Instance(IRQn_Type interrupt_request_number) :
-		interrupt_request_number(interrupt_request_number) {}
+ExternalInterrupt::Instance::Instance(IRQn_Type interrupt_request_number)
+    : interrupt_request_number(interrupt_request_number) {}
 
-void HAL_GPIO_EXTI_Callback (uint16_t GPIO_Pin) {
-	ExternalInterrupt::Instance& exti = ExternalInterrupt::instances[GPIO_Pin];
-	if (exti.is_on) {
-		exti.action();
-	}
+void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin) {
+    ExternalInterrupt::Instance& exti = ExternalInterrupt::instances[GPIO_Pin];
+    if (exti.is_on) {
+        exti.action();
+    }
 }
 
-uint8_t ExternalInterrupt::inscribe(Pin& pin, function<void()>&& action, TRIGGER trigger) {
-	if (not instances.contains(pin.gpio_pin)) {
-		ErrorHandler(" The pin %s is already used or isn t available for EXTI usage", pin.to_string().c_str());
-		return 0;
-	}
+uint8_t ExternalInterrupt::inscribe(Pin& pin, function<void()>&& action,
+                                    TRIGGER trigger) {
+    if (not instances.contains(pin.gpio_pin)) {
+        ErrorHandler(
+            " The pin %s is already used or isn t available for EXTI usage",
+            pin.to_string().c_str());
+        return 0;
+    }
 
-	if (trigger == TRIGGER::RISING_EDGE) {
-		Pin::inscribe(pin, EXTERNAL_INTERRUPT_RISING);
-	}
-	else if (trigger == TRIGGER::FAILING_EDGE) {
-		Pin::inscribe(pin, EXTERNAL_INTERRUPT_FALLING);
-	}
+    if (trigger == TRIGGER::RISING_EDGE) {
+        Pin::inscribe(pin, EXTERNAL_INTERRUPT_RISING);
+    } else if (trigger == TRIGGER::FAILING_EDGE) {
+        Pin::inscribe(pin, EXTERNAL_INTERRUPT_FALLING);
+    } else if (trigger == TRIGGER::BOTH_EDGES) {
+        Pin::inscribe(pin, EXTERNAL_INTERRUPT_RISING_FALLING);
+    }
 
-	service_ids[id_counter] = pin;
-	instances[pin.gpio_pin].action = action;
+    service_ids[id_counter] = pin;
+    instances[pin.gpio_pin].action = action;
 
-	return id_counter++;
+    return id_counter++;
 }
 
 void ExternalInterrupt::start() {
-	for(auto id_instance : instances) {
-		Instance& instance = id_instance.second;
-		  HAL_NVIC_SetPriority(instance.interrupt_request_number, 0, 0);
-		  HAL_NVIC_EnableIRQ(instance.interrupt_request_number);
-	}
+    for (auto id_instance : instances) {
+        Instance& instance = id_instance.second;
+        HAL_NVIC_SetPriority(instance.interrupt_request_number, 0, 0);
+        HAL_NVIC_EnableIRQ(instance.interrupt_request_number);
+    }
 }
 
 void ExternalInterrupt::turn_on(uint8_t id) {
-	if (not service_ids.contains(id)) {
-		ErrorHandler("ID %d is not registered as an active instance", id);
-		return;
-	}
+    if (not service_ids.contains(id)) {
+        ErrorHandler("ID %d is not registered as an active instance", id);
+        return;
+    }
 
-	Instance& instance = instances[service_ids[id].gpio_pin];
-	instance.is_on = true;
+    Instance& instance = instances[service_ids[id].gpio_pin];
+    instance.is_on = true;
 }
 
 bool ExternalInterrupt::get_pin_value(uint8_t id) {
-	if (not service_ids.contains(id)) {
-		ErrorHandler("ID %d is not registered as an active instance", id);
-		return false;
-	}
+    if (not service_ids.contains(id)) {
+        ErrorHandler("ID %d is not registered as an active instance", id);
+        return false;
+    }
 
-	Pin& pin = service_ids[id];
-	return HAL_GPIO_ReadPin(GPIO_PORT, pin.gpio_pin);
+    Pin& pin = service_ids[id];
+    return HAL_GPIO_ReadPin(pin.port, pin.gpio_pin);
 }


### PR DESCRIPTION
Mainly there were two problems:
### Not able to register a pin as a trigger in both edges
`SensorInterrupt` class lets you register a pin as an EXTI in both edges, but within EXTI class you find hardcoded only Triggers RISING and FALLING. The way to register a Pin as an EXTI in both edges has been added.

### Pin class doesn't give the chance of register a pin as an EXTI in both edges
The pin class didn't have the proper operation mode to configure a pin as an EXTI in RISING and FALLING edge. This operation mode has also been added

Ah, and I took the opportunity to apply the formatter hehe. The files are small so I hope it won't be a problem to review them.