### PR TITLE
Feat/Add comparison to pins

### DIFF
--- a/Inc/HALAL/Models/GPIO.hpp
+++ b/Inc/HALAL/Models/GPIO.hpp
@@ -159,6 +159,14 @@ struct GPIODomain {
         return true;
       return ((1 << static_cast<uint8_t>(af)) & afs) != 0;
     }
+
+    constexpr bool operator==(const Pin &other) const {
+      return (port == other.port) && (pin == other.pin);
+    }
+
+    constexpr bool operator!=(const Pin &other) const {
+      return !(*this == other);
+    }
   };
 
   struct Entry {


### PR DESCRIPTION
Just what the title says, this adds comparison operators to the GPIODomain::Pin struct