### PR TITLE
fix(GPIO): Alternative Function numbers were inverted

### DIFF
--- a/Inc/HALAL/Models/GPIO.hpp
+++ b/Inc/HALAL/Models/GPIO.hpp
@@ -196,8 +196,8 @@ struct GPIODomain {
       }
     }
 
-    template <class Ctx> consteval void inscribe(Ctx &ctx) const {
-      ctx.template add<GPIODomain>(e, this);
+    template <class Ctx> consteval std::size_t inscribe(Ctx &ctx) const {
+      return ctx.template add<GPIODomain>(e, this);
     }
   };
 

--- a/Inc/ST-LIB_LOW/DigitalInput2.hpp
+++ b/Inc/ST-LIB_LOW/DigitalInput2.hpp
@@ -18,10 +18,10 @@ struct DigitalInputDomain {
                            GPIODomain::Speed speed = GPIODomain::Speed::Low)
         : gpio{pin, GPIODomain::OperationMode::INPUT, pull, speed} {}
 
-    template <class Ctx> consteval void inscribe(Ctx &ctx) const {
-      const auto gpio_idx = ctx.template add<GPIODomain>(gpio.e, &gpio);
+    template <class Ctx> consteval std::size_t inscribe(Ctx &ctx) const {
+      const auto gpio_idx = gpio.inscribe(ctx);
       Entry e{.gpio_idx = gpio_idx};
-      ctx.template add<DigitalInputDomain>(e, this);
+      return ctx.template add<DigitalInputDomain>(e, this);
     }
   };
 

--- a/Inc/ST-LIB_LOW/DigitalOutput2.hpp
+++ b/Inc/ST-LIB_LOW/DigitalOutput2.hpp
@@ -26,10 +26,10 @@ struct DigitalOutputDomain {
         : gpio{pin, static_cast<GPIODomain::OperationMode>(mode), pull, speed} {
     }
 
-    template <class Ctx> consteval void inscribe(Ctx &ctx) const {
-      const auto gpio_idx = ctx.template add<GPIODomain>(gpio.e, &gpio);
+    template <class Ctx> consteval std::size_t inscribe(Ctx &ctx) const {
+      const auto gpio_idx = gpio.inscribe(ctx);
       Entry e{.gpio_idx = gpio_idx};
-      ctx.template add<DigitalOutputDomain>(e, this);
+      return ctx.template add<DigitalOutputDomain>(e, this);
     }
   };
 


### PR DESCRIPTION
Just what the title says + Make inscribes return std::size_t (the result of the add operation) so that they are easier to use from higher domains