### PR TITLE
fix/GPIO-Assert

### DIFF
--- a/Inc/HALAL/Models/GPIO.hpp
+++ b/Inc/HALAL/Models/GPIO.hpp
@@ -246,7 +246,6 @@ struct GPIODomain {
     static inline std::array<Instance, N> instances{};
 
     static void init(std::span<const Config, N> cfgs) {
-      static_assert(N > 0);
       for (std::size_t i = 0; i < N; ++i) {
         const auto &e = cfgs[i];
         auto [port, gpio_init] = e.init_data;


### PR DESCRIPTION
Remove the static assert of N > 0 in GPIO.hpp since it makes no sense, there are times when you want to try out things with 0 pin configurations...