### PR TITLE
fix(MDMA): Fix, MDMA AHBS is 32-bit only

### DIFF
--- a/Inc/HALAL/Models/MDMA/MDMA.hpp
+++ b/Inc/HALAL/Models/MDMA/MDMA.hpp
@@ -153,10 +153,15 @@ public:
                 (source_data_size == MDMA_SRC_DATASIZE_WORD)        ? 4U :
                 (source_data_size == MDMA_SRC_DATASIZE_DOUBLEWORD)  ? 8U :
                 1U;
-            uint32_t buf_len = static_cast<uint32_t>(std::min(size, static_cast<size_t>(128)));
+            const uint32_t max_buf_len = 128U;
+            uint32_t buf_len = static_cast<uint32_t>(std::min(size, static_cast<size_t>(max_buf_len)));
             buf_len = (buf_len / elem_size) * elem_size;
-            if (buf_len == 0)
+            if (buf_len == 0) {
                 buf_len = elem_size;
+            }
+            if (buf_len > max_buf_len) {
+                buf_len = max_buf_len;
+            }
             nodeConfig.Init.BufferTransferLength = buf_len;
 
             if (HAL_MDMA_LinkedList_CreateNode(&node, &nodeConfig) != HAL_OK) {

--- a/Inc/HALAL/Models/MDMA/MDMA.hpp
+++ b/Inc/HALAL/Models/MDMA/MDMA.hpp
@@ -147,8 +147,12 @@ public:
             nodeConfig.Init.DestinationInc = dest_inc;
 
             // BufferTransferLength must be <= BlockDataLength and a multiple of the element size.
+            // Derive the element size from the selected MDMA SourceDataSize, not directly from effective_size.
             const uint32_t elem_size =
-                static_cast<uint32_t>(effective_size <= 1 ? 1 : effective_size);
+                (source_data_size == MDMA_SRC_DATASIZE_HALFWORD)    ? 2U :
+                (source_data_size == MDMA_SRC_DATASIZE_WORD)        ? 4U :
+                (source_data_size == MDMA_SRC_DATASIZE_DOUBLEWORD)  ? 8U :
+                1U;
             uint32_t buf_len = static_cast<uint32_t>(std::min(size, static_cast<size_t>(128)));
             buf_len = (buf_len / elem_size) * elem_size;
             if (buf_len == 0)

--- a/Inc/HALAL/Models/MDMA/MDMA.hpp
+++ b/Inc/HALAL/Models/MDMA/MDMA.hpp
@@ -79,15 +79,10 @@ public:
             const uintptr_t dst = node.CDAR;
             const size_t size = transfer_size;
 
-            const bool src_is_tcm =
-                (src < 0x00010000U) || (src >= 0x20000000U && src < 0x20020000U);
-            const bool dst_is_tcm =
-                (dst < 0x00010000U) || (dst >= 0x20000000U && dst < 0x20020000U);
-            const size_t max_elem = (src_is_tcm || dst_is_tcm) ? 4u : 8u;
+            if (size == 0)
+                return;
 
-            const size_t size_gran = size & -size;
-            const size_t addr_gran = static_cast<size_t>((src | dst) & -(src | dst));
-            const size_t effective_size = std::min({size_gran, addr_gran, max_elem});
+            const size_t effective_size = compute_elem_size(src, dst, size);
 
             uint32_t source_data_size, dest_data_size, source_inc, dest_inc;
             switch (static_cast<uint32_t>(effective_size)) {
@@ -134,7 +129,27 @@ public:
             );
         }
 
+        static bool is_tcm(uintptr_t addr) {
+            return (addr < 0x00010000U) || (addr >= 0x20000000U && addr < 0x20020000U);
+        }
+
+        // Returns the largest power-of-2 element size (1/2/4/8) valid for both addresses and size.
+        // addr_or==0 (both null) is treated as maximally aligned rather than causing div-by-zero.
+        static size_t compute_elem_size(uintptr_t src, uintptr_t dst, size_t size) {
+            const size_t max_elem = (is_tcm(src) || is_tcm(dst)) ? 4u : 8u;
+            const size_t size_gran = size & -size;
+            const uintptr_t addr_or = src | dst;
+            const size_t addr_gran =
+                (addr_or != 0u) ? static_cast<size_t>(addr_or & -addr_or) : max_elem;
+            return std::min({size_gran, addr_gran, max_elem});
+        }
+
         void init_node(void* src, void* dst, size_t size) {
+            if (size == 0) {
+                ErrorHandler("MDMA: zero-length transfer is invalid");
+                return;
+            }
+
             MDMA_LinkNodeConfTypeDef nodeConfig{};
             nodeConfig.Init.DataAlignment = MDMA_DATAALIGN_RIGHT;
             nodeConfig.Init.SourceBurst = MDMA_SOURCE_BURST_SINGLE;
@@ -158,21 +173,11 @@ public:
             uint32_t source_inc;
             uint32_t dest_inc;
 
-            // The AHBS port (used for TCM) is 32-bit wide, so DOUBLEWORD beats are not supported.
-            const bool src_is_tcm = (reinterpret_cast<uintptr_t>(src) < 0x00010000U) ||
-                                    (reinterpret_cast<uintptr_t>(src) >= 0x20000000U &&
-                                     reinterpret_cast<uintptr_t>(src) < 0x20020000U);
-            const bool dst_is_tcm = (reinterpret_cast<uintptr_t>(dst) < 0x00010000U) ||
-                                    (reinterpret_cast<uintptr_t>(dst) >= 0x20000000U &&
-                                     reinterpret_cast<uintptr_t>(dst) < 0x20020000U);
-            const size_t max_elem = (src_is_tcm || dst_is_tcm) ? 4u : 8u;
-
-            const uintptr_t addr_or =
-                reinterpret_cast<uintptr_t>(src) | reinterpret_cast<uintptr_t>(dst);
-            const size_t size_gran = size & -size; // largest pow-2 dividing size
-            const size_t addr_gran =
-                static_cast<size_t>(addr_or & -addr_or); // largest pow-2 aligning both addresses
-            size_t effective_size = std::min({size_gran, addr_gran, max_elem});
+            const size_t effective_size = compute_elem_size(
+                reinterpret_cast<uintptr_t>(src),
+                reinterpret_cast<uintptr_t>(dst),
+                size
+            );
 
             switch (static_cast<uint32_t>(effective_size)) {
             case 2:
@@ -220,9 +225,9 @@ public:
 
             // HAL_MDMA_LinkedList_CreateNode only sets the request field in CTBR;
             // bus routing bits must be set explicitly for TCM addresses.
-            if (src_is_tcm)
+            if (is_tcm(reinterpret_cast<uintptr_t>(src)))
                 SET_BIT(node.CTBR, MDMA_CTBR_SBUS);
-            if (dst_is_tcm)
+            if (is_tcm(reinterpret_cast<uintptr_t>(dst)))
                 SET_BIT(node.CTBR, MDMA_CTBR_DBUS);
         }
     };

--- a/Inc/HALAL/Models/MDMA/MDMA.hpp
+++ b/Inc/HALAL/Models/MDMA/MDMA.hpp
@@ -76,7 +76,6 @@ public:
             nodeConfig.Init.DataAlignment = MDMA_DATAALIGN_RIGHT;
             nodeConfig.Init.SourceBurst = MDMA_SOURCE_BURST_SINGLE;
             nodeConfig.Init.DestBurst = MDMA_DEST_BURST_SINGLE;
-            nodeConfig.Init.BufferTransferLength = 128;
             nodeConfig.Init.TransferTriggerMode = MDMA_FULL_TRANSFER;
             nodeConfig.Init.SourceBlockAddressOffset = 0;
             nodeConfig.Init.DestBlockAddressOffset = 0;
@@ -96,6 +95,17 @@ public:
             uint32_t dest_inc;
 
             size_t effective_size = size;
+
+            // The AHBS port (used for TCM) is 32-bit wide
+            const bool src_is_tcm =
+                ((reinterpret_cast<uintptr_t>(src) & 0xFF000000U) == 0x20000000U) ||
+                ((reinterpret_cast<uintptr_t>(src) & 0xFF000000U) == 0x00000000U);
+            const bool dst_is_tcm =
+                ((reinterpret_cast<uintptr_t>(dst) & 0xFF000000U) == 0x20000000U) ||
+                ((reinterpret_cast<uintptr_t>(dst) & 0xFF000000U) == 0x00000000U);
+            if ((src_is_tcm || dst_is_tcm) && effective_size > 4)
+                effective_size = 4; // Downgrade to WORD to stay within 32-bit AHBS width
+
             if (effective_size == 2 &&
                 ((reinterpret_cast<uintptr_t>(src) | reinterpret_cast<uintptr_t>(dst)) & 1))
                 effective_size = 1; // Odd address, so fallback to byte-wise
@@ -135,6 +145,15 @@ public:
             nodeConfig.Init.DestDataSize = dest_data_size;
             nodeConfig.Init.SourceInc = source_inc;
             nodeConfig.Init.DestinationInc = dest_inc;
+
+            // BufferTransferLength must be <= BlockDataLength and a multiple of the element size.
+            const uint32_t elem_size =
+                static_cast<uint32_t>(effective_size <= 1 ? 1 : effective_size);
+            uint32_t buf_len = static_cast<uint32_t>(std::min(size, static_cast<size_t>(128)));
+            buf_len = (buf_len / elem_size) * elem_size;
+            if (buf_len == 0)
+                buf_len = elem_size;
+            nodeConfig.Init.BufferTransferLength = buf_len;
 
             if (HAL_MDMA_LinkedList_CreateNode(&node, &nodeConfig) != HAL_OK) {
                 ErrorHandler("Error creating linked list in MDMA");

--- a/Inc/HALAL/Models/MDMA/MDMA.hpp
+++ b/Inc/HALAL/Models/MDMA/MDMA.hpp
@@ -47,6 +47,7 @@ public:
             } else {
                 CLEAR_BIT(node.CTBR, MDMA_CTBR_DBUS);
             }
+            reconfigure_ctcr();
         }
         void set_source(void* source) {
             uint32_t source_address = reinterpret_cast<uint32_t>(source);
@@ -59,6 +60,7 @@ public:
             } else {
                 CLEAR_BIT(node.CTBR, MDMA_CTBR_SBUS);
             }
+            reconfigure_ctcr();
         }
         auto get_node() -> MDMA_LinkNodeTypeDef* { return &node; }
         auto get_size() -> uint32_t { return node.CBNDTR; }
@@ -70,6 +72,78 @@ public:
 
     private:
         alignas(8) MDMA_LinkNodeTypeDef node;
+        size_t transfer_size{0};
+
+        void reconfigure_ctcr() {
+            uintptr_t src = node.CSAR;
+            uintptr_t dst = node.CDAR;
+            size_t size = transfer_size;
+
+            size_t effective_size = size;
+
+            const bool src_is_tcm =
+                ((src & 0xFF000000U) == 0x20000000U) || ((src & 0xFF000000U) == 0x00000000U);
+            const bool dst_is_tcm =
+                ((dst & 0xFF000000U) == 0x20000000U) || ((dst & 0xFF000000U) == 0x00000000U);
+            if ((src_is_tcm || dst_is_tcm) && effective_size > 4)
+                effective_size = 4;
+
+            if (effective_size == 2 && ((src | dst) & 1))
+                effective_size = 1;
+            else if (effective_size == 4 && ((src | dst) & 3))
+                effective_size = 1;
+            else if (effective_size == 8 && ((src | dst) & 7))
+                effective_size = 1;
+
+            uint32_t source_data_size, dest_data_size, source_inc, dest_inc;
+            switch (static_cast<uint32_t>(effective_size)) {
+            case 2:
+                source_data_size = MDMA_SRC_DATASIZE_HALFWORD;
+                dest_data_size = MDMA_DEST_DATASIZE_HALFWORD;
+                source_inc = MDMA_SRC_INC_HALFWORD;
+                dest_inc = MDMA_DEST_INC_HALFWORD;
+                break;
+            case 4:
+                source_data_size = MDMA_SRC_DATASIZE_WORD;
+                dest_data_size = MDMA_DEST_DATASIZE_WORD;
+                source_inc = MDMA_SRC_INC_WORD;
+                dest_inc = MDMA_DEST_INC_WORD;
+                break;
+            case 8:
+                source_data_size = MDMA_SRC_DATASIZE_DOUBLEWORD;
+                dest_data_size = MDMA_DEST_DATASIZE_DOUBLEWORD;
+                source_inc = MDMA_SRC_INC_DOUBLEWORD;
+                dest_inc = MDMA_DEST_INC_DOUBLEWORD;
+                break;
+            default:
+                source_data_size = MDMA_SRC_DATASIZE_BYTE;
+                dest_data_size = MDMA_DEST_DATASIZE_BYTE;
+                source_inc = MDMA_SRC_INC_BYTE;
+                dest_inc = MDMA_DEST_INC_BYTE;
+                break;
+            }
+
+            const uint32_t elem_size = (source_data_size == MDMA_SRC_DATASIZE_HALFWORD)     ? 2U
+                                       : (source_data_size == MDMA_SRC_DATASIZE_WORD)       ? 4U
+                                       : (source_data_size == MDMA_SRC_DATASIZE_DOUBLEWORD) ? 8U
+                                                                                            : 1U;
+            const uint32_t max_buf_len = 128U;
+            uint32_t buf_len =
+                static_cast<uint32_t>(std::min(size, static_cast<size_t>(max_buf_len)));
+            buf_len = (buf_len / elem_size) * elem_size;
+            if (buf_len == 0)
+                buf_len = elem_size;
+
+            // SINCOS/DINCOS must be included: MDMA_SRC_INC_* constants encode both
+            // SINC and SINCOS (increment offset size) bits together.
+            MODIFY_REG(
+                node.CTCR,
+                MDMA_CTCR_SINC | MDMA_CTCR_SINCOS | MDMA_CTCR_DINC | MDMA_CTCR_DINCOS |
+                    MDMA_CTCR_SSIZE | MDMA_CTCR_DSIZE | MDMA_CTCR_TLEN,
+                source_inc | dest_inc | source_data_size | dest_data_size |
+                    ((buf_len - 1U) << MDMA_CTCR_TLEN_Pos)
+            );
+        }
 
         void init_node(void* src, void* dst, size_t size) {
             MDMA_LinkNodeConfTypeDef nodeConfig{};
@@ -85,6 +159,7 @@ public:
             nodeConfig.Init.Request = MDMA_REQUEST_SW;
 
             this->node = {};
+            this->transfer_size = size;
             nodeConfig.SrcAddress = reinterpret_cast<uint32_t>(src);
             nodeConfig.DstAddress = reinterpret_cast<uint32_t>(dst);
             nodeConfig.BlockDataLength = static_cast<uint32_t>(size);
@@ -147,14 +222,15 @@ public:
             nodeConfig.Init.DestinationInc = dest_inc;
 
             // BufferTransferLength must be <= BlockDataLength and a multiple of the element size.
-            // Derive the element size from the selected MDMA SourceDataSize, not directly from effective_size.
-            const uint32_t elem_size =
-                (source_data_size == MDMA_SRC_DATASIZE_HALFWORD)    ? 2U :
-                (source_data_size == MDMA_SRC_DATASIZE_WORD)        ? 4U :
-                (source_data_size == MDMA_SRC_DATASIZE_DOUBLEWORD)  ? 8U :
-                1U;
+            // Derive the element size from the selected MDMA SourceDataSize, not directly from
+            // effective_size.
+            const uint32_t elem_size = (source_data_size == MDMA_SRC_DATASIZE_HALFWORD)     ? 2U
+                                       : (source_data_size == MDMA_SRC_DATASIZE_WORD)       ? 4U
+                                       : (source_data_size == MDMA_SRC_DATASIZE_DOUBLEWORD) ? 8U
+                                                                                            : 1U;
             const uint32_t max_buf_len = 128U;
-            uint32_t buf_len = static_cast<uint32_t>(std::min(size, static_cast<size_t>(max_buf_len)));
+            uint32_t buf_len =
+                static_cast<uint32_t>(std::min(size, static_cast<size_t>(max_buf_len)));
             buf_len = (buf_len / elem_size) * elem_size;
             if (buf_len == 0) {
                 buf_len = elem_size;

--- a/Inc/HALAL/Models/MDMA/MDMA.hpp
+++ b/Inc/HALAL/Models/MDMA/MDMA.hpp
@@ -75,25 +75,19 @@ public:
         size_t transfer_size{0};
 
         void reconfigure_ctcr() {
-            uintptr_t src = node.CSAR;
-            uintptr_t dst = node.CDAR;
-            size_t size = transfer_size;
-
-            size_t effective_size = size;
+            const uintptr_t src = node.CSAR;
+            const uintptr_t dst = node.CDAR;
+            const size_t size = transfer_size;
 
             const bool src_is_tcm =
-                ((src & 0xFF000000U) == 0x20000000U) || ((src & 0xFF000000U) == 0x00000000U);
+                (src < 0x00010000U) || (src >= 0x20000000U && src < 0x20020000U);
             const bool dst_is_tcm =
-                ((dst & 0xFF000000U) == 0x20000000U) || ((dst & 0xFF000000U) == 0x00000000U);
-            if ((src_is_tcm || dst_is_tcm) && effective_size > 4)
-                effective_size = 4;
+                (dst < 0x00010000U) || (dst >= 0x20000000U && dst < 0x20020000U);
+            const size_t max_elem = (src_is_tcm || dst_is_tcm) ? 4u : 8u;
 
-            if (effective_size == 2 && ((src | dst) & 1))
-                effective_size = 1;
-            else if (effective_size == 4 && ((src | dst) & 3))
-                effective_size = 1;
-            else if (effective_size == 8 && ((src | dst) & 7))
-                effective_size = 1;
+            const size_t size_gran = size & -size;
+            const size_t addr_gran = static_cast<size_t>((src | dst) & -(src | dst));
+            const size_t effective_size = std::min({size_gran, addr_gran, max_elem});
 
             uint32_t source_data_size, dest_data_size, source_inc, dest_inc;
             switch (static_cast<uint32_t>(effective_size)) {
@@ -123,13 +117,8 @@ public:
                 break;
             }
 
-            const uint32_t elem_size = (source_data_size == MDMA_SRC_DATASIZE_HALFWORD)     ? 2U
-                                       : (source_data_size == MDMA_SRC_DATASIZE_WORD)       ? 4U
-                                       : (source_data_size == MDMA_SRC_DATASIZE_DOUBLEWORD) ? 8U
-                                                                                            : 1U;
-            const uint32_t max_buf_len = 128U;
-            uint32_t buf_len =
-                static_cast<uint32_t>(std::min(size, static_cast<size_t>(max_buf_len)));
+            const uint32_t elem_size = static_cast<uint32_t>(effective_size);
+            uint32_t buf_len = static_cast<uint32_t>(std::min(size, static_cast<size_t>(128U)));
             buf_len = (buf_len / elem_size) * elem_size;
             if (buf_len == 0)
                 buf_len = elem_size;
@@ -169,25 +158,21 @@ public:
             uint32_t source_inc;
             uint32_t dest_inc;
 
-            size_t effective_size = size;
+            // The AHBS port (used for TCM) is 32-bit wide, so DOUBLEWORD beats are not supported.
+            const bool src_is_tcm = (reinterpret_cast<uintptr_t>(src) < 0x00010000U) ||
+                                    (reinterpret_cast<uintptr_t>(src) >= 0x20000000U &&
+                                     reinterpret_cast<uintptr_t>(src) < 0x20020000U);
+            const bool dst_is_tcm = (reinterpret_cast<uintptr_t>(dst) < 0x00010000U) ||
+                                    (reinterpret_cast<uintptr_t>(dst) >= 0x20000000U &&
+                                     reinterpret_cast<uintptr_t>(dst) < 0x20020000U);
+            const size_t max_elem = (src_is_tcm || dst_is_tcm) ? 4u : 8u;
 
-            // The AHBS port (used for TCM) is 32-bit wide
-            const bool src_is_tcm =
-                ((reinterpret_cast<uintptr_t>(src) & 0xFF000000U) == 0x20000000U) ||
-                ((reinterpret_cast<uintptr_t>(src) & 0xFF000000U) == 0x00000000U);
-            const bool dst_is_tcm =
-                ((reinterpret_cast<uintptr_t>(dst) & 0xFF000000U) == 0x20000000U) ||
-                ((reinterpret_cast<uintptr_t>(dst) & 0xFF000000U) == 0x00000000U);
-            if ((src_is_tcm || dst_is_tcm) && effective_size > 4)
-                effective_size = 4; // Downgrade to WORD to stay within 32-bit AHBS width
-
-            if (effective_size == 2 &&
-                ((reinterpret_cast<uintptr_t>(src) | reinterpret_cast<uintptr_t>(dst)) & 1))
-                effective_size = 1; // Odd address, so fallback to byte-wise
-            else if (effective_size == 4 && ((reinterpret_cast<uintptr_t>(src) | reinterpret_cast<uintptr_t>(dst)) & 3))
-                effective_size = 1; // Not word-aligned, so fallback to byte-wise
-            else if (effective_size == 8 && ((reinterpret_cast<uintptr_t>(src) | reinterpret_cast<uintptr_t>(dst)) & 7))
-                effective_size = 1; // Not doubleword-aligned, so fallback to byte-wise
+            const uintptr_t addr_or =
+                reinterpret_cast<uintptr_t>(src) | reinterpret_cast<uintptr_t>(dst);
+            const size_t size_gran = size & -size; // largest pow-2 dividing size
+            const size_t addr_gran =
+                static_cast<size_t>(addr_or & -addr_or); // largest pow-2 aligning both addresses
+            size_t effective_size = std::min({size_gran, addr_gran, max_elem});
 
             switch (static_cast<uint32_t>(effective_size)) {
             case 2:
@@ -222,27 +207,23 @@ public:
             nodeConfig.Init.DestinationInc = dest_inc;
 
             // BufferTransferLength must be <= BlockDataLength and a multiple of the element size.
-            // Derive the element size from the selected MDMA SourceDataSize, not directly from
-            // effective_size.
-            const uint32_t elem_size = (source_data_size == MDMA_SRC_DATASIZE_HALFWORD)     ? 2U
-                                       : (source_data_size == MDMA_SRC_DATASIZE_WORD)       ? 4U
-                                       : (source_data_size == MDMA_SRC_DATASIZE_DOUBLEWORD) ? 8U
-                                                                                            : 1U;
-            const uint32_t max_buf_len = 128U;
-            uint32_t buf_len =
-                static_cast<uint32_t>(std::min(size, static_cast<size_t>(max_buf_len)));
+            const uint32_t elem_size = static_cast<uint32_t>(effective_size);
+            uint32_t buf_len = static_cast<uint32_t>(std::min(size, static_cast<size_t>(128)));
             buf_len = (buf_len / elem_size) * elem_size;
-            if (buf_len == 0) {
+            if (buf_len == 0)
                 buf_len = elem_size;
-            }
-            if (buf_len > max_buf_len) {
-                buf_len = max_buf_len;
-            }
             nodeConfig.Init.BufferTransferLength = buf_len;
 
             if (HAL_MDMA_LinkedList_CreateNode(&node, &nodeConfig) != HAL_OK) {
                 ErrorHandler("Error creating linked list in MDMA");
             }
+
+            // HAL_MDMA_LinkedList_CreateNode only sets the request field in CTBR;
+            // bus routing bits must be set explicitly for TCM addresses.
+            if (src_is_tcm)
+                SET_BIT(node.CTBR, MDMA_CTBR_SBUS);
+            if (dst_is_tcm)
+                SET_BIT(node.CTBR, MDMA_CTBR_DBUS);
         }
     };
 


### PR DESCRIPTION
If you tried to do a transfer of a double or a struct of size >= 8 bytes that happened to be aligned to 8 bytes, and be in TCM memory, the MDMA transfer failed because the bus that connects it to TCM memory is only 32-bit wide.