### PR TITLE
Hotfix/MPU Part 3

### DIFF
--- a/.changesets/hotfix-mpu-synamic-regions-linker-symbols.md
+++ b/.changesets/hotfix-mpu-synamic-regions-linker-symbols.md
@@ -1,0 +1,2 @@
+release: patch
+summary: MPUDomain dynamic regions were configured using the linker symbol values instead of their addresses (that is the correct way of using linker symbols). That made non-cached regions cached, and caused harware undefined behaviour.

--- a/Inc/HALAL/Models/MPU.hpp
+++ b/Inc/HALAL/Models/MPU.hpp
@@ -310,18 +310,18 @@ struct MPUDomain {
 
             // Dynamic Configuration based on Linker Symbols
             configure_dynamic_region(
-                (uintptr_t)__mpu_d1_nc_start,
-                (uintptr_t)__mpu_d1_nc_end,
+                reinterpret_cast<uintptr_t>(&__mpu_d1_nc_start),
+                reinterpret_cast<uintptr_t>(&__mpu_d1_nc_end),
                 MPU_REGION_NUMBER3
             );
             configure_dynamic_region(
-                (uintptr_t)__mpu_d2_nc_start,
-                (uintptr_t)__mpu_d2_nc_end,
+                reinterpret_cast<uintptr_t>(&__mpu_d2_nc_start),
+                reinterpret_cast<uintptr_t>(&__mpu_d2_nc_end),
                 MPU_REGION_NUMBER5
             );
             configure_dynamic_region(
-                (uintptr_t)__mpu_d3_nc_start,
-                (uintptr_t)__mpu_d3_nc_end,
+                reinterpret_cast<uintptr_t>(&__mpu_d3_nc_start),
+                reinterpret_cast<uintptr_t>(&__mpu_d3_nc_end),
                 MPU_REGION_NUMBER7
             );
 


### PR DESCRIPTION
The MPU dynamic regions (Non-Cached regions) were being configured with linker symbol values instead of addresses, which caused undefined behaviour that even could acouse hardfault.