### PR TITLE
Max out ARR for encoder

### DIFF
--- a/Inc/HALAL/Services/Encoder/Encoder.hpp
+++ b/Inc/HALAL/Services/Encoder/Encoder.hpp
@@ -63,7 +63,11 @@ public:
         }
 
         tim->instance->tim->PSC = 5;
-        tim->instance->tim->ARR = 55000;
+        if constexpr(tim->is_32bit_instance) {
+            tim->instance->tim->ARR = UINT32_MAX;
+        } else {
+            tim->instance->tim->ARR = UINT16_MAX;
+        }
         timer = tim;
     }
 

--- a/Inc/HALAL/Services/Encoder/Encoder.hpp
+++ b/Inc/HALAL/Services/Encoder/Encoder.hpp
@@ -63,7 +63,7 @@ public:
         }
 
         tim->instance->tim->PSC = 5;
-        if constexpr(tim->is_32bit_instance) {
+        if constexpr (tim->is_32bit_instance) {
             tim->instance->tim->ARR = UINT32_MAX;
         } else {
             tim->instance->tim->ARR = UINT16_MAX;

--- a/Tests/Time/encoder_test.cpp
+++ b/Tests/Time/encoder_test.cpp
@@ -82,7 +82,7 @@ TEST_F(EncoderTest, ResetUsesConfiguredInitialCounterValue) {
 
     ST_LIB::Encoder<encoder_timer_decl>::reset();
 
-    EXPECT_EQ(TIM2_BASE->ARR, UINT32_MAX / 2);
+    EXPECT_EQ(TIM2_BASE->ARR, UINT32_MAX);
     EXPECT_EQ(TIM2_BASE->CNT, ST_LIB::Encoder<encoder_timer_decl>::get_initial_counter_value());
 }
 

--- a/Tests/Time/encoder_test.cpp
+++ b/Tests/Time/encoder_test.cpp
@@ -82,7 +82,7 @@ TEST_F(EncoderTest, ResetUsesConfiguredInitialCounterValue) {
 
     ST_LIB::Encoder<encoder_timer_decl>::reset();
 
-    EXPECT_EQ(TIM2_BASE->ARR, 55000U);
+    EXPECT_EQ(TIM2_BASE->ARR, UINT32_MAX / 2);
     EXPECT_EQ(TIM2_BASE->CNT, ST_LIB::Encoder<encoder_timer_decl>::get_initial_counter_value());
 }
 


### PR DESCRIPTION
NOTE: something should probably be changed for underflow...

NOPE apparently value starts in the middle of the range so it won't underflow/overflow

note that this change is included in feat/newInputCapture too since I had the change locally :P