### PR TITLE
Hotfix/sched register b4 start

### DIFF
--- a/Inc/HALAL/Models/TimerDomain/TimerDomain.hpp
+++ b/Inc/HALAL/Models/TimerDomain/TimerDomain.hpp
@@ -27,7 +27,8 @@
 #error Scheduler timer must be a 32 bit timer
 #endif
 extern TIM_TypeDef* Scheduler_global_timer;
-void scheduler_global_timer_callback(void *raw);
+void Scheduler_global_timer_callback(void *raw);
+void Scheduler_start(void);
 
 // NOTE: only works for static arrays
 #define ARRAY_LENGTH(a) (sizeof(a) / sizeof(*a))
@@ -677,9 +678,9 @@ TimerXList
 
             static void init(std::span<const Config, N> cfgs) {
                 Scheduler_global_timer = cmsis_timers[timer_idxmap[SCHEDULER_TIMER_DOMAIN]];
-                callbacks[ST_LIB::timer_idxmap[SCHEDULER_TIMER_DOMAIN]] = scheduler_global_timer_callback;
+                callbacks[ST_LIB::timer_idxmap[SCHEDULER_TIMER_DOMAIN]] = Scheduler_global_timer_callback;
                 rcc_enable_timer(Scheduler_global_timer);
-                Scheduler::start();
+                Scheduler_start();
 
                 for (std::size_t i = 0; i < N; i++) {
                     const Config& e = cfgs[i];

--- a/Inc/HALAL/Models/TimerDomain/TimerDomain.hpp
+++ b/Inc/HALAL/Models/TimerDomain/TimerDomain.hpp
@@ -678,7 +678,8 @@ TimerXList
 
             static void init(std::span<const Config, N> cfgs) {
                 Scheduler_global_timer = cmsis_timers[timer_idxmap[SCHEDULER_TIMER_DOMAIN]];
-                callbacks[ST_LIB::timer_idxmap[SCHEDULER_TIMER_DOMAIN]] = Scheduler_global_timer_callback;
+                callbacks[ST_LIB::timer_idxmap[SCHEDULER_TIMER_DOMAIN]] = 
+                    Scheduler_global_timer_callback;
                 rcc_enable_timer(Scheduler_global_timer);
                 Scheduler_start();
 

--- a/Inc/HALAL/Models/TimerDomain/TimerDomain.hpp
+++ b/Inc/HALAL/Models/TimerDomain/TimerDomain.hpp
@@ -678,7 +678,7 @@ TimerXList
 
             static void init(std::span<const Config, N> cfgs) {
                 Scheduler_global_timer = cmsis_timers[timer_idxmap[SCHEDULER_TIMER_DOMAIN]];
-                callbacks[ST_LIB::timer_idxmap[SCHEDULER_TIMER_DOMAIN]] = 
+                callbacks[ST_LIB::timer_idxmap[SCHEDULER_TIMER_DOMAIN]] =
                     Scheduler_global_timer_callback;
                 rcc_enable_timer(Scheduler_global_timer);
                 Scheduler_start();

--- a/Inc/HALAL/Models/TimerDomain/TimerDomain.hpp
+++ b/Inc/HALAL/Models/TimerDomain/TimerDomain.hpp
@@ -27,6 +27,7 @@
 #error Scheduler timer must be a 32 bit timer
 #endif
 extern TIM_TypeDef* Scheduler_global_timer;
+void scheduler_global_timer_callback(void *raw);
 
 // NOTE: only works for static arrays
 #define ARRAY_LENGTH(a) (sizeof(a) / sizeof(*a))
@@ -676,7 +677,9 @@ TimerXList
 
             static void init(std::span<const Config, N> cfgs) {
                 Scheduler_global_timer = cmsis_timers[timer_idxmap[SCHEDULER_TIMER_DOMAIN]];
+                callbacks[ST_LIB::timer_idxmap[SCHEDULER_TIMER_DOMAIN]] = scheduler_global_timer_callback;
                 rcc_enable_timer(Scheduler_global_timer);
+                Scheduler::start();
 
                 for (std::size_t i = 0; i < N; i++) {
                     const Config& e = cfgs[i];

--- a/Inc/HALAL/Models/TimerDomain/TimerDomain.hpp
+++ b/Inc/HALAL/Models/TimerDomain/TimerDomain.hpp
@@ -27,7 +27,7 @@
 #error Scheduler timer must be a 32 bit timer
 #endif
 extern TIM_TypeDef* Scheduler_global_timer;
-void Scheduler_global_timer_callback(void *raw);
+void Scheduler_global_timer_callback(void* raw);
 void Scheduler_start(void);
 
 // NOTE: only works for static arrays

--- a/Inc/HALAL/Services/Time/Scheduler.hpp
+++ b/Inc/HALAL/Services/Time/Scheduler.hpp
@@ -31,8 +31,7 @@ struct Scheduler {
     static constexpr uint32_t INVALID_ID = 2 * kMaxTasks;
 
     // temporary, will be removed
-    [[deprecated]]
-    static inline void start() {}
+    [[deprecated]] static inline void start() {}
     static void update();
     static inline uint64_t get_global_tick() {
         return global_tick_us_ + Scheduler_global_timer->CNT;

--- a/Inc/HALAL/Services/Time/Scheduler.hpp
+++ b/Inc/HALAL/Services/Time/Scheduler.hpp
@@ -20,7 +20,7 @@
 #endif
 
 extern TIM_TypeDef* Scheduler_global_timer;
-void Scheduler_global_timer_callback(void *raw);
+void Scheduler_global_timer_callback(void* raw);
 void Scheduler_start(void);
 
 struct Scheduler {

--- a/Inc/HALAL/Services/Time/Scheduler.hpp
+++ b/Inc/HALAL/Services/Time/Scheduler.hpp
@@ -31,6 +31,7 @@ struct Scheduler {
     static constexpr uint32_t INVALID_ID = 2 * kMaxTasks;
 
     // temporary, will be removed
+    [[deprecated]]
     static inline void start() {}
     static void update();
     static inline uint64_t get_global_tick() {

--- a/Inc/HALAL/Services/Time/Scheduler.hpp
+++ b/Inc/HALAL/Services/Time/Scheduler.hpp
@@ -20,7 +20,8 @@
 #endif
 
 extern TIM_TypeDef* Scheduler_global_timer;
-void scheduler_global_timer_callback(void *raw);
+void Scheduler_global_timer_callback(void *raw);
+void Scheduler_start(void);
 
 struct Scheduler {
     using callback_t = void (*)();
@@ -29,7 +30,8 @@ struct Scheduler {
     // if it isn't it could theoretically be used as an id in set_timeout
     static constexpr uint32_t INVALID_ID = 2 * kMaxTasks;
 
-    static void start();
+    // temporary, will be removed
+    static inline void start() {}
     static void update();
     static inline uint64_t get_global_tick() {
         return global_tick_us_ + Scheduler_global_timer->CNT;
@@ -43,6 +45,8 @@ struct Scheduler {
 
     // internal
     static void on_timer_update();
+    static void schedule_next_interval();
+    static constexpr uint32_t FREQUENCY = 1'000'000u; // 1 MHz -> 1us precision
 #ifndef SIM_ON
 private:
 #endif
@@ -61,7 +65,6 @@ private:
     static_assert(INVALID_ID >= kMaxTasks, "INVALID_ID must not be a possible task id");
 
     static_assert((kMaxTasks & (kMaxTasks - 1)) == 0, "kMaxTasks must be a power of two");
-    static constexpr uint32_t FREQUENCY = 1'000'000u; // 1 MHz -> 1us precision
 
     static std::array<Task, kMaxTasks> tasks_;
     static_assert(
@@ -87,8 +90,6 @@ private:
     static inline void release_slot(uint8_t id);
     static void insert_sorted(uint8_t id);
     static void remove_sorted(uint8_t id);
-    static void schedule_next_interval();
-    static inline void configure_timer_for_interval(uint32_t microseconds);
 
     // helpers
     static inline uint8_t get_at(uint8_t idx);

--- a/Inc/HALAL/Services/Time/Scheduler.hpp
+++ b/Inc/HALAL/Services/Time/Scheduler.hpp
@@ -20,6 +20,7 @@
 #endif
 
 extern TIM_TypeDef* Scheduler_global_timer;
+void scheduler_global_timer_callback(void *raw);
 
 struct Scheduler {
     using callback_t = void (*)();

--- a/Src/HALAL/Services/Time/Scheduler.cpp
+++ b/Src/HALAL/Services/Time/Scheduler.cpp
@@ -70,6 +70,8 @@ void Scheduler::start() {
     static_assert((Scheduler::FREQUENCY % 1'000'000) == 0u, "frequenct must be a multiple of 1MHz");
     Scheduler_global_timer =
         ST_LIB::TimerDomain::cmsis_timers[ST_LIB::timer_idxmap[SCHEDULER_TIMER_DOMAIN]];
+    ST_LIB::TimerDomain::callbacks[ST_LIB::timer_idxmap[static_cast<uint8_t>(SCHEDULER_TIMER_DOMAIN
+    )]] = scheduler_global_timer_callback;
 
     // TODO: change this to use TimerDomain::get_timer_clock()?
     uint32_t prescaler = (SystemCoreClock / Scheduler::FREQUENCY);
@@ -144,9 +146,6 @@ void Scheduler::start() {
     Scheduler_global_timer->DIER |= LL_TIM_DIER_UIE;
     Scheduler_global_timer->CR1 =
         LL_TIM_CLOCKDIVISION_DIV1 | (Scheduler_global_timer->CR1 & ~TIM_CR1_CKD);
-
-    ST_LIB::TimerDomain::callbacks[ST_LIB::timer_idxmap[static_cast<uint8_t>(SCHEDULER_TIMER_DOMAIN
-    )]] = scheduler_global_timer_callback;
 
     Scheduler_global_timer->CNT = 0; /* Clear counter value */
 

--- a/Src/HALAL/Services/Time/Scheduler.cpp
+++ b/Src/HALAL/Services/Time/Scheduler.cpp
@@ -60,18 +60,18 @@ inline void Scheduler::global_timer_enable() {
 }
 
 // ----------------------------
-void scheduler_global_timer_callback(void* raw) {
+void Scheduler_global_timer_callback(void* raw) {
     (void)raw;
     Scheduler::on_timer_update();
 }
 // ----------------------------
 
-void Scheduler::start() {
+void Scheduler_start(void) {
     static_assert((Scheduler::FREQUENCY % 1'000'000) == 0u, "frequenct must be a multiple of 1MHz");
     Scheduler_global_timer =
         ST_LIB::TimerDomain::cmsis_timers[ST_LIB::timer_idxmap[SCHEDULER_TIMER_DOMAIN]];
     ST_LIB::TimerDomain::callbacks[ST_LIB::timer_idxmap[static_cast<uint8_t>(SCHEDULER_TIMER_DOMAIN
-    )]] = scheduler_global_timer_callback;
+    )]] = Scheduler_global_timer_callback;
 
     // TODO: change this to use TimerDomain::get_timer_clock()?
     uint32_t prescaler = (SystemCoreClock / Scheduler::FREQUENCY);

--- a/Tests/StateMachine/state_machine_test.cpp
+++ b/Tests/StateMachine/state_machine_test.cpp
@@ -155,6 +155,8 @@ protected:
         test_nested_machine.get_states()[1].unregister_all_timed_actions();
 
         reset_test_state();
+
+        Scheduler_start();
     }
 };
 
@@ -216,8 +218,6 @@ TEST_F(StateMachineTest, MasterStateChangeExitsNested) {
 TEST_F(StateMachineTest, CyclicActionsRun) {
     test_machine.start();
 
-    Scheduler::start();
-
     tick_scheduler(100);
     tick_scheduler(10000);
 
@@ -242,7 +242,6 @@ static int check_transition_task_count = 0;
 
 TEST_F(StateMachineTest, StressTestWithScheduler) {
     test_machine.start();
-    Scheduler::start();
 
     custom_task_count = 0;
     check_transition_task_count = 0;

--- a/Tests/Time/scheduler_test.cpp
+++ b/Tests/Time/scheduler_test.cpp
@@ -27,6 +27,8 @@ protected:
         TIM2_BASE->SR = 0;
         TIM2_BASE->CR1 = 0;
         TIM2_BASE->DIER = 0;
+
+        Scheduler_start();
     }
 };
 


### PR DESCRIPTION
`Scheduler::start` is now done in `board::init` from `TimerDomain.hpp`