### PR TITLE
fix: RXER pin is now optional in EthernetPin struct

### DIFF
--- a/.changesets/fix_pinset.md
+++ b/.changesets/fix_pinset.md
@@ -1,0 +1,4 @@
+release: patch
+summary: RXER pin for Ethernet is now optional
+
+H11 ethernet doesn't use RXER pin. The RXER pin is now a pointer so it can hold a nullptr. Ethernet constructor now has a std::optional for this pin

--- a/Inc/HALAL/Services/Communication/Ethernet/NewEthernet.hpp
+++ b/Inc/HALAL/Services/Communication/Ethernet/NewEthernet.hpp
@@ -1,17 +1,16 @@
 #pragma once
 
-#include "stm32h7xx_hal.h"
-
 #include "C++Utilities/CppUtils.hpp"
 #include "DigitalOutput2.hpp"
+#include "stm32h7xx_hal.h"
 
 #ifdef STLIB_ETH
+#include "ErrorHandler/ErrorHandler.hpp"
 #include "HALAL/Models/MAC/MAC.hpp"
 #include "HALAL/Services/Communication/Ethernet/LWIP/Ethernet.hpp"
 #include "HALAL/Services/Communication/Ethernet/LWIP/EthernetHelper.hpp"
 #include "HALAL/Services/Communication/Ethernet/LWIP/EthernetNode.hpp"
 #include "HALAL/Services/Communication/SNTP/SNTP.hpp"
-#include "ErrorHandler/ErrorHandler.hpp"
 #include "HALAL/Services/InfoWarning/InfoWarning.hpp"
 extern "C" {
 #include "ethernetif.h"
@@ -35,7 +34,6 @@ extern void compile_error(const char* msg);
 #endif
 
 struct EthernetDomain {
-
     struct EthernetPins {
         const GPIODomain::Pin& MDC;
         const GPIODomain::Pin& REF_CLK;
@@ -43,39 +41,35 @@ struct EthernetDomain {
         const GPIODomain::Pin& CRS_DV;
         const GPIODomain::Pin& RXD0;
         const GPIODomain::Pin& RXD1;
-        const GPIODomain::Pin& RXER;
+        const GPIODomain::Pin* RXER;
         const GPIODomain::Pin& TXD1;
         const GPIODomain::Pin& TX_EN;
         const GPIODomain::Pin& TXD0;
         const GPIODomain::Pin& PHY_RST;
     };
 
-    constexpr static EthernetPins PINSET_H10{
-        .MDC = PC1,
-        .REF_CLK = PA1,
-        .MDIO = PA2,
-        .CRS_DV = PA7,
-        .RXD0 = PC4,
-        .RXD1 = PC5,
-        .RXER = PG2,
-        .TXD1 = PB13,
-        .TX_EN = PG11,
-        .TXD0 = PG13,
-        .PHY_RST = PG0
-    };
-    constexpr static EthernetPins PINSET_H11{
-        .MDC = PC1,
-        .REF_CLK = PA1,
-        .MDIO = PA2,
-        .CRS_DV = PA7,
-        .RXD0 = PC4,
-        .RXD1 = PC5,
-        .RXER = PG2,
-        .TXD1 = PB13,
-        .TX_EN = PB11,
-        .TXD0 = PB12,
-        .PHY_RST = PF14
-    };
+    constexpr static EthernetPins PINSET_H10{.MDC = PC1,
+                                             .REF_CLK = PA1,
+                                             .MDIO = PA2,
+                                             .CRS_DV = PA7,
+                                             .RXD0 = PC4,
+                                             .RXD1 = PC5,
+                                             .RXER = &PG2,
+                                             .TXD1 = PB13,
+                                             .TX_EN = PG11,
+                                             .TXD0 = PG13,
+                                             .PHY_RST = PG0};
+    constexpr static EthernetPins PINSET_H11{.MDC = PC1,
+                                             .REF_CLK = PA1,
+                                             .MDIO = PA2,
+                                             .CRS_DV = PA7,
+                                             .RXD0 = PC4,
+                                             .RXD1 = PC5,
+                                             .RXER = nullptr,
+                                             .TXD1 = PB13,
+                                             .TX_EN = PB11,
+                                             .TXD0 = PB12,
+                                             .PHY_RST = PF14};
 
     struct Entry {
         const char* local_mac;
@@ -93,95 +87,57 @@ struct EthernetDomain {
         EthernetPins pins;
         Entry e;
 
-        std::array<GPIODomain::GPIO, 10> rmii_gpios;
+        std::array<GPIODomain::GPIO, 9> rmii_gpios;
         DigitalOutputDomain::DigitalOutput phy_reset;
+        std::optional<GPIODomain::GPIO> rxer_gpio;
 
-        consteval Ethernet(
-            EthernetPins pins,
-            const char* local_mac,
-            const char* local_ip,
-            const char* subnet_mask = "255.255.0.0",
-            const char* gateway = "192.168.1.1",
-            const char* sntp_server = SNTP::DEFAULT_SERVER_IP
-        )
-            : pins{pins}, e{local_mac, local_ip, subnet_mask, gateway, sntp_server},
-              rmii_gpios{
-                  GPIODomain::GPIO(
-                      pins.MDC,
-                      GPIODomain::OperationMode::ALT_PP,
-                      GPIODomain::Pull::None,
-                      GPIODomain::Speed::VeryHigh,
-                      GPIODomain::AlternateFunction::AF11
-                  ),
-                  GPIODomain::GPIO(
-                      pins.REF_CLK,
-                      GPIODomain::OperationMode::ALT_PP,
-                      GPIODomain::Pull::None,
-                      GPIODomain::Speed::VeryHigh,
-                      GPIODomain::AlternateFunction::AF11
-                  ),
-                  GPIODomain::GPIO(
-                      pins.MDIO,
-                      GPIODomain::OperationMode::ALT_OD,
-                      GPIODomain::Pull::Up,
-                      GPIODomain::Speed::VeryHigh,
-                      GPIODomain::AlternateFunction::AF11
-                  ),
-                  GPIODomain::GPIO(
-                      pins.CRS_DV,
-                      GPIODomain::OperationMode::ALT_PP,
-                      GPIODomain::Pull::None,
-                      GPIODomain::Speed::VeryHigh,
-                      GPIODomain::AlternateFunction::AF11
-                  ),
-                  GPIODomain::GPIO(
-                      pins.RXD0,
-                      GPIODomain::OperationMode::ALT_PP,
-                      GPIODomain::Pull::None,
-                      GPIODomain::Speed::VeryHigh,
-                      GPIODomain::AlternateFunction::AF11
-                  ),
-                  GPIODomain::GPIO(
-                      pins.RXD1,
-                      GPIODomain::OperationMode::ALT_PP,
-                      GPIODomain::Pull::None,
-                      GPIODomain::Speed::VeryHigh,
-                      GPIODomain::AlternateFunction::AF11
-                  ),
-                  GPIODomain::GPIO(
-                      pins.RXER,
-                      GPIODomain::OperationMode::ALT_PP,
-                      GPIODomain::Pull::None,
-                      GPIODomain::Speed::VeryHigh,
-                      GPIODomain::AlternateFunction::AF11
-                  ),
-                  GPIODomain::GPIO(
-                      pins.TXD1,
-                      GPIODomain::OperationMode::ALT_PP,
-                      GPIODomain::Pull::None,
-                      GPIODomain::Speed::VeryHigh,
-                      GPIODomain::AlternateFunction::AF11
-                  ),
-                  GPIODomain::GPIO(
-                      pins.TX_EN,
-                      GPIODomain::OperationMode::ALT_PP,
-                      GPIODomain::Pull::None,
-                      GPIODomain::Speed::VeryHigh,
-                      GPIODomain::AlternateFunction::AF11
-                  ),
-                  GPIODomain::GPIO(
-                      pins.TXD0,
-                      GPIODomain::OperationMode::ALT_PP,
-                      GPIODomain::Pull::None,
-                      GPIODomain::Speed::VeryHigh,
-                      GPIODomain::AlternateFunction::AF11
-                  )
-              },
-              phy_reset{pins.PHY_RST} {}
+        consteval Ethernet(EthernetPins pins, const char* local_mac, const char* local_ip,
+                           const char* subnet_mask = "255.255.0.0",
+                           const char* gateway = "192.168.1.1",
+                           const char* sntp_server = SNTP::DEFAULT_SERVER_IP)
+            : pins{pins},
+              e{local_mac, local_ip, subnet_mask, gateway, sntp_server},
+              rmii_gpios{GPIODomain::GPIO(pins.MDC, GPIODomain::OperationMode::ALT_PP,
+                                          GPIODomain::Pull::None, GPIODomain::Speed::VeryHigh,
+                                          GPIODomain::AlternateFunction::AF11),
+                         GPIODomain::GPIO(pins.REF_CLK, GPIODomain::OperationMode::ALT_PP,
+                                          GPIODomain::Pull::None, GPIODomain::Speed::VeryHigh,
+                                          GPIODomain::AlternateFunction::AF11),
+                         GPIODomain::GPIO(pins.MDIO, GPIODomain::OperationMode::ALT_OD,
+                                          GPIODomain::Pull::Up, GPIODomain::Speed::VeryHigh,
+                                          GPIODomain::AlternateFunction::AF11),
+                         GPIODomain::GPIO(pins.CRS_DV, GPIODomain::OperationMode::ALT_PP,
+                                          GPIODomain::Pull::None, GPIODomain::Speed::VeryHigh,
+                                          GPIODomain::AlternateFunction::AF11),
+                         GPIODomain::GPIO(pins.RXD0, GPIODomain::OperationMode::ALT_PP,
+                                          GPIODomain::Pull::None, GPIODomain::Speed::VeryHigh,
+                                          GPIODomain::AlternateFunction::AF11),
+                         GPIODomain::GPIO(pins.RXD1, GPIODomain::OperationMode::ALT_PP,
+                                          GPIODomain::Pull::None, GPIODomain::Speed::VeryHigh,
+                                          GPIODomain::AlternateFunction::AF11),
+                         GPIODomain::GPIO(pins.TXD1, GPIODomain::OperationMode::ALT_PP,
+                                          GPIODomain::Pull::None, GPIODomain::Speed::VeryHigh,
+                                          GPIODomain::AlternateFunction::AF11),
+                         GPIODomain::GPIO(pins.TX_EN, GPIODomain::OperationMode::ALT_PP,
+                                          GPIODomain::Pull::None, GPIODomain::Speed::VeryHigh,
+                                          GPIODomain::AlternateFunction::AF11),
+                         GPIODomain::GPIO(pins.TXD0, GPIODomain::OperationMode::ALT_PP,
+                                          GPIODomain::Pull::None, GPIODomain::Speed::VeryHigh,
+                                          GPIODomain::AlternateFunction::AF11)},
+              phy_reset{pins.PHY_RST},
+              rxer_gpio{pins.RXER ? std::optional<GPIODomain::GPIO>{GPIODomain::GPIO(
+                                        *pins.RXER, GPIODomain::OperationMode::ALT_PP,
+                                        GPIODomain::Pull::None, GPIODomain::Speed::VeryHigh,
+                                        GPIODomain::AlternateFunction::AF11)}
+                                  : std::nullopt} {}
 
-        template <class Ctx> consteval std::size_t inscribe(Ctx& ctx) const {
+        template <class Ctx>
+        consteval std::size_t inscribe(Ctx& ctx) const {
             for (const auto& gpio : rmii_gpios) {
                 gpio.inscribe(ctx);
+            }
+            if (rxer_gpio.has_value()) {
+                rxer_gpio->inscribe(ctx);
             }
 
             const auto phy_reset_id = phy_reset.inscribe(ctx);
@@ -210,7 +166,8 @@ struct EthernetDomain {
         size_t phy_reset_id;
     };
 
-    template <size_t N> static consteval array<Config, N> build(span<const Entry> config) {
+    template <size_t N>
+    static consteval array<Config, N> build(span<const Entry> config) {
         array<Config, N> cfgs{};
         static_assert(N <= max_instances, "EthernetDomain supports at most one instance");
         if constexpr (N == 0) {
@@ -255,13 +212,12 @@ struct EthernetDomain {
         };
     };
 
-    template <std::size_t N> struct Init {
+    template <std::size_t N>
+    struct Init {
         static inline std::array<Instance, N> instances{};
 
-        static void init(
-            std::span<const Config, N> cfgs,
-            std::span<DigitalOutputDomain::Instance> do_instances
-        ) {
+        static void init(std::span<const Config, N> cfgs,
+                         std::span<DigitalOutputDomain::Instance> do_instances) {
             static_assert(N <= max_instances, "EthernetDomain supports at most one instance");
             if constexpr (N == 0) {
                 (void)cfgs;
@@ -273,9 +229,9 @@ struct EthernetDomain {
             /* --- RESET PHY --- */
 #ifndef NUCLEO
             // RESET_N pin low then high
-            do_instances[e.phy_reset_id].turn_off(); // RESET_N = 0
+            do_instances[e.phy_reset_id].turn_off();  // RESET_N = 0
             HAL_Delay(PHY_RESET_LOW_DELAY_MS);
-            do_instances[e.phy_reset_id].turn_on(); // RESET_N = 1
+            do_instances[e.phy_reset_id].turn_on();  // RESET_N = 1
             HAL_Delay(PHY_RESET_HIGH_DELAY_MS);
 #else
             // Nucleo boards typically rely on the PHY's own reset circuitry.
@@ -339,7 +295,7 @@ struct EthernetDomain {
         }
     };
 };
-} // namespace ST_LIB
+}  // namespace ST_LIB
 
 #else
 namespace ST_LIB {
@@ -348,16 +304,16 @@ struct EthernetDomain {
     static constexpr std::size_t max_instances{0};
     struct Entry {};
     struct Config {};
-    template <size_t N> static consteval array<Config, N> build(span<const Entry> config) {
+    template <size_t N>
+    static consteval array<Config, N> build(span<const Entry> config) {
         return {};
     }
     struct Instance {};
-    template <std::size_t N> struct Init {
-        static void init(
-            std::span<const Config, N> cfgs,
-            std::span<DigitalOutputDomain::Instance> do_instances
-        ){};
+    template <std::size_t N>
+    struct Init {
+        static void init(std::span<const Config, N> cfgs,
+                         std::span<DigitalOutputDomain::Instance> do_instances) {};
     };
 };
-} // namespace ST_LIB
-#endif // STLIB_ETH
+}  // namespace ST_LIB
+#endif  // STLIB_ETH

--- a/Inc/HALAL/Services/Communication/Ethernet/NewEthernet.hpp
+++ b/Inc/HALAL/Services/Communication/Ethernet/NewEthernet.hpp
@@ -35,13 +35,15 @@ extern void compile_error(const char* msg);
 
 struct EthernetDomain {
     struct EthernetPins {
+        using OptionalPin = std::optional<reference_wrapper<const GPIODomain::Pin>>;
+
         const GPIODomain::Pin& MDC;
         const GPIODomain::Pin& REF_CLK;
         const GPIODomain::Pin& MDIO;
         const GPIODomain::Pin& CRS_DV;
         const GPIODomain::Pin& RXD0;
         const GPIODomain::Pin& RXD1;
-        const GPIODomain::Pin* RXER;
+        OptionalPin RXER;
         const GPIODomain::Pin& TXD1;
         const GPIODomain::Pin& TX_EN;
         const GPIODomain::Pin& TXD0;
@@ -55,7 +57,7 @@ struct EthernetDomain {
         .CRS_DV = PA7,
         .RXD0 = PC4,
         .RXD1 = PC5,
-        .RXER = &PG2,
+        .RXER = std::cref(PG2),
         .TXD1 = PB13,
         .TX_EN = PG11,
         .TXD0 = PG13,
@@ -68,7 +70,7 @@ struct EthernetDomain {
         .CRS_DV = PA7,
         .RXD0 = PC4,
         .RXD1 = PC5,
-        .RXER = nullptr,
+        .RXER = std::nullopt,
         .TXD1 = PB13,
         .TX_EN = PB11,
         .TXD0 = PB12,
@@ -94,6 +96,22 @@ struct EthernetDomain {
         std::array<GPIODomain::GPIO, 9> rmii_gpios;
         DigitalOutputDomain::DigitalOutput phy_reset;
         std::optional<GPIODomain::GPIO> rxer_gpio;
+
+        static consteval std::optional<GPIODomain::GPIO> make_rxer_gpio(
+            EthernetPins::OptionalPin rxer_pin
+        ) {
+            if (!rxer_pin.has_value()) {
+                return std::nullopt;
+            }
+
+            return GPIODomain::GPIO(
+                rxer_pin->get(),
+                GPIODomain::OperationMode::ALT_PP,
+                GPIODomain::Pull::None,
+                GPIODomain::Speed::VeryHigh,
+                GPIODomain::AlternateFunction::AF11
+            );
+        }
 
         consteval Ethernet(
             EthernetPins pins,
@@ -170,16 +188,7 @@ struct EthernetDomain {
                   )
               },
               phy_reset{pins.PHY_RST},
-              rxer_gpio{
-                  pins.RXER ? std::optional<GPIODomain::GPIO>{GPIODomain::GPIO(
-                                  *pins.RXER,
-                                  GPIODomain::OperationMode::ALT_PP,
-                                  GPIODomain::Pull::None,
-                                  GPIODomain::Speed::VeryHigh,
-                                  GPIODomain::AlternateFunction::AF11
-                              )}
-                            : std::nullopt
-              } {}
+              rxer_gpio{make_rxer_gpio(pins.RXER)} {}
 
         template <class Ctx> consteval std::size_t inscribe(Ctx& ctx) const {
             for (const auto& gpio : rmii_gpios) {

--- a/Inc/HALAL/Services/Communication/Ethernet/NewEthernet.hpp
+++ b/Inc/HALAL/Services/Communication/Ethernet/NewEthernet.hpp
@@ -97,9 +97,8 @@ struct EthernetDomain {
         DigitalOutputDomain::DigitalOutput phy_reset;
         std::optional<GPIODomain::GPIO> rxer_gpio;
 
-        static consteval std::optional<GPIODomain::GPIO> make_rxer_gpio(
-            EthernetPins::OptionalPin rxer_pin
-        ) {
+        static consteval std::optional<GPIODomain::GPIO>
+        make_rxer_gpio(EthernetPins::OptionalPin rxer_pin) {
             if (!rxer_pin.has_value()) {
                 return std::nullopt;
             }
@@ -187,8 +186,7 @@ struct EthernetDomain {
                       GPIODomain::AlternateFunction::AF11
                   )
               },
-              phy_reset{pins.PHY_RST},
-              rxer_gpio{make_rxer_gpio(pins.RXER)} {}
+              phy_reset{pins.PHY_RST}, rxer_gpio{make_rxer_gpio(pins.RXER)} {}
 
         template <class Ctx> consteval std::size_t inscribe(Ctx& ctx) const {
             for (const auto& gpio : rmii_gpios) {

--- a/Inc/HALAL/Services/Communication/Ethernet/NewEthernet.hpp
+++ b/Inc/HALAL/Services/Communication/Ethernet/NewEthernet.hpp
@@ -48,28 +48,32 @@ struct EthernetDomain {
         const GPIODomain::Pin& PHY_RST;
     };
 
-    constexpr static EthernetPins PINSET_H10{.MDC = PC1,
-                                             .REF_CLK = PA1,
-                                             .MDIO = PA2,
-                                             .CRS_DV = PA7,
-                                             .RXD0 = PC4,
-                                             .RXD1 = PC5,
-                                             .RXER = &PG2,
-                                             .TXD1 = PB13,
-                                             .TX_EN = PG11,
-                                             .TXD0 = PG13,
-                                             .PHY_RST = PG0};
-    constexpr static EthernetPins PINSET_H11{.MDC = PC1,
-                                             .REF_CLK = PA1,
-                                             .MDIO = PA2,
-                                             .CRS_DV = PA7,
-                                             .RXD0 = PC4,
-                                             .RXD1 = PC5,
-                                             .RXER = nullptr,
-                                             .TXD1 = PB13,
-                                             .TX_EN = PB11,
-                                             .TXD0 = PB12,
-                                             .PHY_RST = PF14};
+    constexpr static EthernetPins PINSET_H10{
+        .MDC = PC1,
+        .REF_CLK = PA1,
+        .MDIO = PA2,
+        .CRS_DV = PA7,
+        .RXD0 = PC4,
+        .RXD1 = PC5,
+        .RXER = &PG2,
+        .TXD1 = PB13,
+        .TX_EN = PG11,
+        .TXD0 = PG13,
+        .PHY_RST = PG0
+    };
+    constexpr static EthernetPins PINSET_H11{
+        .MDC = PC1,
+        .REF_CLK = PA1,
+        .MDIO = PA2,
+        .CRS_DV = PA7,
+        .RXD0 = PC4,
+        .RXD1 = PC5,
+        .RXER = nullptr,
+        .TXD1 = PB13,
+        .TX_EN = PB11,
+        .TXD0 = PB12,
+        .PHY_RST = PF14
+    };
 
     struct Entry {
         const char* local_mac;
@@ -91,48 +95,93 @@ struct EthernetDomain {
         DigitalOutputDomain::DigitalOutput phy_reset;
         std::optional<GPIODomain::GPIO> rxer_gpio;
 
-        consteval Ethernet(EthernetPins pins, const char* local_mac, const char* local_ip,
-                           const char* subnet_mask = "255.255.0.0",
-                           const char* gateway = "192.168.1.1",
-                           const char* sntp_server = SNTP::DEFAULT_SERVER_IP)
-            : pins{pins},
-              e{local_mac, local_ip, subnet_mask, gateway, sntp_server},
-              rmii_gpios{GPIODomain::GPIO(pins.MDC, GPIODomain::OperationMode::ALT_PP,
-                                          GPIODomain::Pull::None, GPIODomain::Speed::VeryHigh,
-                                          GPIODomain::AlternateFunction::AF11),
-                         GPIODomain::GPIO(pins.REF_CLK, GPIODomain::OperationMode::ALT_PP,
-                                          GPIODomain::Pull::None, GPIODomain::Speed::VeryHigh,
-                                          GPIODomain::AlternateFunction::AF11),
-                         GPIODomain::GPIO(pins.MDIO, GPIODomain::OperationMode::ALT_OD,
-                                          GPIODomain::Pull::Up, GPIODomain::Speed::VeryHigh,
-                                          GPIODomain::AlternateFunction::AF11),
-                         GPIODomain::GPIO(pins.CRS_DV, GPIODomain::OperationMode::ALT_PP,
-                                          GPIODomain::Pull::None, GPIODomain::Speed::VeryHigh,
-                                          GPIODomain::AlternateFunction::AF11),
-                         GPIODomain::GPIO(pins.RXD0, GPIODomain::OperationMode::ALT_PP,
-                                          GPIODomain::Pull::None, GPIODomain::Speed::VeryHigh,
-                                          GPIODomain::AlternateFunction::AF11),
-                         GPIODomain::GPIO(pins.RXD1, GPIODomain::OperationMode::ALT_PP,
-                                          GPIODomain::Pull::None, GPIODomain::Speed::VeryHigh,
-                                          GPIODomain::AlternateFunction::AF11),
-                         GPIODomain::GPIO(pins.TXD1, GPIODomain::OperationMode::ALT_PP,
-                                          GPIODomain::Pull::None, GPIODomain::Speed::VeryHigh,
-                                          GPIODomain::AlternateFunction::AF11),
-                         GPIODomain::GPIO(pins.TX_EN, GPIODomain::OperationMode::ALT_PP,
-                                          GPIODomain::Pull::None, GPIODomain::Speed::VeryHigh,
-                                          GPIODomain::AlternateFunction::AF11),
-                         GPIODomain::GPIO(pins.TXD0, GPIODomain::OperationMode::ALT_PP,
-                                          GPIODomain::Pull::None, GPIODomain::Speed::VeryHigh,
-                                          GPIODomain::AlternateFunction::AF11)},
+        consteval Ethernet(
+            EthernetPins pins,
+            const char* local_mac,
+            const char* local_ip,
+            const char* subnet_mask = "255.255.0.0",
+            const char* gateway = "192.168.1.1",
+            const char* sntp_server = SNTP::DEFAULT_SERVER_IP
+        )
+            : pins{pins}, e{local_mac, local_ip, subnet_mask, gateway, sntp_server},
+              rmii_gpios{
+                  GPIODomain::GPIO(
+                      pins.MDC,
+                      GPIODomain::OperationMode::ALT_PP,
+                      GPIODomain::Pull::None,
+                      GPIODomain::Speed::VeryHigh,
+                      GPIODomain::AlternateFunction::AF11
+                  ),
+                  GPIODomain::GPIO(
+                      pins.REF_CLK,
+                      GPIODomain::OperationMode::ALT_PP,
+                      GPIODomain::Pull::None,
+                      GPIODomain::Speed::VeryHigh,
+                      GPIODomain::AlternateFunction::AF11
+                  ),
+                  GPIODomain::GPIO(
+                      pins.MDIO,
+                      GPIODomain::OperationMode::ALT_OD,
+                      GPIODomain::Pull::Up,
+                      GPIODomain::Speed::VeryHigh,
+                      GPIODomain::AlternateFunction::AF11
+                  ),
+                  GPIODomain::GPIO(
+                      pins.CRS_DV,
+                      GPIODomain::OperationMode::ALT_PP,
+                      GPIODomain::Pull::None,
+                      GPIODomain::Speed::VeryHigh,
+                      GPIODomain::AlternateFunction::AF11
+                  ),
+                  GPIODomain::GPIO(
+                      pins.RXD0,
+                      GPIODomain::OperationMode::ALT_PP,
+                      GPIODomain::Pull::None,
+                      GPIODomain::Speed::VeryHigh,
+                      GPIODomain::AlternateFunction::AF11
+                  ),
+                  GPIODomain::GPIO(
+                      pins.RXD1,
+                      GPIODomain::OperationMode::ALT_PP,
+                      GPIODomain::Pull::None,
+                      GPIODomain::Speed::VeryHigh,
+                      GPIODomain::AlternateFunction::AF11
+                  ),
+                  GPIODomain::GPIO(
+                      pins.TXD1,
+                      GPIODomain::OperationMode::ALT_PP,
+                      GPIODomain::Pull::None,
+                      GPIODomain::Speed::VeryHigh,
+                      GPIODomain::AlternateFunction::AF11
+                  ),
+                  GPIODomain::GPIO(
+                      pins.TX_EN,
+                      GPIODomain::OperationMode::ALT_PP,
+                      GPIODomain::Pull::None,
+                      GPIODomain::Speed::VeryHigh,
+                      GPIODomain::AlternateFunction::AF11
+                  ),
+                  GPIODomain::GPIO(
+                      pins.TXD0,
+                      GPIODomain::OperationMode::ALT_PP,
+                      GPIODomain::Pull::None,
+                      GPIODomain::Speed::VeryHigh,
+                      GPIODomain::AlternateFunction::AF11
+                  )
+              },
               phy_reset{pins.PHY_RST},
-              rxer_gpio{pins.RXER ? std::optional<GPIODomain::GPIO>{GPIODomain::GPIO(
-                                        *pins.RXER, GPIODomain::OperationMode::ALT_PP,
-                                        GPIODomain::Pull::None, GPIODomain::Speed::VeryHigh,
-                                        GPIODomain::AlternateFunction::AF11)}
-                                  : std::nullopt} {}
+              rxer_gpio{
+                  pins.RXER ? std::optional<GPIODomain::GPIO>{GPIODomain::GPIO(
+                                  *pins.RXER,
+                                  GPIODomain::OperationMode::ALT_PP,
+                                  GPIODomain::Pull::None,
+                                  GPIODomain::Speed::VeryHigh,
+                                  GPIODomain::AlternateFunction::AF11
+                              )}
+                            : std::nullopt
+              } {}
 
-        template <class Ctx>
-        consteval std::size_t inscribe(Ctx& ctx) const {
+        template <class Ctx> consteval std::size_t inscribe(Ctx& ctx) const {
             for (const auto& gpio : rmii_gpios) {
                 gpio.inscribe(ctx);
             }
@@ -166,8 +215,7 @@ struct EthernetDomain {
         size_t phy_reset_id;
     };
 
-    template <size_t N>
-    static consteval array<Config, N> build(span<const Entry> config) {
+    template <size_t N> static consteval array<Config, N> build(span<const Entry> config) {
         array<Config, N> cfgs{};
         static_assert(N <= max_instances, "EthernetDomain supports at most one instance");
         if constexpr (N == 0) {
@@ -212,12 +260,13 @@ struct EthernetDomain {
         };
     };
 
-    template <std::size_t N>
-    struct Init {
+    template <std::size_t N> struct Init {
         static inline std::array<Instance, N> instances{};
 
-        static void init(std::span<const Config, N> cfgs,
-                         std::span<DigitalOutputDomain::Instance> do_instances) {
+        static void init(
+            std::span<const Config, N> cfgs,
+            std::span<DigitalOutputDomain::Instance> do_instances
+        ) {
             static_assert(N <= max_instances, "EthernetDomain supports at most one instance");
             if constexpr (N == 0) {
                 (void)cfgs;
@@ -229,9 +278,9 @@ struct EthernetDomain {
             /* --- RESET PHY --- */
 #ifndef NUCLEO
             // RESET_N pin low then high
-            do_instances[e.phy_reset_id].turn_off();  // RESET_N = 0
+            do_instances[e.phy_reset_id].turn_off(); // RESET_N = 0
             HAL_Delay(PHY_RESET_LOW_DELAY_MS);
-            do_instances[e.phy_reset_id].turn_on();  // RESET_N = 1
+            do_instances[e.phy_reset_id].turn_on(); // RESET_N = 1
             HAL_Delay(PHY_RESET_HIGH_DELAY_MS);
 #else
             // Nucleo boards typically rely on the PHY's own reset circuitry.
@@ -295,7 +344,7 @@ struct EthernetDomain {
         }
     };
 };
-}  // namespace ST_LIB
+} // namespace ST_LIB
 
 #else
 namespace ST_LIB {
@@ -304,16 +353,16 @@ struct EthernetDomain {
     static constexpr std::size_t max_instances{0};
     struct Entry {};
     struct Config {};
-    template <size_t N>
-    static consteval array<Config, N> build(span<const Entry> config) {
+    template <size_t N> static consteval array<Config, N> build(span<const Entry> config) {
         return {};
     }
     struct Instance {};
-    template <std::size_t N>
-    struct Init {
-        static void init(std::span<const Config, N> cfgs,
-                         std::span<DigitalOutputDomain::Instance> do_instances) {};
+    template <std::size_t N> struct Init {
+        static void init(
+            std::span<const Config, N> cfgs,
+            std::span<DigitalOutputDomain::Instance> do_instances
+        ){};
     };
 };
-}  // namespace ST_LIB
-#endif  // STLIB_ETH
+} // namespace ST_LIB
+#endif // STLIB_ETH


### PR DESCRIPTION
H11 ethernet doesn't use RXER pin. The RXER pin is now a pointer so it can hold a nullptr. Ethernet constructor now has a std::optional for this pin