### PR TITLE
feat: Add fault propagation to FaultController

### DIFF
--- a/.changesets/fault-propagation.md
+++ b/.changesets/fault-propagation.md
@@ -1,4 +1,4 @@
 release: minor
-summary: Add fault propagation to FaultController for sending FAULT order to remote peers and suppressing re-propagation on received faults
+summary: Add fault propagation to FaultController for sending FAULT order to remote peers with single-shot loop prevention via the `!faulted` guard
 
 Star-topology design: the `!faulted` guard in `request_fault()` is the only loop breaker. Each board propagates exactly once on the `!faulted → faulted` transition, so no `fault_received_from_peer` flag is needed. Works for any node faulting first (local fault or CS-commanded fault).

--- a/.changesets/fault-propagation.md
+++ b/.changesets/fault-propagation.md
@@ -1,0 +1,4 @@
+release: minor
+summary: Add fault propagation to FaultController for sending FAULT order to remote peers and suppressing re-propagation on received faults
+
+Star-topology design: the `!faulted` guard in `request_fault()` is the only loop breaker. Each board propagates exactly once on the `!faulted → faulted` transition, so no `fault_received_from_peer` flag is needed. Works for any node faulting first (local fault or CS-commanded fault).

--- a/Inc/ST-LIB_HIGH/Protections/FaultController.hpp
+++ b/Inc/ST-LIB_HIGH/Protections/FaultController.hpp
@@ -4,6 +4,11 @@
 #include "ST-LIB_HIGH/Protections/ProtectionTypes.hpp"
 #include "StateMachine/StateMachine.hpp"
 
+#ifdef STLIB_ETH
+#include "HALAL/Models/Packets/Order.hpp"
+#include "HALAL/Models/Packets/OrderProtocol.hpp"
+#endif
+
 namespace ST_LIB::TestAccess {
 struct FaultController;
 }
@@ -84,12 +89,20 @@ public:
         reconstruct_runtime_machine<Policy>(
             preserve_preinstalled_fault ? RuntimeState::FAULT : RuntimeState::OPERATIONAL
         );
+#ifdef STLIB_ETH
+        propagation_targets = {};
+        propagation_target_count = 0;
+#endif
     }
 
     static void start();
     static void check_transitions();
     static bool is_faulted();
     static const FaultCause* latched_fault_cause();
+
+#ifdef STLIB_ETH
+    static void register_fault_propagation(OrderProtocol* socket, Order* fault_order);
+#endif
 
 private:
     friend class PanicReporter;
@@ -175,6 +188,19 @@ private:
     static void publish_fault_diagnostic(const FaultCause& cause);
     static void request_fault(const FaultCause& cause);
     static void on_fault_state_enter();
+
+#ifdef STLIB_ETH
+    static void propagate_fault();
+    static void on_fault_order_received();
+
+    struct FaultPropagationTarget {
+        OrderProtocol* socket;
+        Order* fault_order;
+    };
+    static constexpr size_t max_propagation_targets = 8;
+    static array<FaultPropagationTarget, max_propagation_targets> propagation_targets;
+    static size_t propagation_target_count;
+#endif
 
     static RuntimeStorage runtime_storage;
     static IStateMachine* global_machine;

--- a/Src/ST-LIB_HIGH/Protections/FaultController.cpp
+++ b/Src/ST-LIB_HIGH/Protections/FaultController.cpp
@@ -171,6 +171,41 @@ void FaultController::publish_fault_diagnostic(const FaultCause& cause) {
     Diagnostics::Hub::flush_urgent();
 }
 
+#ifdef STLIB_ETH
+array<FaultController::FaultPropagationTarget, FaultController::max_propagation_targets>
+    FaultController::propagation_targets{};
+size_t FaultController::propagation_target_count = 0;
+
+void FaultController::register_fault_propagation(OrderProtocol* socket, Order* fault_order) {
+    if (socket == nullptr || fault_order == nullptr)
+        return;
+    if (propagation_target_count >= max_propagation_targets)
+        return;
+    propagation_targets[propagation_target_count] = {socket, fault_order};
+    propagation_target_count++;
+    fault_order->set_callback(&FaultController::on_fault_order_received);
+}
+
+void FaultController::on_fault_order_received() {
+    request_fault(FaultCause::runtime_fault(
+        "FAULT order received from peer",
+        false,
+        __LINE__,
+        __func__,
+        __FILE__
+    ));
+}
+
+void FaultController::propagate_fault() {
+    for (size_t i = 0; i < propagation_target_count; i++) {
+        auto& target = propagation_targets[i];
+        if (target.socket != nullptr && target.fault_order != nullptr) {
+            target.socket->send_order(*target.fault_order);
+        }
+    }
+}
+#endif
+
 void FaultController::request_fault(const FaultCause& cause) {
     if (!faulted) {
         latched_cause = cause;
@@ -184,6 +219,10 @@ void FaultController::request_fault(const FaultCause& cause) {
                 runtime_storage.rebuild_as_fault();
             }
         }
+
+#ifdef STLIB_ETH
+        propagate_fault();
+#endif
     }
 
     publish_fault_diagnostic(cause);

--- a/Src/ST-LIB_HIGH/Protections/FaultController.cpp
+++ b/Src/ST-LIB_HIGH/Protections/FaultController.cpp
@@ -202,7 +202,11 @@ void FaultController::propagate_fault() {
         if (target.socket != nullptr && target.fault_order != nullptr) {
             if (!target.socket->send_order(*target.fault_order)) {
                 Diagnostics::Hub::publish_runtime_warning(
-                    "FAULT order propagation failed", false, __LINE__, __func__, __FILE__
+                    "FAULT order propagation failed",
+                    false,
+                    __LINE__,
+                    __func__,
+                    __FILE__
                 );
                 Diagnostics::Hub::flush_urgent();
             }

--- a/Src/ST-LIB_HIGH/Protections/FaultController.cpp
+++ b/Src/ST-LIB_HIGH/Protections/FaultController.cpp
@@ -200,7 +200,12 @@ void FaultController::propagate_fault() {
     for (size_t i = 0; i < propagation_target_count; i++) {
         auto& target = propagation_targets[i];
         if (target.socket != nullptr && target.fault_order != nullptr) {
-            target.socket->send_order(*target.fault_order);
+            if (!target.socket->send_order(*target.fault_order)) {
+                Diagnostics::Hub::publish_runtime_warning(
+                    "FAULT order propagation failed", false, __LINE__, __func__, __FILE__
+                );
+                Diagnostics::Hub::flush_urgent();
+            }
         }
     }
 }

--- a/Tests/TestAccess.hpp
+++ b/Tests/TestAccess.hpp
@@ -32,6 +32,10 @@ struct FaultController {
         ::FaultController::has_latched_cause = false;
         ::FaultController::faulted = false;
         ::FaultController::runtime_started = false;
+#ifdef STLIB_ETH
+        ::FaultController::propagation_targets = {};
+        ::FaultController::propagation_target_count = 0;
+#endif
     }
 
     static void request_fault(const ::FaultCause& cause) {


### PR DESCRIPTION
## Summary

Add automatic fault propagation to `FaultController` so that when a board enters FAULT, it sends the FAULT order (ID 0) to all registered TCP peers, and conversely detects incoming FAULT orders from peers to enter FAULT automatically.

## Changes

### `FaultController.hpp`
- Added `#ifdef STLIB_ETH` guarded includes for `Order.hpp` and `OrderProtocol.hpp`
- New public API: `register_fault_propagation(OrderProtocol* socket, Order* fault_order)`
- New private members: `FaultPropagationTarget` struct, static storage for up to 8 targets, `propagate_fault()`, `on_fault_order_received()`

### `FaultController.cpp`
- `register_fault_propagation()`: stores socket+order pair and **replaces the order's callback** with `on_fault_order_received` so that when the FAULT order arrives on that socket, FaultController enters FAULT automatically.
- `on_fault_order_received()`: calls `request_fault()` — this is the reception path.
- `propagate_fault()`: iterates all registered sockets and sends the FAULT order via `send_order()`.
- `request_fault()` now calls `propagate_fault()` inside the `if (!faulted)` block — so propagation only fires on the initial fault entry, not on subsequent duplicate calls.

## Loop Prevention

The `if (!faulted)` guard in `request_fault()` is the **only** loop breaker. Each board propagates exactly once, on the `!faulted → faulted` transition. No `fault_received_from_peer` flag needed.

Designed for star topology (VCU at center):

| Scenario | Sequence |
|---|---|
| **Local fault** (e.g. HVBMS faults) | HVBMS: `!faulted → faulted` → propagate to VCU. VCU: `!faulted → faulted` → propagate to CS, HVBMS, PCU, LCU. All replies: already faulted → stop. |
| **CS commands FAULT to VCU** | VCU: `!faulted → faulted` → propagate to CS, HVBMS, PCU, LCU. All replies: already faulted → stop. |

- Works with both `Socket*` and `ServerSocket*` (both inherit from `OrderProtocol`).
- No-op on boards built without `STLIB_ETH` (all code guarded).

## Usage (application side)

```cpp
// After creating sockets and the FAULT order:
FaultController::register_fault_propagation(socket_a, fault_order);
FaultController::register_fault_propagation(socket_b, fault_order);
// ...
```

Registration enables both reception (callback hijack) and sending (propagation on local fault). Without registration, neither works.