### PR TITLE
Fix SPI45 2MHz clock source

### DIFF
--- a/.changesets/spi45-hsi-clock-source.md
+++ b/.changesets/spi45-hsi-clock-source.md
@@ -1,0 +1,5 @@
+release: patch
+summary: Drive SPI4 and SPI5 from HSI for stable 2 MHz BMS transfers
+
+SPI4 and SPI5 now use the 64 MHz HSI peripheral clock source instead of PCLK2,
+allowing a 2 MHz request to select the /32 SPI prescaler deterministically.

--- a/Inc/HALAL/Models/SPI/SPI2.hpp
+++ b/Inc/HALAL/Models/SPI/SPI2.hpp
@@ -1371,7 +1371,7 @@ struct SPIDomain {
                     spi_number = 3;
                 } else if (peripheral == SPIPeripheral::spi4) {
                     PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_SPI4;
-                    PeriphClkInitStruct.Spi45ClockSelection = RCC_SPI45CLKSOURCE_PCLK2;
+                    PeriphClkInitStruct.Spi45ClockSelection = RCC_SPI45CLKSOURCE_HSI;
                     if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct) != HAL_OK) {
                         PANIC("Unable to configure SPI4 clock");
                     }
@@ -1379,7 +1379,7 @@ struct SPIDomain {
                     spi_number = 4;
                 } else if (peripheral == SPIPeripheral::spi5) {
                     PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_SPI5;
-                    PeriphClkInitStruct.Spi45ClockSelection = RCC_SPI45CLKSOURCE_PCLK2;
+                    PeriphClkInitStruct.Spi45ClockSelection = RCC_SPI45CLKSOURCE_HSI;
                     if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct) != HAL_OK) {
                         PANIC("Unable to configure SPI5 clock");
                     }

--- a/Inc/MockedDrivers/stm32h7xx_hal_mock.h
+++ b/Inc/MockedDrivers/stm32h7xx_hal_mock.h
@@ -62,6 +62,7 @@ typedef struct {
 } RCC_TypeDef;
 extern RCC_TypeDef* RCC;
 extern uint32_t SystemCoreClock;
+#define HSI_VALUE 64000000U
 
 #define RCC_D1CFGR_HPRE_Msk (0xFU << 0U)
 #define RCC_D2CFGR_D2PPRE1_Pos 4U
@@ -596,6 +597,7 @@ typedef struct {
 #define RCC_SPI123CLKSOURCE_PLL 0x00000001U
 #define RCC_SPI45CLKSOURCE_PLL2 0x00000002U
 #define RCC_SPI45CLKSOURCE_PCLK2 0x00000003U
+#define RCC_SPI45CLKSOURCE_HSI 0x00000004U
 #define RCC_SPI6CLKSOURCE_PLL2 0x00000002U
 
 typedef struct TIM_TypeDef TIM_TypeDef;
@@ -946,7 +948,9 @@ static inline HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeD
     return HAL_OK;
 }
 static inline uint32_t HAL_RCCEx_GetPeriphCLKFreq(uint32_t PeriphClk) {
-    (void)PeriphClk;
+    if (PeriphClk == RCC_PERIPHCLK_SPI45) {
+        return HSI_VALUE;
+    }
     return SystemCoreClock;
 }
 static inline HAL_StatusTypeDef HAL_DMA_Init(DMA_HandleTypeDef* hdma) {

--- a/Src/HALAL/Models/HALconfig/Halconfig.cpp
+++ b/Src/HALAL/Models/HALconfig/Halconfig.cpp
@@ -19,7 +19,10 @@ void HALconfig::system_clock() {
 
     __HAL_RCC_PLL_PLLSOURCE_CONFIG(RCC_PLLSOURCE_HSE);
 
-    RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSI | RCC_OSCILLATORTYPE_HSE;
+    RCC_OscInitStruct.OscillatorType =
+        RCC_OSCILLATORTYPE_HSI | RCC_OSCILLATORTYPE_LSI | RCC_OSCILLATORTYPE_HSE;
+    RCC_OscInitStruct.HSIState = RCC_HSI_DIV1;
+    RCC_OscInitStruct.HSICalibrationValue = RCC_HSICALIBRATION_DEFAULT;
     RCC_OscInitStruct.LSIState = RCC_LSI_ON;
     RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
     RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSE;


### PR DESCRIPTION
## Summary

- Route SPI4/SPI5 peripheral clocks from HSI instead of PCLK2 during SPI domain initialization.
- Explicitly keep HSI enabled at divide-by-1 in the system clock setup.

## Why

The current code drives SPI4/SPI5 from PCLK2. With the board clock tree, that source is not an exact power-of-two multiple of 2 MHz, so the SPI prescaler calculation cannot land exactly on the requested BMS SPI rate.

HSI provides a 64 MHz source. With the existing 2 MHz max baud request, ST-LIB selects the /32 SPI prescaler, producing a deterministic 2 MHz SPI4 SCK.

> [!IMPORTANT] 
> This is need for the **HVBMS** to work properly

> [!WARNING] 
> This may affect other boards that use SPI4 with a different baudrate, if the requested one cannot be properly determined prescaling 64MHz