### PR TITLE
feat: retry pending fault propagation to disconnected peers

### DIFF
--- a/.changesets/fault-propagation-retry.md
+++ b/.changesets/fault-propagation-retry.md
@@ -1,0 +1,7 @@
+release: patch
+summary: Retry pending FAULT order propagation to disconnected peers via check_transitions()
+
+When propagate_fault() fails to send the FAULT order (e.g. TCP connection not yet
+established), the target is marked pending. check_transitions() automatically
+retries pending targets on each call while the board remains faulted, until the
+send succeeds.

--- a/Inc/ST-LIB_HIGH/Protections/FaultController.hpp
+++ b/Inc/ST-LIB_HIGH/Protections/FaultController.hpp
@@ -92,6 +92,7 @@ public:
 #ifdef STLIB_ETH
         propagation_targets = {};
         propagation_target_count = 0;
+        last_retry_us = 0;
 #endif
     }
 
@@ -191,15 +192,19 @@ private:
 
 #ifdef STLIB_ETH
     static void propagate_fault();
+    static void retry_pending_fault_propagation();
     static void on_fault_order_received();
 
     struct FaultPropagationTarget {
         OrderProtocol* socket;
         Order* fault_order;
+        bool pending = false;
     };
     static constexpr size_t max_propagation_targets = 8;
+    static constexpr uint64_t propagation_retry_period_us = 100'000;
     static array<FaultPropagationTarget, max_propagation_targets> propagation_targets;
     static size_t propagation_target_count;
+    static uint64_t last_retry_us;
 #endif
 
     static RuntimeStorage runtime_storage;

--- a/Src/ST-LIB_HIGH/Protections/FaultController.cpp
+++ b/Src/ST-LIB_HIGH/Protections/FaultController.cpp
@@ -1,6 +1,7 @@
 #include "ST-LIB_HIGH/Protections/FaultController.hpp"
 
 #include "HALAL/Services/Diagnostics/Diagnostics.hpp"
+#include "HALAL/Services/Time/Scheduler.hpp"
 
 namespace {
 
@@ -164,6 +165,15 @@ void FaultController::check_transitions() {
         return;
     }
     global_machine->check_transitions();
+#ifdef STLIB_ETH
+    if (faulted) {
+        const uint64_t now_us = Scheduler::get_global_tick();
+        if (now_us - last_retry_us >= propagation_retry_period_us) {
+            last_retry_us = now_us;
+            retry_pending_fault_propagation();
+        }
+    }
+#endif
 }
 
 void FaultController::publish_fault_diagnostic(const FaultCause& cause) {
@@ -175,6 +185,7 @@ void FaultController::publish_fault_diagnostic(const FaultCause& cause) {
 array<FaultController::FaultPropagationTarget, FaultController::max_propagation_targets>
     FaultController::propagation_targets{};
 size_t FaultController::propagation_target_count = 0;
+uint64_t FaultController::last_retry_us = 0;
 
 void FaultController::register_fault_propagation(OrderProtocol* socket, Order* fault_order) {
     if (socket == nullptr || fault_order == nullptr)
@@ -200,13 +211,32 @@ void FaultController::propagate_fault() {
     for (size_t i = 0; i < propagation_target_count; i++) {
         auto& target = propagation_targets[i];
         if (target.socket != nullptr && target.fault_order != nullptr) {
-            if (!target.socket->send_order(*target.fault_order)) {
+            target.pending = true;
+            if (target.socket->send_order(*target.fault_order)) {
+                target.pending = false;
+            } else {
                 Diagnostics::Hub::publish_runtime_warning(
-                    "FAULT order propagation failed",
+                    "FAULT order propagation failed, will retry",
                     false,
                     __LINE__,
                     __func__,
                     __FILE__
+                );
+                Diagnostics::Hub::flush_urgent();
+            }
+        }
+    }
+}
+
+void FaultController::retry_pending_fault_propagation() {
+    for (size_t i = 0; i < propagation_target_count; i++) {
+        auto& target = propagation_targets[i];
+        if (target.pending && target.socket != nullptr && target.fault_order != nullptr) {
+            if (target.socket->send_order(*target.fault_order)) {
+                target.pending = false;
+                Diagnostics::Hub::publish_runtime_info(
+                    "FAULT order propagation succeeded after retry",
+                    false, __LINE__, __func__, __FILE__
                 );
                 Diagnostics::Hub::flush_urgent();
             }

--- a/Src/ST-LIB_HIGH/Protections/FaultController.cpp
+++ b/Src/ST-LIB_HIGH/Protections/FaultController.cpp
@@ -236,7 +236,10 @@ void FaultController::retry_pending_fault_propagation() {
                 target.pending = false;
                 Diagnostics::Hub::publish_runtime_info(
                     "FAULT order propagation succeeded after retry",
-                    false, __LINE__, __func__, __FILE__
+                    false,
+                    __LINE__,
+                    __func__,
+                    __FILE__
                 );
                 Diagnostics::Hub::flush_urgent();
             }

--- a/Tests/TestAccess.hpp
+++ b/Tests/TestAccess.hpp
@@ -35,6 +35,7 @@ struct FaultController {
 #ifdef STLIB_ETH
         ::FaultController::propagation_targets = {};
         ::FaultController::propagation_target_count = 0;
+        ::FaultController::last_retry_us = 0;
 #endif
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #676. When `propagate_fault()` fails to send the FAULT order (e.g. TCP connection not yet established), the target is marked `pending` and retried automatically from `check_transitions()` while the board remains faulted.

## Changes

### `FaultController.hpp`
- Added `bool pending` to `FaultPropagationTarget` struct
- Added `retry_pending_fault_propagation()` private method declaration

### `FaultController.cpp`
- Added `#include "HALAL/Services/Time/Scheduler.hpp"`
- Added `fault_propagation_retry_period_us` constant (100ms)
- `propagate_fault()`: sets `pending = true` before sending, clears on success. Warning message updated to "will retry".
- `retry_pending_fault_propagation()`: iterates targets, retries `send_order()` for pending ones, clears `pending` on success.
- `check_transitions()`: calls `retry_pending_fault_propagation()` when `faulted` under `STLIB_ETH`, **throttled to every 100ms** via `Scheduler::get_global_tick()`.

## Behavior

| Scenario | What happens |
|---|---|
| Fault + all peers connected | `propagate_fault()` sends to all, all `pending = false`, retry is a no-op |
| Fault + some peers disconnected | `propagate_fault()` marks disconnected as `pending`. Retried every 100ms until TCP comes up and send succeeds |
| Fault + no peers connected | All targets marked `pending`. Retried every 100ms until connections establish |

Retry is throttled to 100ms to avoid hammering the TCP stack in the tight main loop. No new public API — retry is driven automatically from `check_transitions()` which the application already calls in its main loop.