### PR TITLE
Fix/volatile

### DIFF
--- a/.changesets/fix-volatiles.md
+++ b/.changesets/fix-volatiles.md
@@ -1,0 +1,4 @@
+release: patch
+summary: Fix incorrect usage of non-volatile buffers in peripherals. This wrong usage was causing undefined behaviour, since the compiler could optimize out reads and writes that should have been going directly to memory.
+
+There's a minor API change: now the MPU macros for memory regions include the volatile keyword for the non-cached variants.

--- a/Inc/HALAL/Models/DMA/DMA2.hpp
+++ b/Inc/HALAL/Models/DMA/DMA2.hpp
@@ -475,6 +475,10 @@ struct DMADomain {
     struct Instance {
         DMA_HandleTypeDef dma;
 
+        /**
+         * @warning Ensure SrcAddress and DstAddress are in DMA-accessible memory
+         * @note Compiler may optimize away the reads and writes from Src and Dst, either use voalatile buffers or ensure some kind of memory barrier to preven this
+         */
         void start(uint32_t SrcAddress, uint32_t DstAddress, uint32_t DataLength) {
             HAL_DMA_Start_IT(&dma, SrcAddress, DstAddress, DataLength);
         }

--- a/Inc/HALAL/Models/DMA/DMA2.hpp
+++ b/Inc/HALAL/Models/DMA/DMA2.hpp
@@ -477,7 +477,8 @@ struct DMADomain {
 
         /**
          * @warning Ensure SrcAddress and DstAddress are in DMA-accessible memory
-         * @note Compiler may optimize away the reads and writes from Src and Dst, either use voalatile buffers or ensure some kind of memory barrier to preven this
+         * @note Compiler may optimize away the reads and writes from Src and Dst, either use
+         * voalatile buffers or ensure some kind of memory barrier to preven this
          */
         void start(uint32_t SrcAddress, uint32_t DstAddress, uint32_t DataLength) {
             HAL_DMA_Start_IT(&dma, SrcAddress, DstAddress, DataLength);

--- a/Inc/HALAL/Models/MDMA/MDMA.hpp
+++ b/Inc/HALAL/Models/MDMA/MDMA.hpp
@@ -23,7 +23,8 @@ class MDMA {
 public:
     /**
      * @brief A helper struct to create and manage MDMA linked list nodes.
-     * @note If you don't use volatile values, the compiler may optimize away reads/writes of source and dest addresses. It is planned to make the class add a targetted memory barrier for this
+     * @note If you don't use volatile values, the compiler may optimize away reads/writes of source
+     * and dest addresses. It is planned to make the class add a targetted memory barrier for this
      */
     struct LinkedListNode {
         template <typename T> LinkedListNode(T* source_ptr, void* dest_ptr) {
@@ -243,7 +244,7 @@ private:
         volatile MDMA_LinkNodeTypeDef* transfer_node;
 
         Instance() : handle{}, id(0U), done(nullptr), transfer_node(nullptr) {}
-        
+
         Instance(
             MDMA_HandleTypeDef handle_,
             uint8_t id_,
@@ -260,7 +261,8 @@ private:
 
     inline static std::array<Instance, 8> instances{};
     static std::bitset<8> instance_free_map;
-    inline static Stack<std::pair<volatile MDMA::LinkedListNode*, volatile bool*>, 50> transfer_queue{};
+    inline static Stack<std::pair<volatile MDMA::LinkedListNode*, volatile bool*>, 50>
+        transfer_queue{};
 
     static void TransferCompleteCallback(MDMA_HandleTypeDef* hmdma);
     static void TransferErrorCallback(MDMA_HandleTypeDef* hmdma);
@@ -303,5 +305,6 @@ public:
      * @param check A reference boolean that will be set to true if the transfer was successfully
      * done, false otherwise.
      */
-    static void transfer_list(volatile MDMA::LinkedListNode* first_node, volatile bool* check = nullptr);
+    static void
+    transfer_list(volatile MDMA::LinkedListNode* first_node, volatile bool* check = nullptr);
 };

--- a/Inc/HALAL/Models/MDMA/MDMA.hpp
+++ b/Inc/HALAL/Models/MDMA/MDMA.hpp
@@ -32,11 +32,10 @@ public:
         template <typename T> LinkedListNode(T* source_ptr, void* dest_ptr, size_t size) {
             init_node(source_ptr, dest_ptr, size);
         }
-
-        void set_next(MDMA_LinkNodeTypeDef* next_node) {
+        void set_next(volatile MDMA_LinkNodeTypeDef* next_node) volatile {
             node.CLAR = reinterpret_cast<uint32_t>(next_node);
         }
-        void set_destination(void* destination) {
+        void set_destination(void* destination) volatile {
             uint32_t destination_address = reinterpret_cast<uint32_t>(destination);
             node.CDAR = destination_address;
 
@@ -49,7 +48,7 @@ public:
             }
             reconfigure_ctcr();
         }
-        void set_source(void* source) {
+        void set_source(void* source) volatile {
             uint32_t source_address = reinterpret_cast<uint32_t>(source);
             node.CSAR = source_address;
 
@@ -62,19 +61,19 @@ public:
             }
             reconfigure_ctcr();
         }
-        auto get_node() -> MDMA_LinkNodeTypeDef* { return &node; }
-        auto get_size() -> uint32_t { return node.CBNDTR; }
-        auto get_destination() -> uint32_t { return node.CDAR; }
-        auto get_source() -> uint32_t { return node.CSAR; }
-        auto get_next() -> MDMA_LinkNodeTypeDef* {
-            return reinterpret_cast<MDMA_LinkNodeTypeDef*>(node.CLAR);
+        auto get_node() volatile -> volatile MDMA_LinkNodeTypeDef* { return &node; }
+        auto get_size() const volatile -> uint32_t { return node.CBNDTR; }
+        auto get_destination() const volatile -> uint32_t { return node.CDAR; }
+        auto get_source() const volatile -> uint32_t { return node.CSAR; }
+        auto get_next() const volatile -> volatile MDMA_LinkNodeTypeDef* {
+            return reinterpret_cast<volatile MDMA_LinkNodeTypeDef*>(node.CLAR);
         }
 
     private:
         alignas(8) MDMA_LinkNodeTypeDef node;
         size_t transfer_size{0};
 
-        void reconfigure_ctcr() {
+        void reconfigure_ctcr() volatile {
             const uintptr_t src = node.CSAR;
             const uintptr_t dst = node.CDAR;
             const size_t size = transfer_size;
@@ -240,27 +239,27 @@ private:
         MDMA_HandleTypeDef handle;
         uint8_t id;
         volatile bool* done;
-        MDMA_LinkNodeTypeDef* transfer_node;
+        volatile MDMA_LinkNodeTypeDef* transfer_node;
 
         Instance() : handle{}, id(0U), done(nullptr), transfer_node(nullptr) {}
-
+        
         Instance(
             MDMA_HandleTypeDef handle_,
             uint8_t id_,
             volatile bool* done_,
-            MDMA_LinkNodeTypeDef* transfer_node_
+            volatile MDMA_LinkNodeTypeDef* transfer_node_
         )
             : handle(handle_), id(id_), done(done_), transfer_node(transfer_node_) {}
     };
-    static void prepare_transfer(Instance& instance, MDMA::LinkedListNode* first_node);
-    static void prepare_transfer(Instance& instance, MDMA_LinkNodeTypeDef* first_node);
+    static void prepare_transfer(Instance& instance, volatile MDMA::LinkedListNode* first_node);
+    static void prepare_transfer(Instance& instance, volatile MDMA_LinkNodeTypeDef* first_node);
     static Instance& get_instance(uint8_t id);
     static MDMA_Channel_TypeDef* get_channel(uint8_t id);
     static uint8_t get_instance_id(MDMA_Channel_TypeDef* channel);
 
     inline static std::array<Instance, 8> instances{};
     static std::bitset<8> instance_free_map;
-    inline static Stack<std::pair<MDMA::LinkedListNode*, volatile bool*>, 50> transfer_queue{};
+    inline static Stack<std::pair<volatile MDMA::LinkedListNode*, volatile bool*>, 50> transfer_queue{};
 
     static void TransferCompleteCallback(MDMA_HandleTypeDef* hmdma);
     static void TransferErrorCallback(MDMA_HandleTypeDef* hmdma);
@@ -303,5 +302,5 @@ public:
      * @param check A reference boolean that will be set to true if the transfer was successfully
      * done, false otherwise.
      */
-    static void transfer_list(MDMA::LinkedListNode* first_node, volatile bool* check = nullptr);
+    static void transfer_list(volatile MDMA::LinkedListNode* first_node, volatile bool* check = nullptr);
 };

--- a/Inc/HALAL/Models/MDMA/MDMA.hpp
+++ b/Inc/HALAL/Models/MDMA/MDMA.hpp
@@ -23,6 +23,7 @@ class MDMA {
 public:
     /**
      * @brief A helper struct to create and manage MDMA linked list nodes.
+     * @note If you don't use volatile values, the compiler may optimize away reads/writes of source and dest addresses. It is planned to make the class add a targetted memory barrier for this
      */
     struct LinkedListNode {
         template <typename T> LinkedListNode(T* source_ptr, void* dest_ptr) {

--- a/Inc/HALAL/Models/MPU.hpp
+++ b/Inc/HALAL/Models/MPU.hpp
@@ -63,9 +63,9 @@
 #define D1_NC __attribute__((section(".mpu_ram_d1_nc.user"), used)) volatile
 #define D2_NC __attribute__((section(".mpu_ram_d2_nc.user"), used)) volatile
 #define D3_NC __attribute__((section(".mpu_ram_d3_nc.user"), used)) volatile
-#define D1_C  __attribute__((section(".ram_d1.user"), used))
-#define D2_C  __attribute__((section(".ram_d2.user"), used))
-#define D3_C  __attribute__((section(".ram_d3.user"), used))
+#define D1_C __attribute__((section(".ram_d1.user"), used))
+#define D2_C __attribute__((section(".ram_d2.user"), used))
+#define D3_C __attribute__((section(".ram_d3.user"), used))
 #endif
 
 // Memory Bank Symbols from Linker
@@ -278,7 +278,10 @@ struct MPUDomain {
             using Request = std::remove_cvref_t<decltype(Target)>;
             static_assert(mpu_buffer_request<Request>, "Target must be a valid MPUDomain buffer");
             constexpr bool is_nc = Request::e.memory_type == MemoryType::NonCached;
-            static_assert(is_nc && std::is_volatile_v<typename Request::buffer_type>, "Non cached buffers must be volatile to work as intended");
+            static_assert(
+                is_nc && std::is_volatile_v<typename Request::buffer_type>,
+                "Non cached buffers must be volatile to work as intended"
+            );
             using T = typename Request::buffer_type;
             return *new (ptr) T(std::forward<Args>(args)...);
         }
@@ -287,7 +290,10 @@ struct MPUDomain {
             using Request = std::remove_cvref_t<decltype(Target)>;
             static_assert(mpu_buffer_request<Request>, "Target must be a valid MPUDomain buffer");
             constexpr bool is_nc = Request::e.memory_type == MemoryType::NonCached;
-            static_assert(is_nc && std::is_volatile_v<typename Request::buffer_type>, "Non cached buffers must be volatile to work as intended"); 
+            static_assert(
+                is_nc && std::is_volatile_v<typename Request::buffer_type>,
+                "Non cached buffers must be volatile to work as intended"
+            );
             using T = typename Request::buffer_type;
             return static_cast<T*>(ptr);
         }
@@ -310,18 +316,18 @@ struct MPUDomain {
         static constexpr auto Sizes = calculate_total_sizes(cfgs);
 
         // Sections defined in Linker Script (aligned to 32 bytes just in case)
-        __attribute__((section(".mpu_ram_d1_nc.buffer"))) alignas(32
-        ) static inline volatile uint8_t d1_nc_buffer[Sizes.d1_nc_total > 0 ? Sizes.d1_nc_total : 1];
+        __attribute__((section(".mpu_ram_d1_nc.buffer"))) alignas(32) static inline volatile uint8_t
+            d1_nc_buffer[Sizes.d1_nc_total > 0 ? Sizes.d1_nc_total : 1];
         __attribute__((section(".ram_d1.buffer"))) alignas(32
         ) static inline uint8_t d1_c_buffer[Sizes.d1_c_total > 0 ? Sizes.d1_c_total : 1];
 
-        __attribute__((section(".mpu_ram_d2_nc.buffer"))) alignas(32
-        ) static inline volatile uint8_t d2_nc_buffer[Sizes.d2_nc_total > 0 ? Sizes.d2_nc_total : 1];
+        __attribute__((section(".mpu_ram_d2_nc.buffer"))) alignas(32) static inline volatile uint8_t
+            d2_nc_buffer[Sizes.d2_nc_total > 0 ? Sizes.d2_nc_total : 1];
         __attribute__((section(".ram_d2.buffer"))) alignas(32
         ) static inline uint8_t d2_c_buffer[Sizes.d2_c_total > 0 ? Sizes.d2_c_total : 1];
 
-        __attribute__((section(".mpu_ram_d3_nc.buffer"))) alignas(32
-        ) static inline volatile uint8_t d3_nc_buffer[Sizes.d3_nc_total > 0 ? Sizes.d3_nc_total : 1];
+        __attribute__((section(".mpu_ram_d3_nc.buffer"))) alignas(32) static inline volatile uint8_t
+            d3_nc_buffer[Sizes.d3_nc_total > 0 ? Sizes.d3_nc_total : 1];
         __attribute__((section(".ram_d3.buffer"))) alignas(32
         ) static inline uint8_t d3_c_buffer[Sizes.d3_c_total > 0 ? Sizes.d3_c_total : 1];
 

--- a/Inc/HALAL/Models/MPU.hpp
+++ b/Inc/HALAL/Models/MPU.hpp
@@ -44,15 +44,29 @@
 // Defines for attributes
 // Note1: Variables declared with these attributes will likely not be initialized by the startup
 // Note2: These attributes can only be used for static/global variables
-#define D1_NC __attribute__((section(".mpu_ram_d1_nc.user")))
-#define D2_NC __attribute__((section(".mpu_ram_d2_nc.user")))
-#define D3_NC __attribute__((section(".mpu_ram_d3_nc.user")))
-#define D1_C __attribute__((section(".ram_d1.user")))
-#define D2_C __attribute__((section(".ram_d2.user")))
-#define D3_C __attribute__((section(".ram_d3.user")))
-
-// Define for RAM code
+#ifdef SIM_ON
+#define D1_NC
+#define D2_NC
+#define D3_NC
+#define D1_C
+#define D2_C
+#define D3_C
+#define RAM_CODE
+#else
+/*
+ * Use C++ attribute syntax when compiled as C++, otherwise fall back to GCC-style
+ * `__attribute__` so the header is safe to include from both C and C++ translation
+ * units (some build units may be plain C and would reject the [[...]] syntax).
+ */
 #define RAM_CODE __attribute__((section(".ram_code")))
+
+#define D1_NC __attribute__((section(".mpu_ram_d1_nc.user"), used)) volatile
+#define D2_NC __attribute__((section(".mpu_ram_d2_nc.user"), used)) volatile
+#define D3_NC __attribute__((section(".mpu_ram_d3_nc.user"), used)) volatile
+#define D1_C  __attribute__((section(".ram_d1.user"), used))
+#define D2_C  __attribute__((section(".ram_d2.user"), used))
+#define D3_C  __attribute__((section(".ram_d3.user"), used))
+#endif
 
 // Memory Bank Symbols from Linker
 extern "C" const char __itcm_base;
@@ -260,14 +274,21 @@ struct MPUDomain {
         void* ptr;
         std::size_t size;
 
-        template <mpu_buffer_request auto& Target, typename... Args>
-        auto& construct(Args&&... args) {
-            using T = typename std::remove_cvref_t<decltype(Target)>::buffer_type;
+        template <auto& Target, typename... Args> auto& construct(Args&&... args) {
+            using Request = std::remove_cvref_t<decltype(Target)>;
+            static_assert(mpu_buffer_request<Request>, "Target must be a valid MPUDomain buffer");
+            constexpr bool is_nc = Request::e.memory_type == MemoryType::NonCached;
+            static_assert(is_nc && std::is_volatile_v<typename Request::buffer_type>, "Non cached buffers must be volatile to work as intended");
+            using T = typename Request::buffer_type;
             return *new (ptr) T(std::forward<Args>(args)...);
         }
 
-        template <mpu_buffer_request auto& Target> auto* as() {
-            using T = typename std::remove_cvref_t<decltype(Target)>::buffer_type;
+        template <auto& Target> auto* as() {
+            using Request = std::remove_cvref_t<decltype(Target)>;
+            static_assert(mpu_buffer_request<Request>, "Target must be a valid MPUDomain buffer");
+            constexpr bool is_nc = Request::e.memory_type == MemoryType::NonCached;
+            static_assert(is_nc && std::is_volatile_v<typename Request::buffer_type>, "Non cached buffers must be volatile to work as intended"); 
+            using T = typename Request::buffer_type;
             return static_cast<T*>(ptr);
         }
     };
@@ -290,17 +311,17 @@ struct MPUDomain {
 
         // Sections defined in Linker Script (aligned to 32 bytes just in case)
         __attribute__((section(".mpu_ram_d1_nc.buffer"))) alignas(32
-        ) static inline uint8_t d1_nc_buffer[Sizes.d1_nc_total > 0 ? Sizes.d1_nc_total : 1];
+        ) static inline volatile uint8_t d1_nc_buffer[Sizes.d1_nc_total > 0 ? Sizes.d1_nc_total : 1];
         __attribute__((section(".ram_d1.buffer"))) alignas(32
         ) static inline uint8_t d1_c_buffer[Sizes.d1_c_total > 0 ? Sizes.d1_c_total : 1];
 
         __attribute__((section(".mpu_ram_d2_nc.buffer"))) alignas(32
-        ) static inline uint8_t d2_nc_buffer[Sizes.d2_nc_total > 0 ? Sizes.d2_nc_total : 1];
+        ) static inline volatile uint8_t d2_nc_buffer[Sizes.d2_nc_total > 0 ? Sizes.d2_nc_total : 1];
         __attribute__((section(".ram_d2.buffer"))) alignas(32
         ) static inline uint8_t d2_c_buffer[Sizes.d2_c_total > 0 ? Sizes.d2_c_total : 1];
 
         __attribute__((section(".mpu_ram_d3_nc.buffer"))) alignas(32
-        ) static inline uint8_t d3_nc_buffer[Sizes.d3_nc_total > 0 ? Sizes.d3_nc_total : 1];
+        ) static inline volatile uint8_t d3_nc_buffer[Sizes.d3_nc_total > 0 ? Sizes.d3_nc_total : 1];
         __attribute__((section(".ram_d3.buffer"))) alignas(32
         ) static inline uint8_t d3_c_buffer[Sizes.d3_c_total > 0 ? Sizes.d3_c_total : 1];
 
@@ -326,7 +347,7 @@ struct MPUDomain {
             );
 
             // Assign pointers
-            uint8_t* bases_nc[3] = {&d1_nc_buffer[0], &d2_nc_buffer[0], &d3_nc_buffer[0]};
+            volatile uint8_t* bases_nc[3] = {&d1_nc_buffer[0], &d2_nc_buffer[0], &d3_nc_buffer[0]};
             uint8_t* bases_c[3] = {&d1_c_buffer[0], &d2_c_buffer[0], &d3_c_buffer[0]};
 
             for (std::size_t i = 0; i < N; i++) {
@@ -338,7 +359,7 @@ struct MPUDomain {
                     size_t d_idx = static_cast<size_t>(cfg.domain) - 1;
 
                     if (cfg.type == MemoryType::NonCached) {
-                        inst.ptr = bases_nc[d_idx] + cfg.offset;
+                        inst.ptr = const_cast<uint8_t*>(bases_nc[d_idx] + cfg.offset);
                     } else {
                         inst.ptr = bases_c[d_idx] + cfg.offset;
                     }

--- a/Inc/HALAL/Models/MPUManager/MPUManager.hpp
+++ b/Inc/HALAL/Models/MPUManager/MPUManager.hpp
@@ -8,7 +8,8 @@
 class MPUManager {
 public:
     static volatile void* allocate_non_cached_memory(uint32_t size) {
-        volatile void* buffer = (void*)((uint8_t*)no_cached_ram_start + no_cached_ram_occupied_bytes);
+        volatile void* buffer =
+            (void*)((uint8_t*)no_cached_ram_start + no_cached_ram_occupied_bytes);
         no_cached_ram_occupied_bytes = no_cached_ram_occupied_bytes + size;
         if (no_cached_ram_occupied_bytes > NO_CACHED_RAM_MAXIMUM_SPACE) {
             uint32_t excess_bytes = no_cached_ram_occupied_bytes - NO_CACHED_RAM_MAXIMUM_SPACE;

--- a/Inc/HALAL/Models/MPUManager/MPUManager.hpp
+++ b/Inc/HALAL/Models/MPUManager/MPUManager.hpp
@@ -7,8 +7,8 @@
 
 class MPUManager {
 public:
-    static void* allocate_non_cached_memory(uint32_t size) {
-        void* buffer = (void*)((uint8_t*)no_cached_ram_start + no_cached_ram_occupied_bytes);
+    static volatile void* allocate_non_cached_memory(uint32_t size) {
+        volatile void* buffer = (void*)((uint8_t*)no_cached_ram_start + no_cached_ram_occupied_bytes);
         no_cached_ram_occupied_bytes = no_cached_ram_occupied_bytes + size;
         if (no_cached_ram_occupied_bytes > NO_CACHED_RAM_MAXIMUM_SPACE) {
             uint32_t excess_bytes = no_cached_ram_occupied_bytes - NO_CACHED_RAM_MAXIMUM_SPACE;
@@ -19,7 +19,7 @@ public:
     }
 
 private:
-    static void* no_cached_ram_start;
+    static volatile void* no_cached_ram_start;
     static uint32_t no_cached_ram_occupied_bytes;
 };
 

--- a/Inc/HALAL/Models/SPI/SPI2.hpp
+++ b/Inc/HALAL/Models/SPI/SPI2.hpp
@@ -559,7 +559,8 @@ struct SPIDomain {
 
     /**
      * @brief SPI Wrapper for Master mode operations.
-     * @warning DMA operations may be optimized away by the compiler, you should either use volatile buffers or add some kind of memory barrier after DMA operations to ensure data integrity.
+     * @warning DMA operations may be optimized away by the compiler, you should either use volatile
+     * buffers or add some kind of memory barrier after DMA operations to ensure data integrity.
      */
     template <auto& device_request> struct SPIWrapper<device_request, true> {
         static constexpr uint32_t data_bits =
@@ -725,7 +726,8 @@ struct SPIDomain {
             using rx_element_type = std::remove_volatile_t<T>;
             auto error_code = HAL_SPI_TransmitReceive(
                 &spi_instance.hspi,
-                reinterpret_cast<const uint8_t*>(const_cast<const tx_element_type*>(tx_data.data())),
+                reinterpret_cast<const uint8_t*>(const_cast<const tx_element_type*>(tx_data.data())
+                ),
                 reinterpret_cast<uint8_t*>(const_cast<rx_element_type*>(&rx_data)),
                 size / frame_size,
                 10
@@ -766,8 +768,7 @@ struct SPIDomain {
          */
         template <typename T1, typename T2>
         bool transceive(const T1& tx_data, T2& rx_data)
-            requires(std::is_trivially_copyable_v<std::remove_volatile_t<T1>> && 
-                     std::is_trivially_copyable_v<std::remove_volatile_t<T2>>)
+            requires(std::is_trivially_copyable_v<std::remove_volatile_t<T1>> && std::is_trivially_copyable_v<std::remove_volatile_t<T2>>)
         {
             using tx_element_type = std::remove_volatile_t<T1>;
             using rx_element_type = std::remove_volatile_t<T2>;
@@ -914,7 +915,8 @@ struct SPIDomain {
             using rx_element_type = std::remove_volatile_t<E2>;
             auto error_code = HAL_SPI_TransmitReceive_DMA(
                 &spi_instance.hspi,
-                reinterpret_cast<const uint8_t*>(const_cast<const tx_element_type*>(tx_data.data())),
+                reinterpret_cast<const uint8_t*>(const_cast<const tx_element_type*>(tx_data.data())
+                ),
                 reinterpret_cast<uint8_t*>(const_cast<rx_element_type*>(rx_data.data())),
                 size / frame_size
             );
@@ -943,7 +945,8 @@ struct SPIDomain {
             using rx_element_type = std::remove_volatile_t<T>;
             auto error_code = HAL_SPI_TransmitReceive_DMA(
                 &spi_instance.hspi,
-                reinterpret_cast<const uint8_t*>(const_cast<const tx_element_type*>(tx_data.data())),
+                reinterpret_cast<const uint8_t*>(const_cast<const tx_element_type*>(tx_data.data())
+                ),
                 reinterpret_cast<uint8_t*>(const_cast<rx_element_type*>(&rx_data)),
                 size / frame_size
             );
@@ -989,8 +992,7 @@ struct SPIDomain {
          */
         template <typename T1, typename T2>
         bool transceive_DMA(const T1& tx_data, T2& rx_data, volatile bool* operation_flag = nullptr)
-            requires(std::is_trivially_copyable_v<std::remove_volatile_t<T1>> && 
-                     std::is_trivially_copyable_v<std::remove_volatile_t<T2>>)
+            requires(std::is_trivially_copyable_v<std::remove_volatile_t<T1>> && std::is_trivially_copyable_v<std::remove_volatile_t<T2>>)
         {
             using tx_element_type = std::remove_volatile_t<T1>;
             using rx_element_type = std::remove_volatile_t<T2>;
@@ -1029,7 +1031,8 @@ struct SPIDomain {
 
     /**
      * @brief SPI Wrapper for Slave mode operations. Doesn't allow for blocking operations.
-     * @warning DMA operations may be optimized away by the compiler, you should either use volatile buffers or add some kind of memory barrier after DMA operations to ensure data integrity.
+     * @warning DMA operations may be optimized away by the compiler, you should either use volatile
+     * buffers or add some kind of memory barrier after DMA operations to ensure data integrity.
      */
     template <auto& device_request> struct SPIWrapper<device_request, false> {
         static constexpr uint32_t data_bits =
@@ -1192,7 +1195,8 @@ struct SPIDomain {
             using rx_element_type = std::remove_volatile_t<E2>;
             auto error_code = HAL_SPI_TransmitReceive_DMA(
                 &spi_instance.hspi,
-                reinterpret_cast<const uint8_t*>(const_cast<const tx_element_type*>(tx_data.data())),
+                reinterpret_cast<const uint8_t*>(const_cast<const tx_element_type*>(tx_data.data())
+                ),
                 reinterpret_cast<uint8_t*>(const_cast<rx_element_type*>(rx_data.data())),
                 size / frame_size
             );
@@ -1221,7 +1225,8 @@ struct SPIDomain {
             using rx_element_type = std::remove_volatile_t<T>;
             auto error_code = HAL_SPI_TransmitReceive_DMA(
                 &spi_instance.hspi,
-                reinterpret_cast<const uint8_t*>(const_cast<const tx_element_type*>(tx_data.data())),
+                reinterpret_cast<const uint8_t*>(const_cast<const tx_element_type*>(tx_data.data())
+                ),
                 reinterpret_cast<uint8_t*>(const_cast<rx_element_type*>(&rx_data)),
                 size / frame_size
             );
@@ -1264,8 +1269,7 @@ struct SPIDomain {
          */
         template <typename T1, typename T2>
         bool transceive(const T1& tx_data, T2& rx_data, volatile bool* operation_flag = nullptr)
-            requires(std::is_trivially_copyable_v<std::remove_volatile_t<T1>> && 
-                     std::is_trivially_copyable_v<std::remove_volatile_t<T2>>)
+            requires(std::is_trivially_copyable_v<std::remove_volatile_t<T1>> && std::is_trivially_copyable_v<std::remove_volatile_t<T2>>)
         {
             using tx_element_type = std::remove_volatile_t<T1>;
             using rx_element_type = std::remove_volatile_t<T2>;

--- a/Inc/HALAL/Models/SPI/SPI2.hpp
+++ b/Inc/HALAL/Models/SPI/SPI2.hpp
@@ -559,6 +559,7 @@ struct SPIDomain {
 
     /**
      * @brief SPI Wrapper for Master mode operations.
+     * @warning DMA operations may be optimized away by the compiler, you should either use volatile buffers or add some kind of memory barrier after DMA operations to ensure data integrity.
      */
     template <auto& device_request> struct SPIWrapper<device_request, true> {
         static constexpr uint32_t data_bits =
@@ -596,9 +597,10 @@ struct SPIDomain {
                 );
                 return false;
             }
+            using element_type = std::remove_volatile_t<E>;
             auto error_code = HAL_SPI_Transmit(
                 &spi_instance.hspi,
-                (uint8_t*)data.data(),
+                reinterpret_cast<const uint8_t*>(const_cast<const element_type*>(data.data())),
                 data.size_bytes() / frame_size,
                 10
             );
@@ -610,20 +612,21 @@ struct SPIDomain {
          */
         template <typename T>
         bool send(const T& data)
-            requires std::is_trivially_copyable_v<T>
+            requires std::is_trivially_copyable_v<std::remove_volatile_t<T>>
         {
-            if (sizeof(T) % frame_size != 0) {
+            using element_type = std::remove_volatile_t<T>;
+            if (sizeof(element_type) % frame_size != 0) {
                 ErrorHandler(
                     "SPI data type size (%d) not aligned to frame size (%d)",
-                    sizeof(T),
+                    sizeof(element_type),
                     frame_size
                 );
                 return false;
             }
             auto error_code = HAL_SPI_Transmit(
                 &spi_instance.hspi,
-                reinterpret_cast<const uint8_t*>(&data),
-                sizeof(T) / frame_size,
+                reinterpret_cast<const uint8_t*>(const_cast<const element_type*>(&data)),
+                sizeof(element_type) / frame_size,
                 10
             );
             return check_error_code(error_code);
@@ -641,9 +644,10 @@ struct SPIDomain {
                 );
                 return false;
             }
+            using element_type = std::remove_volatile_t<E>;
             auto error_code = HAL_SPI_Receive(
                 &spi_instance.hspi,
-                (uint8_t*)data.data(),
+                reinterpret_cast<uint8_t*>(const_cast<element_type*>(data.data())),
                 data.size_bytes() / frame_size,
                 10
             );
@@ -655,20 +659,21 @@ struct SPIDomain {
          */
         template <typename T>
         bool receive(T& data)
-            requires std::is_trivially_copyable_v<T>
+            requires std::is_trivially_copyable_v<std::remove_volatile_t<T>>
         {
-            if (sizeof(T) % frame_size != 0) {
+            using element_type = std::remove_volatile_t<T>;
+            if (sizeof(element_type) % frame_size != 0) {
                 ErrorHandler(
                     "SPI data type size (%d) not aligned to frame size (%d)",
-                    sizeof(T),
+                    sizeof(element_type),
                     frame_size
                 );
                 return false;
             }
             auto error_code = HAL_SPI_Receive(
                 &spi_instance.hspi,
-                reinterpret_cast<uint8_t*>(&data),
-                sizeof(T) / frame_size,
+                reinterpret_cast<const uint8_t*>(const_cast<const element_type*>(&data)),
+                sizeof(element_type) / frame_size,
                 10
             );
             return check_error_code(error_code);
@@ -688,10 +693,12 @@ struct SPIDomain {
                 );
                 return false;
             }
+            using tx_element_type = std::remove_volatile_t<E1>;
+            using rx_element_type = std::remove_volatile_t<E2>;
             auto error_code = HAL_SPI_TransmitReceive(
                 &spi_instance.hspi,
-                (uint8_t*)tx_data.data(),
-                (uint8_t*)rx_data.data(),
+                reinterpret_cast<const uint8_t*>(const_cast<tx_element_type*>(tx_data.data())),
+                reinterpret_cast<uint8_t*>(const_cast<rx_element_type*>(rx_data.data())),
                 size / frame_size,
                 10
             );
@@ -714,10 +721,12 @@ struct SPIDomain {
                 );
                 return false;
             }
+            using tx_element_type = std::remove_volatile_t<E>;
+            using rx_element_type = std::remove_volatile_t<T>;
             auto error_code = HAL_SPI_TransmitReceive(
                 &spi_instance.hspi,
-                (uint8_t*)tx_data.data(),
-                reinterpret_cast<uint8_t*>(&rx_data),
+                reinterpret_cast<const uint8_t*>(const_cast<const tx_element_type*>(tx_data.data())),
+                reinterpret_cast<uint8_t*>(const_cast<rx_element_type*>(&rx_data)),
                 size / frame_size,
                 10
             );
@@ -740,10 +749,12 @@ struct SPIDomain {
                 );
                 return false;
             }
+            using tx_element_type = std::remove_volatile_t<T>;
+            using rx_element_type = std::remove_volatile_t<E>;
             auto error_code = HAL_SPI_TransmitReceive(
                 &spi_instance.hspi,
-                reinterpret_cast<const uint8_t*>(&tx_data),
-                (uint8_t*)rx_data.data(),
+                reinterpret_cast<const uint8_t*>(const_cast<const tx_element_type*>(&tx_data)),
+                reinterpret_cast<uint8_t*>(const_cast<rx_element_type*>(rx_data.data())),
                 size / frame_size,
                 10
             );
@@ -755,9 +766,12 @@ struct SPIDomain {
          */
         template <typename T1, typename T2>
         bool transceive(const T1& tx_data, T2& rx_data)
-            requires(std::is_trivially_copyable_v<T1> && std::is_trivially_copyable_v<T2>)
+            requires(std::is_trivially_copyable_v<std::remove_volatile_t<T1>> && 
+                     std::is_trivially_copyable_v<std::remove_volatile_t<T2>>)
         {
-            size_t size = std::min(sizeof(T1), sizeof(T2));
+            using tx_element_type = std::remove_volatile_t<T1>;
+            using rx_element_type = std::remove_volatile_t<T2>;
+            size_t size = std::min(sizeof(tx_element_type), sizeof(rx_element_type));
             if (size % frame_size != 0) {
                 ErrorHandler(
                     "SPI transaction size (%d) not aligned to frame size (%d)",
@@ -768,8 +782,8 @@ struct SPIDomain {
             }
             auto error_code = HAL_SPI_TransmitReceive(
                 &spi_instance.hspi,
-                reinterpret_cast<const uint8_t*>(&tx_data),
-                reinterpret_cast<uint8_t*>(&rx_data),
+                reinterpret_cast<const uint8_t*>(const_cast<const tx_element_type*>(&tx_data)),
+                reinterpret_cast<uint8_t*>(const_cast<rx_element_type*>(&rx_data)),
                 size / frame_size,
                 10
             );
@@ -791,9 +805,10 @@ struct SPIDomain {
                 );
                 return false;
             }
+            using element_type = std::remove_volatile_t<E>;
             auto error_code = HAL_SPI_Transmit_DMA(
                 &spi_instance.hspi,
-                (uint8_t*)data.data(),
+                reinterpret_cast<uint8_t*>(const_cast<element_type*>(data.data())),
                 data.size_bytes() / frame_size
             );
             return check_error_code(error_code);
@@ -805,21 +820,22 @@ struct SPIDomain {
          */
         template <typename T>
         bool send_DMA(const T& data, volatile bool* operation_flag = nullptr)
-            requires std::is_trivially_copyable_v<T>
+            requires std::is_trivially_copyable_v<std::remove_volatile_t<T>>
         {
             spi_instance.operation_flag = operation_flag;
-            if (sizeof(T) % frame_size != 0) {
+            using element_type = std::remove_volatile_t<T>;
+            if (sizeof(element_type) % frame_size != 0) {
                 ErrorHandler(
                     "SPI data size (%d) not aligned to frame size (%d)",
-                    sizeof(T),
+                    sizeof(element_type),
                     frame_size
                 );
                 return false;
             }
             auto error_code = HAL_SPI_Transmit_DMA(
                 &spi_instance.hspi,
-                reinterpret_cast<const uint8_t*>(&data),
-                sizeof(T) / frame_size
+                reinterpret_cast<const uint8_t*>(const_cast<const element_type*>(&data)),
+                sizeof(element_type) / frame_size
             );
             return check_error_code(error_code);
         }
@@ -839,9 +855,10 @@ struct SPIDomain {
                 );
                 return false;
             }
+            using element_type = std::remove_volatile_t<E>;
             auto error_code = HAL_SPI_Receive_DMA(
                 &spi_instance.hspi,
-                (uint8_t*)data.data(),
+                reinterpret_cast<uint8_t*>(const_cast<element_type*>(data.data())),
                 data.size_bytes() / frame_size
             );
             return check_error_code(error_code);
@@ -853,21 +870,22 @@ struct SPIDomain {
          */
         template <typename T>
         bool receive_DMA(T& data, volatile bool* operation_flag = nullptr)
-            requires std::is_trivially_copyable_v<T>
+            requires std::is_trivially_copyable_v<std::remove_volatile_t<T>>
         {
             spi_instance.operation_flag = operation_flag;
-            if (sizeof(T) % frame_size != 0) {
+            using element_type = std::remove_volatile_t<T>;
+            if (sizeof(element_type) % frame_size != 0) {
                 ErrorHandler(
                     "SPI data size (%d) not aligned to frame size (%d)",
-                    sizeof(T),
+                    sizeof(element_type),
                     frame_size
                 );
                 return false;
             }
             auto error_code = HAL_SPI_Receive_DMA(
                 &spi_instance.hspi,
-                reinterpret_cast<uint8_t*>(&data),
-                sizeof(T) / frame_size
+                reinterpret_cast<uint8_t*>(const_cast<element_type*>(&data)),
+                sizeof(element_type) / frame_size
             );
             return check_error_code(error_code);
         }
@@ -892,10 +910,12 @@ struct SPIDomain {
                 );
                 return false;
             }
+            using tx_element_type = std::remove_volatile_t<E1>;
+            using rx_element_type = std::remove_volatile_t<E2>;
             auto error_code = HAL_SPI_TransmitReceive_DMA(
                 &spi_instance.hspi,
-                (uint8_t*)tx_data.data(),
-                (uint8_t*)rx_data.data(),
+                reinterpret_cast<const uint8_t*>(const_cast<const tx_element_type*>(tx_data.data())),
+                reinterpret_cast<uint8_t*>(const_cast<rx_element_type*>(rx_data.data())),
                 size / frame_size
             );
             return check_error_code(error_code);
@@ -919,10 +939,12 @@ struct SPIDomain {
                 );
                 return false;
             }
+            using tx_element_type = std::remove_volatile_t<E>;
+            using rx_element_type = std::remove_volatile_t<T>;
             auto error_code = HAL_SPI_TransmitReceive_DMA(
                 &spi_instance.hspi,
-                (uint8_t*)tx_data.data(),
-                reinterpret_cast<uint8_t*>(&rx_data),
+                reinterpret_cast<const uint8_t*>(const_cast<const tx_element_type*>(tx_data.data())),
+                reinterpret_cast<uint8_t*>(const_cast<rx_element_type*>(&rx_data)),
                 size / frame_size
             );
             return check_error_code(error_code);
@@ -950,10 +972,12 @@ struct SPIDomain {
                 );
                 return false;
             }
+            using tx_element_type = std::remove_volatile_t<T>;
+            using rx_element_type = std::remove_volatile_t<E>;
             auto error_code = HAL_SPI_TransmitReceive_DMA(
                 &spi_instance.hspi,
-                reinterpret_cast<const uint8_t*>(&tx_data),
-                (uint8_t*)rx_data.data(),
+                reinterpret_cast<const uint8_t*>(const_cast<const tx_element_type*>(&tx_data)),
+                reinterpret_cast<uint8_t*>(const_cast<rx_element_type*>(rx_data.data())),
                 size / frame_size
             );
             return check_error_code(error_code);
@@ -965,10 +989,13 @@ struct SPIDomain {
          */
         template <typename T1, typename T2>
         bool transceive_DMA(const T1& tx_data, T2& rx_data, volatile bool* operation_flag = nullptr)
-            requires(std::is_trivially_copyable_v<T1> && std::is_trivially_copyable_v<T2>)
+            requires(std::is_trivially_copyable_v<std::remove_volatile_t<T1>> && 
+                     std::is_trivially_copyable_v<std::remove_volatile_t<T2>>)
         {
+            using tx_element_type = std::remove_volatile_t<T1>;
+            using rx_element_type = std::remove_volatile_t<T2>;
             spi_instance.operation_flag = operation_flag;
-            auto size = std::min(sizeof(T1), sizeof(T2));
+            auto size = std::min(sizeof(tx_element_type), sizeof(rx_element_type));
             if (size % frame_size != 0) {
                 ErrorHandler(
                     "SPI transaction size (%d) not aligned to frame size (%d)",
@@ -979,8 +1006,8 @@ struct SPIDomain {
             }
             auto error_code = HAL_SPI_TransmitReceive_DMA(
                 &spi_instance.hspi,
-                reinterpret_cast<const uint8_t*>(&tx_data),
-                reinterpret_cast<uint8_t*>(&rx_data),
+                reinterpret_cast<const uint8_t*>(const_cast<const tx_element_type*>(&tx_data)),
+                reinterpret_cast<uint8_t*>(const_cast<rx_element_type*>(&rx_data)),
                 size / frame_size
             );
             return check_error_code(error_code);
@@ -1002,6 +1029,7 @@ struct SPIDomain {
 
     /**
      * @brief SPI Wrapper for Slave mode operations. Doesn't allow for blocking operations.
+     * @warning DMA operations may be optimized away by the compiler, you should either use volatile buffers or add some kind of memory barrier after DMA operations to ensure data integrity.
      */
     template <auto& device_request> struct SPIWrapper<device_request, false> {
         static constexpr uint32_t data_bits =
@@ -1055,9 +1083,10 @@ struct SPIDomain {
                 );
                 return false;
             }
+            using element_type = std::remove_volatile_t<E>;
             auto error_code = HAL_SPI_Receive_DMA(
                 &spi_instance.hspi,
-                (uint8_t*)data.data(),
+                reinterpret_cast<uint8_t*>(const_cast<element_type*>(data.data())),
                 data.size_bytes() / frame_size
             );
             return check_error_code(error_code);
@@ -1069,21 +1098,22 @@ struct SPIDomain {
          */
         template <typename T>
         bool listen(T& data, volatile bool* operation_flag = nullptr)
-            requires std::is_trivially_copyable_v<T>
+            requires std::is_trivially_copyable_v<std::remove_volatile_t<T>>
         {
             spi_instance.operation_flag = operation_flag;
-            if (sizeof(T) % frame_size != 0) {
+            using element_type = std::remove_volatile_t<T>;
+            if (sizeof(element_type) % frame_size != 0) {
                 ErrorHandler(
                     "SPI data size (%d) not aligned to frame size (%d)",
-                    sizeof(T),
+                    sizeof(element_type),
                     frame_size
                 );
                 return false;
             }
             auto error_code = HAL_SPI_Receive_DMA(
                 &spi_instance.hspi,
-                reinterpret_cast<uint8_t*>(&data),
-                sizeof(T) / frame_size
+                reinterpret_cast<uint8_t*>(const_cast<element_type*>(&data)),
+                sizeof(element_type) / frame_size
             );
             return check_error_code(error_code);
         }
@@ -1103,9 +1133,10 @@ struct SPIDomain {
                 );
                 return false;
             }
+            using element_type = std::remove_volatile_t<E>;
             auto error_code = HAL_SPI_Transmit_DMA(
                 &spi_instance.hspi,
-                (uint8_t*)tx_data.data(),
+                reinterpret_cast<const uint8_t*>(const_cast<const element_type*>(tx_data.data())),
                 tx_data.size_bytes() / frame_size
             );
             return check_error_code(error_code);
@@ -1117,21 +1148,22 @@ struct SPIDomain {
          */
         template <typename T>
         bool arm(const T& data, volatile bool* operation_flag = nullptr)
-            requires std::is_trivially_copyable_v<T>
+            requires std::is_trivially_copyable_v<std::remove_volatile_t<T>>
         {
             spi_instance.operation_flag = operation_flag;
-            if (sizeof(T) % frame_size != 0) {
+            using element_type = std::remove_volatile_t<T>;
+            if (sizeof(element_type) % frame_size != 0) {
                 ErrorHandler(
                     "SPI data size (%d) not aligned to frame size (%d)",
-                    sizeof(T),
+                    sizeof(element_type),
                     frame_size
                 );
                 return false;
             }
             auto error_code = HAL_SPI_Transmit_DMA(
                 &spi_instance.hspi,
-                reinterpret_cast<const uint8_t*>(&data),
-                sizeof(T) / frame_size
+                reinterpret_cast<const uint8_t*>(const_cast<const element_type*>(&data)),
+                sizeof(element_type) / frame_size
             );
             return check_error_code(error_code);
         }
@@ -1156,10 +1188,12 @@ struct SPIDomain {
                 );
                 return false;
             }
+            using tx_element_type = std::remove_volatile_t<E1>;
+            using rx_element_type = std::remove_volatile_t<E2>;
             auto error_code = HAL_SPI_TransmitReceive_DMA(
                 &spi_instance.hspi,
-                (uint8_t*)tx_data.data(),
-                (uint8_t*)rx_data.data(),
+                reinterpret_cast<const uint8_t*>(const_cast<const tx_element_type*>(tx_data.data())),
+                reinterpret_cast<uint8_t*>(const_cast<rx_element_type*>(rx_data.data())),
                 size / frame_size
             );
             return check_error_code(error_code);
@@ -1183,10 +1217,12 @@ struct SPIDomain {
                 );
                 return false;
             }
+            using tx_element_type = std::remove_volatile_t<E>;
+            using rx_element_type = std::remove_volatile_t<T>;
             auto error_code = HAL_SPI_TransmitReceive_DMA(
                 &spi_instance.hspi,
-                (uint8_t*)tx_data.data(),
-                reinterpret_cast<uint8_t*>(&rx_data),
+                reinterpret_cast<const uint8_t*>(const_cast<const tx_element_type*>(tx_data.data())),
+                reinterpret_cast<uint8_t*>(const_cast<rx_element_type*>(&rx_data)),
                 size / frame_size
             );
             return check_error_code(error_code);
@@ -1211,10 +1247,12 @@ struct SPIDomain {
                 );
                 return false;
             }
+            using rx_element_type = std::remove_volatile_t<E>;
+            using tx_element_type = std::remove_volatile_t<T>;
             auto error_code = HAL_SPI_TransmitReceive_DMA(
                 &spi_instance.hspi,
-                reinterpret_cast<const uint8_t*>(&tx_data),
-                (uint8_t*)rx_data.data(),
+                reinterpret_cast<const uint8_t*>(const_cast<const tx_element_type*>(&tx_data)),
+                reinterpret_cast<uint8_t*>(const_cast<rx_element_type*>(rx_data.data())),
                 size / frame_size
             );
             return check_error_code(error_code);
@@ -1226,10 +1264,13 @@ struct SPIDomain {
          */
         template <typename T1, typename T2>
         bool transceive(const T1& tx_data, T2& rx_data, volatile bool* operation_flag = nullptr)
-            requires(std::is_trivially_copyable_v<T1> && std::is_trivially_copyable_v<T2>)
+            requires(std::is_trivially_copyable_v<std::remove_volatile_t<T1>> && 
+                     std::is_trivially_copyable_v<std::remove_volatile_t<T2>>)
         {
+            using tx_element_type = std::remove_volatile_t<T1>;
+            using rx_element_type = std::remove_volatile_t<T2>;
             spi_instance.operation_flag = operation_flag;
-            auto size = std::min(sizeof(T1), sizeof(T2));
+            auto size = std::min(sizeof(tx_element_type), sizeof(rx_element_type));
             if (size % frame_size != 0) {
                 ErrorHandler(
                     "SPI transaction size (%d) not aligned to frame size (%d)",
@@ -1238,10 +1279,10 @@ struct SPIDomain {
                 );
                 return false;
             }
-            auto error_code = HAL_SPI_TransmitReceive_DMA( // (TODO) These functions should actually allow volatiles
+            auto error_code = HAL_SPI_TransmitReceive_DMA(
                 &spi_instance.hspi,
-                reinterpret_cast<const uint8_t*>(&tx_data),
-                reinterpret_cast<uint8_t*>(&rx_data),
+                reinterpret_cast<const uint8_t*>(const_cast<const tx_element_type*>(&tx_data)),
+                reinterpret_cast<uint8_t*>(const_cast<rx_element_type*>(&rx_data)),
                 size / frame_size
             );
             return check_error_code(error_code);

--- a/Inc/HALAL/Models/SPI/SPI2.hpp
+++ b/Inc/HALAL/Models/SPI/SPI2.hpp
@@ -1240,8 +1240,8 @@ struct SPIDomain {
             }
             auto error_code = HAL_SPI_TransmitReceive_DMA(
                 &spi_instance.hspi,
-                reinterpret_cast<const uint8_t*>(&tx_data),
-                reinterpret_cast<uint8_t*>(&rx_data),
+                const_cast<uint8_t*>(reinterpret_cast<const volatile uint8_t*>(&tx_data)),
+                const_cast<uint8_t*>(reinterpret_cast<volatile uint8_t*>(&rx_data)),
                 size / frame_size
             );
             return check_error_code(error_code);

--- a/Inc/HALAL/Models/SPI/SPI2.hpp
+++ b/Inc/HALAL/Models/SPI/SPI2.hpp
@@ -1238,10 +1238,10 @@ struct SPIDomain {
                 );
                 return false;
             }
-            auto error_code = HAL_SPI_TransmitReceive_DMA(
+            auto error_code = HAL_SPI_TransmitReceive_DMA( // (TODO) These functions should actually allow volatiles
                 &spi_instance.hspi,
-                const_cast<uint8_t*>(reinterpret_cast<const volatile uint8_t*>(&tx_data)),
-                const_cast<uint8_t*>(reinterpret_cast<volatile uint8_t*>(&rx_data)),
+                reinterpret_cast<const uint8_t*>(&tx_data),
+                reinterpret_cast<uint8_t*>(&rx_data),
                 size / frame_size
             );
             return check_error_code(error_code);

--- a/Inc/HALAL/Services/ADC/ADC.hpp
+++ b/Inc/HALAL/Services/ADC/ADC.hpp
@@ -991,9 +991,7 @@ struct ADCDomain {
 
                 if (HAL_ADC_Start_DMA(
                         hadc,
-                        reinterpret_cast<uint32_t*>(
-                            const_cast<uint16_t*>(buffer)
-                        ),
+                        reinterpret_cast<uint32_t*>(const_cast<uint16_t*>(buffer)),
                         channel_count
                     ) != HAL_OK) {
                     ErrorHandler("ADC DMA start failed");

--- a/Inc/HALAL/Services/ADC/ADC.hpp
+++ b/Inc/HALAL/Services/ADC/ADC.hpp
@@ -828,7 +828,7 @@ struct ADCDomain {
             }
             return 0;
         }
-        static uint16_t* get_dma_buffer(Peripheral peripheral) {
+        static volatile uint16_t* get_dma_buffer(Peripheral peripheral) {
             const auto buffer_size = buffer_size_for(peripheral);
             const auto buffer_offset = buffer_offset_for(peripheral);
             if (buffer_size == 0U) {
@@ -840,12 +840,12 @@ struct ADCDomain {
                 return nullptr;
             }
 
-            uint16_t* buffer = &dma_buffer_pool[buffer_offset];
+            volatile uint16_t* buffer = &dma_buffer_pool[buffer_offset];
             std::fill_n(buffer, buffer_size, uint16_t{0});
             return buffer;
         }
 
-        static uint16_t* get_dma_slot(Peripheral peripheral, uint8_t index) {
+        static volatile uint16_t* get_dma_slot(Peripheral peripheral, uint8_t index) {
             if (index >= buffer_size_for(peripheral)) {
                 return nullptr;
             }
@@ -945,7 +945,7 @@ struct ADCDomain {
                     ErrorHandler("ADC DMA instance unavailable");
                     continue;
                 }
-                uint16_t* buffer = get_dma_buffer(peripheral);
+                volatile uint16_t* buffer = get_dma_buffer(peripheral);
                 if (buffer == nullptr) {
                     continue;
                 }
@@ -989,8 +989,13 @@ struct ADCDomain {
                     continue;
                 }
 
-                if (HAL_ADC_Start_DMA(hadc, reinterpret_cast<uint32_t*>(buffer), channel_count) !=
-                    HAL_OK) {
+                if (HAL_ADC_Start_DMA(
+                        hadc,
+                        reinterpret_cast<uint32_t*>(
+                            const_cast<std::remove_volatile_t<std::remove_pointer_t<decltype(buffer)>>*>(buffer)
+                        ),
+                        channel_count
+                    ) != HAL_OK) {
                     ErrorHandler("ADC DMA start failed");
                     continue;
                 }

--- a/Inc/HALAL/Services/ADC/ADC.hpp
+++ b/Inc/HALAL/Services/ADC/ADC.hpp
@@ -992,7 +992,7 @@ struct ADCDomain {
                 if (HAL_ADC_Start_DMA(
                         hadc,
                         reinterpret_cast<uint32_t*>(
-                            const_cast<std::remove_volatile_t<std::remove_pointer_t<decltype(buffer)>>*>(buffer)
+                            const_cast<uint16_t*>(buffer)
                         ),
                         channel_count
                     ) != HAL_OK) {

--- a/Inc/HALAL/Services/DFSDM/DFSDM.hpp
+++ b/Inc/HALAL/Services/DFSDM/DFSDM.hpp
@@ -1017,7 +1017,7 @@ struct DFSDM_CHANNEL_DOMAIN {
             ErrorHandler("Filter cannot be bigger than 3");
             return 0;
         }
-        static int32_t* get_buffer_filter(uint8_t filter) {
+        static volatile int32_t* get_buffer_filter(uint8_t filter) {
             switch (filter) {
             case 0:
                 return Buffer_Filter0;
@@ -1032,7 +1032,7 @@ struct DFSDM_CHANNEL_DOMAIN {
             return 0;
         }
 
-        static int32_t* get_buffer_pointer(const Config cfg) {
+        static volatile int32_t* get_buffer_pointer(const Config cfg) {
             return get_buffer_filter(cfg.filter) + cfg.buffer_pos_ini;
         }
 

--- a/Inc/MockedDrivers/stm32h7xx_hal_mock.h
+++ b/Inc/MockedDrivers/stm32h7xx_hal_mock.h
@@ -906,7 +906,8 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive(
     uint16_t Size,
     uint32_t Timeout
 );
-HAL_StatusTypeDef HAL_SPI_Transmit_DMA(SPI_HandleTypeDef* hspi, const uint8_t* pData, uint16_t Size);
+HAL_StatusTypeDef
+HAL_SPI_Transmit_DMA(SPI_HandleTypeDef* hspi, const uint8_t* pData, uint16_t Size);
 HAL_StatusTypeDef HAL_SPI_Receive_DMA(SPI_HandleTypeDef* hspi, uint8_t* pData, uint16_t Size);
 HAL_StatusTypeDef HAL_SPI_TransmitReceive_DMA(
     SPI_HandleTypeDef* hspi,

--- a/Inc/MockedDrivers/stm32h7xx_hal_mock.h
+++ b/Inc/MockedDrivers/stm32h7xx_hal_mock.h
@@ -896,21 +896,21 @@ HAL_StatusTypeDef HAL_SPI_Init(SPI_HandleTypeDef* hspi);
 HAL_StatusTypeDef HAL_SPI_DeInit(SPI_HandleTypeDef* hspi);
 HAL_StatusTypeDef HAL_SPI_Abort(SPI_HandleTypeDef* hspi);
 HAL_StatusTypeDef
-HAL_SPI_Transmit(SPI_HandleTypeDef* hspi, uint8_t* pData, uint16_t Size, uint32_t Timeout);
+HAL_SPI_Transmit(SPI_HandleTypeDef* hspi, const uint8_t* pData, uint16_t Size, uint32_t Timeout);
 HAL_StatusTypeDef
 HAL_SPI_Receive(SPI_HandleTypeDef* hspi, uint8_t* pData, uint16_t Size, uint32_t Timeout);
 HAL_StatusTypeDef HAL_SPI_TransmitReceive(
     SPI_HandleTypeDef* hspi,
-    uint8_t* pTxData,
+    const uint8_t* pTxData,
     uint8_t* pRxData,
     uint16_t Size,
     uint32_t Timeout
 );
-HAL_StatusTypeDef HAL_SPI_Transmit_DMA(SPI_HandleTypeDef* hspi, uint8_t* pData, uint16_t Size);
+HAL_StatusTypeDef HAL_SPI_Transmit_DMA(SPI_HandleTypeDef* hspi, const uint8_t* pData, uint16_t Size);
 HAL_StatusTypeDef HAL_SPI_Receive_DMA(SPI_HandleTypeDef* hspi, uint8_t* pData, uint16_t Size);
 HAL_StatusTypeDef HAL_SPI_TransmitReceive_DMA(
     SPI_HandleTypeDef* hspi,
-    uint8_t* pTxData,
+    const uint8_t* pTxData,
     uint8_t* pRxData,
     uint16_t Size
 );

--- a/Src/HALAL/Models/MDMA/MDMA.cpp
+++ b/Src/HALAL/Models/MDMA/MDMA.cpp
@@ -112,7 +112,10 @@ void MDMA::inscribe(Instance& instance, uint8_t id) {
     nodeConfig.SrcAddress = reinterpret_cast<uint32_t>(nullptr);
     nodeConfig.DstAddress = reinterpret_cast<uint32_t>(nullptr);
 
-    const HAL_StatusTypeDef status = HAL_MDMA_LinkedList_CreateNode(const_cast<MDMA_LinkNodeTypeDef*>(transfer_node), &nodeConfig);
+    const HAL_StatusTypeDef status = HAL_MDMA_LinkedList_CreateNode(
+        const_cast<MDMA_LinkNodeTypeDef*>(transfer_node),
+        &nodeConfig
+    );
     if (status != HAL_OK) {
         ErrorHandler("Error creating linked list in MDMA");
     }

--- a/Src/HALAL/Models/MDMA/MDMA.cpp
+++ b/Src/HALAL/Models/MDMA/MDMA.cpp
@@ -18,7 +18,7 @@ uint8_t MDMA::get_instance_id(MDMA_Channel_TypeDef* channel) {
     return static_cast<uint8_t>((address - (MDMA_BASE + 0x40UL)) / 0x40UL);
 }
 
-void MDMA::prepare_transfer(Instance& instance, MDMA_LinkNodeTypeDef* first_node) {
+void MDMA::prepare_transfer(Instance& instance, volatile MDMA_LinkNodeTypeDef* first_node) {
     if (instance.handle.State == HAL_MDMA_STATE_BUSY) {
         ErrorHandler("MDMA transfer already in progress");
         return;
@@ -27,7 +27,7 @@ void MDMA::prepare_transfer(Instance& instance, MDMA_LinkNodeTypeDef* first_node
 
     instance.handle.State = HAL_MDMA_STATE_BUSY;
     instance.handle.ErrorCode = HAL_MDMA_ERROR_NONE;
-    instance.handle.FirstLinkedListNodeAddress = first_node;
+    instance.handle.FirstLinkedListNodeAddress = const_cast<MDMA_LinkNodeTypeDef*>(first_node);
 
     MDMA_Channel_TypeDef* channel = instance.handle.Instance;
 
@@ -56,7 +56,7 @@ void MDMA::prepare_transfer(Instance& instance, MDMA_LinkNodeTypeDef* first_node
     }
 }
 
-void MDMA::prepare_transfer(Instance& instance, LinkedListNode* first_node) {
+void MDMA::prepare_transfer(Instance& instance, volatile LinkedListNode* first_node) {
     MDMA::prepare_transfer(instance, first_node->get_node());
 }
 
@@ -91,7 +91,7 @@ void MDMA::inscribe(Instance& instance, uint8_t id) {
     mdma_handle.Init.DestBlockAddressOffset = 0;
 
     MDMA_LinkNodeConfTypeDef nodeConfig{};
-    MDMA_LinkNodeTypeDef* transfer_node = &internal_nodes[id];
+    auto transfer_node = &internal_nodes[id];
 
     nodeConfig.Init.DataAlignment = MDMA_DATAALIGN_PACKENABLE;
     nodeConfig.Init.SourceBurst = MDMA_SOURCE_BURST_SINGLE;
@@ -112,7 +112,7 @@ void MDMA::inscribe(Instance& instance, uint8_t id) {
     nodeConfig.SrcAddress = reinterpret_cast<uint32_t>(nullptr);
     nodeConfig.DstAddress = reinterpret_cast<uint32_t>(nullptr);
 
-    const HAL_StatusTypeDef status = HAL_MDMA_LinkedList_CreateNode(transfer_node, &nodeConfig);
+    const HAL_StatusTypeDef status = HAL_MDMA_LinkedList_CreateNode(const_cast<MDMA_LinkNodeTypeDef*>(transfer_node), &nodeConfig);
     if (status != HAL_OK) {
         ErrorHandler("Error creating linked list in MDMA");
     }
@@ -182,7 +182,7 @@ void MDMA::irq_handler() {
     }
 }
 
-void MDMA::transfer_list(MDMA::LinkedListNode* first_node, volatile bool* done) {
+void MDMA::transfer_list(volatile MDMA::LinkedListNode* first_node, volatile bool* done) {
     if (transfer_queue.size() >= TRANSFER_QUEUE_MAX_SIZE) {
         ErrorHandler("MDMA transfer queue full");
         return;

--- a/Src/HALAL/Models/MPUManager/MPUManager.cpp
+++ b/Src/HALAL/Models/MPUManager/MPUManager.cpp
@@ -4,8 +4,8 @@
 alignas(32) uint8_t mpu_manager_memory_pool[NO_CACHED_RAM_MAXIMUM_SPACE];
 #else
 __attribute__((section(".mpu_ram_d3_nc.legacy"))) alignas(32
-) uint8_t mpu_manager_memory_pool[NO_CACHED_RAM_MAXIMUM_SPACE];
+) volatile uint8_t mpu_manager_memory_pool[NO_CACHED_RAM_MAXIMUM_SPACE];
 #endif
 
-void* MPUManager::no_cached_ram_start = mpu_manager_memory_pool;
+volatile void* MPUManager::no_cached_ram_start = mpu_manager_memory_pool;
 uint32_t MPUManager::no_cached_ram_occupied_bytes = 0;

--- a/Src/MockedDrivers/mocked_hal_spi.cpp
+++ b/Src/MockedDrivers/mocked_hal_spi.cpp
@@ -123,12 +123,12 @@ extern "C" HAL_StatusTypeDef HAL_SPI_Abort(SPI_HandleTypeDef* hspi) {
 }
 
 extern "C" HAL_StatusTypeDef
-HAL_SPI_Transmit(SPI_HandleTypeDef* hspi, uint8_t* pData, uint16_t Size, uint32_t Timeout) {
+HAL_SPI_Transmit(SPI_HandleTypeDef* hspi, const uint8_t* pData, uint16_t Size, uint32_t Timeout) {
     (void)Timeout;
     g_state.calls[static_cast<std::size_t>(ST_LIB::MockedHAL::SPIOperation::Transmit)]++;
     g_state.last_handle = hspi;
     g_state.last_size_words = Size;
-    store_tx(pData, static_cast<std::size_t>(Size) * frame_bytes(hspi));
+    store_tx(const_cast<uint8_t*>(pData), static_cast<std::size_t>(Size) * frame_bytes(hspi));
     return take_status();
 }
 
@@ -144,7 +144,7 @@ HAL_SPI_Receive(SPI_HandleTypeDef* hspi, uint8_t* pData, uint16_t Size, uint32_t
 
 extern "C" HAL_StatusTypeDef HAL_SPI_TransmitReceive(
     SPI_HandleTypeDef* hspi,
-    uint8_t* pTxData,
+    const uint8_t* pTxData,
     uint8_t* pRxData,
     uint16_t Size,
     uint32_t Timeout
@@ -154,17 +154,17 @@ extern "C" HAL_StatusTypeDef HAL_SPI_TransmitReceive(
     g_state.last_handle = hspi;
     g_state.last_size_words = Size;
     const auto size_bytes = static_cast<std::size_t>(Size) * frame_bytes(hspi);
-    store_tx(pTxData, size_bytes);
+    store_tx(const_cast<uint8_t*>(pTxData), size_bytes);
     fill_rx(pRxData, size_bytes);
     return take_status();
 }
 
 extern "C" HAL_StatusTypeDef
-HAL_SPI_Transmit_DMA(SPI_HandleTypeDef* hspi, uint8_t* pData, uint16_t Size) {
+HAL_SPI_Transmit_DMA(SPI_HandleTypeDef* hspi, const uint8_t* pData, uint16_t Size) {
     g_state.calls[static_cast<std::size_t>(ST_LIB::MockedHAL::SPIOperation::TransmitDMA)]++;
     g_state.last_handle = hspi;
     g_state.last_size_words = Size;
-    store_tx(pData, static_cast<std::size_t>(Size) * frame_bytes(hspi));
+    store_tx(const_cast<uint8_t*>(pData), static_cast<std::size_t>(Size) * frame_bytes(hspi));
     return take_status();
 }
 
@@ -179,7 +179,7 @@ HAL_SPI_Receive_DMA(SPI_HandleTypeDef* hspi, uint8_t* pData, uint16_t Size) {
 
 extern "C" HAL_StatusTypeDef HAL_SPI_TransmitReceive_DMA(
     SPI_HandleTypeDef* hspi,
-    uint8_t* pTxData,
+    const uint8_t* pTxData,
     uint8_t* pRxData,
     uint16_t Size
 ) {
@@ -187,7 +187,7 @@ extern "C" HAL_StatusTypeDef HAL_SPI_TransmitReceive_DMA(
     g_state.last_handle = hspi;
     g_state.last_size_words = Size;
     const auto size_bytes = static_cast<std::size_t>(Size) * frame_bytes(hspi);
-    store_tx(pTxData, size_bytes);
+    store_tx(const_cast<uint8_t*>(pTxData), size_bytes);
     fill_rx(pRxData, size_bytes);
     return take_status();
 }


### PR DESCRIPTION
Closes #638 
Fixes lots of small errors in the library related to not using volatiles to access memory that is / should be non-cached.
Check the issue for more information.

There may be more hidden errors elsewhere in the codebase, but this takes care of a good chunk of them and should not let compile any code that doesn't follow the volatile rules (as long as it follows standard practices)