### PR TITLE
Hotfix/mpu config

### DIFF
--- a/Inc/HALAL/Models/MPU.hpp
+++ b/Inc/HALAL/Models/MPU.hpp
@@ -382,12 +382,14 @@ struct MPUDomain {
 
         // DTCM (Normal, Cacheable)
         // TEX=1, C=1, B=1: Normal, Write-Back, Write and Read Allocate
+        // TCMs are like Cache, so they are not really cacheable, and the MPU settings are ignored
         configure_region(reinterpret_cast<uintptr_t>(&__dtcm_base), reinterpret_cast<size_t>(&__dtcm_size), MPU_REGION_NUMBER10,
                          MPU_TEX_LEVEL1, MPU_REGION_FULL_ACCESS, MPU_INSTRUCTION_ACCESS_DISABLE,
                          MPU_ACCESS_NOT_SHAREABLE, MPU_ACCESS_CACHEABLE, MPU_ACCESS_BUFFERABLE);
 
         // ITCM (Normal, Cacheable)
         // TEX=0, C=1, B=0: Normal, Write-Through, No Read-Allocate (Read optimized)
+        // TCMs are like Cache, so they are not really cacheable, and the MPU settings are ignored
         configure_region(reinterpret_cast<uintptr_t>(&__itcm_base), reinterpret_cast<size_t>(&__itcm_size), MPU_REGION_NUMBER11,
                          MPU_TEX_LEVEL0, MPU_REGION_FULL_ACCESS, MPU_INSTRUCTION_ACCESS_ENABLE,
                          MPU_ACCESS_NOT_SHAREABLE, MPU_ACCESS_CACHEABLE, MPU_ACCESS_NOT_BUFFERABLE);


### PR DESCRIPTION
Was using a configuration that caused undefined behaviour for flash, now using the correct one.

Check this [application note](https://www.st.com/resource/en/application_note/dm00272912-managing-memory-protection-unit-in-stm32-mcus-stmicroelectronics.pdf)